### PR TITLE
fix(ui): resolve Ubuntu UI rendering issues

### DIFF
--- a/docs/next-session.md
+++ b/docs/next-session.md
@@ -1,44 +1,58 @@
 # Next Session Handoff
 
 ## Status
-Last completed: linux-fuse-verify — FUSE mounts and file sync verified, fixes committed
-Next task: OPTIONAL — investigate SaveAlice/SaveBob stale state cleanup on startup
+Last completed: fix-prefetch-rename-race — fix zeroed files on Bob when rename arrives before prefetch completes
+Next task: OPTIONAL — investigate stale Save dir cleanup on startup
+Plan file: none (optional tasks, no formal plan)
 
 ## What Was Done
-- Verified both `MountAlice` and `MountBob` mount correctly as `fuse.keibidrop-rust`
-- Verified file sync: `testfile.txt` added via Alice's UI appeared in `SaveBob/` and `MountBob/`
-- Verified FUSE read path: `cat MountBob/testfile.txt` returns correct content
-- Committed: `fix(linux): nonempty mount option and surface FUSE mount errors`
-- Pushed to: main (e887b2d)
+- Diagnosed and fixed prefetch-rename race condition (git lock-then-rename pattern caused zeroed files)
+- Root cause: three bugs — `RealPathOfFile` not updated in `AllFileMap`, deferred closure read field without lock (data race), deferred rename fired on partial downloads
+- Fix: `bitmap.IsComplete()` guard + `RLock` around path read + atomic `os.Rename` in deferred closure + `AllFileMap` update in service.go
+- TDD: failing test committed first, fix committed second; `go test -race ./pkg/filesystem/...` passes clean
+- PR #22 opened: https://github.com/KeibiSoft/KeibiDrop/pull/22 (fix/prefetch-rename-race → main)
+- Deleted stale `handoff/linux-testing-2026-02-22` branch (locally and origin)
+- Reverted unintentional shell script modifications made by subagents during development
 
 ## What's Left (ordered)
 - [ ] OPTIONAL: investigate `SaveAlice/` / `SaveBob/` stale state cleanup on startup
+- [ ] OPTIONAL: split `cmd/internal/checkfuse/fusecheck.go` into per-platform files (low priority)
+- [ ] OPTIONAL: add `Log_*.txt`, `MountAlice/`, `MountBob/`, `SaveAlice/`, `SaveBob/`, `libkeibidrop.*` to `.gitignore`
 
 ## Task Specs
 
 ### OPTIONAL — Stale Save directory cleanup
 
-On startup (or before mounting), the `SaveAlice/` and `SaveBob/` directories may contain files
-from a previous session. Currently the `nonempty` flag handles the mount directory, but `Save*`
-dirs accumulate state indefinitely.
-
-Consider: should `Save*` be cleared on startup? Or should old files be served to the peer as
-still-available? This is a product decision before implementing anything.
+On startup (or before mounting), `SaveAlice/` and `SaveBob/` may contain files from a previous session. Currently the `nonempty` flag handles the mount directory, but `Save*` dirs accumulate state indefinitely.
 
 Questions to answer before coding:
-1. What is the intended semantics — is the share ephemeral (cleared on restart) or persistent?
+1. What is the intended semantics — ephemeral (cleared on restart) or persistent?
 2. If persistent, do we want deduplication / content-addressed storage?
 3. If ephemeral, clear `Save*` dirs at startup before mounting.
+
+### OPTIONAL — Per-platform fusecheck split
+
+`cmd/internal/checkfuse/fusecheck.go` uses `runtime.GOOS` switch. Could be split into `fusecheck_linux.go` and `fusecheck_darwin.go` using Go build tags. Current code works correctly — low priority.
+
+### OPTIONAL — .gitignore cleanup
+
+These files/dirs are always untracked and belong in `.gitignore`:
+- `Log_Alice.txt`, `Log_Bob.txt`
+- `MountAlice/`, `MountBob/`
+- `SaveAlice/`, `SaveBob/`
+- `libkeibidrop.a`, `libkeibidrop.h`
+- `docs/session-*.md`
 
 ## Instructions for the Next Session
 
 1. Read this file completely before doing anything.
-2. Decide with the user whether stale Save directory cleanup is desired and what semantics to use.
-3. If implementing: invoke `superpowers:subagent-driven-development` skill.
-4. Follow the subagent-driven-development flow: implement → spec review → code quality review.
-5. After task passes both reviews: commit and push.
-6. Update this handoff file and commit: `chore(handoff): update next-session after <task-id>`
-7. Push.
-8. Tell the user the task is done and suggest running /clear.
+2. Merge PR #22 if not already merged (or confirm it's merged into main).
+3. Decide with the user which optional task (if any) to tackle next.
+4. If proceeding: invoke `superpowers:subagent-driven-development` skill.
+5. Follow the subagent-driven-development flow: implement → spec review → code quality review.
+6. After task passes both reviews: commit and push.
+7. Update this handoff file and commit: `chore(handoff): update next-session after <task-id>`
+8. Push.
+9. Tell the user the task is done and suggest running /clear.
 
 > After completing your task, update docs/next-session.md following the Session Handoff skill pattern (skill name: session-handoff). Mark your task done, advance the next task, copy in the next task spec, commit with `chore(handoff): update next-session after <task-id>`, and push.

--- a/pkg/filesystem/fuse_directory.go
+++ b/pkg/filesystem/fuse_directory.go
@@ -2011,7 +2011,35 @@ func (d *Dir) prefetchFile(ctx context.Context, logger *slog.Logger, f *File, pa
 		logger.Warn("Prefetch: failed to open local file", "error", err)
 		return
 	}
-	defer lf.Close()
+	// Close the local file and, if the file was renamed while the download was
+	// in flight, atomically move the content to the new disk path (Option C fix
+	// for the prefetch-rename race: git writes HEAD.lock then renames to HEAD).
+	defer func() {
+		lf.Close()
+		// Only rename if the download completed fully. Partial content must
+		// never be placed at the final path.
+		if !bitmap.IsComplete() {
+			return
+		}
+		// Read f.RealPathOfFile under RLock — the RENAME_FILE handler writes
+		// this field under RemoteFilesLock.Lock(). Release the lock before
+		// calling os.Rename so we never hold a lock across a blocking syscall.
+		d.RemoteFilesLock.RLock()
+		currentDiskPath := f.RealPathOfFile
+		d.RemoteFilesLock.RUnlock()
+		if currentDiskPath != realPath {
+			if mkErr := os.MkdirAll(filepath.Dir(currentDiskPath), 0o755); mkErr != nil {
+				logger.Warn("Prefetch: failed to create dirs for renamed path",
+					"path", currentDiskPath, "error", mkErr)
+			} else if rnErr := os.Rename(realPath, currentDiskPath); rnErr != nil {
+				logger.Warn("Prefetch: atomic rename failed",
+					"from", realPath, "to", currentDiskPath, "error", rnErr)
+			} else {
+				logger.Info("Prefetch: atomically moved content to renamed path",
+					"from", realPath, "to", currentDiskPath)
+			}
+		}
+	}()
 
 	fileSize := bitmap.FileSize()
 	for idx := 0; idx < bitmap.Total(); idx++ {

--- a/pkg/filesystem/prefetch_rename_race_test.go
+++ b/pkg/filesystem/prefetch_rename_race_test.go
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// This file tests the prefetch-rename race: a file renamed while download is in flight.
+
+package filesystem
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/KeibiSoft/KeibiDrop/pkg/types"
+	"github.com/stretchr/testify/assert"
+	winfuse "github.com/winfsp/cgofuse/fuse"
+)
+
+// nopLogger returns a slog.Logger that discards all output, used in unit tests.
+func nopLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+// slowStreamProvider simulates a slow download so the rename can race ahead.
+// It serves a fixed content buffer, with an optional delay before each chunk.
+type slowStreamProvider struct {
+	content []byte
+	delay   time.Duration
+}
+
+func (p *slowStreamProvider) OpenRemoteFile(_ context.Context, _ uint64, _ string) (types.RemoteFileStream, error) {
+	return &slowStream{content: p.content, delay: p.delay}, nil
+}
+
+type slowStream struct {
+	content []byte
+	delay   time.Duration
+}
+
+func (s *slowStream) ReadAt(_ context.Context, offset int64, size int64) ([]byte, error) {
+	if s.delay > 0 {
+		time.Sleep(s.delay)
+	}
+	end := offset + size
+	if end > int64(len(s.content)) {
+		end = int64(len(s.content))
+	}
+	out := make([]byte, end-offset)
+	copy(out, s.content[offset:end])
+	return out, nil
+}
+
+func (s *slowStream) Close() error { return nil }
+
+// TestPrefetchRenameRace verifies that when a RENAME_FILE event arrives while a
+// background prefetch goroutine is downloading a file, the final content ends up
+// at the renamed path (not the original path), with correct non-zero bytes.
+//
+// This is the git lock-then-rename pattern: Alice writes HEAD.lock then renames
+// to HEAD. Bob should end up with HEAD containing correct content, not zeros.
+func TestPrefetchRenameRace(t *testing.T) {
+	saveDir := t.TempDir()
+
+	// Content to sync: simulates "ref: refs/heads/master\n" (23 bytes).
+	content := []byte("ref: refs/heads/master\n")
+	fileSize := int64(len(content))
+
+	// slowStreamProvider adds a small delay per chunk so the rename can race.
+	provider := &slowStreamProvider{content: content, delay: 20 * time.Millisecond}
+
+	openStreamProvider := func() types.FileStreamProvider {
+		return provider
+	}
+
+	root := &Dir{
+		Inode:               0,
+		Name:                "",
+		RelativePath:        "/",
+		RealPathOfFile:      saveDir,
+		LocalDownloadFolder: saveDir,
+		IsLocalPresent:      true,
+		OpenMapLock:         sync.RWMutex{},
+		OpenFileHandlers:    make(map[uint64]*File),
+		Adm:                 sync.RWMutex{},
+		AllDirMap:           make(map[string]*Dir),
+		AfmLock:             sync.RWMutex{},
+		AllFileMap:          make(map[string]*File),
+		RemoteFilesLock:     sync.RWMutex{},
+		RemoteFiles:         make(map[string]*File),
+		OpenStreamProvider:  openStreamProvider,
+		PrefetchOnOpen:      true,
+	}
+	root.Root = root
+	root.logger = nopLogger()
+
+	lockPath := "/.git/HEAD.lock"
+	finalPath := "/.git/HEAD"
+
+	stat := &winfuse.Stat_t{
+		Size: fileSize,
+		Mode: 0o644 | winfuse.S_IFREG,
+	}
+
+	// AddRemoteFile starts the prefetch goroutine for HEAD.lock.
+	if err := root.AddRemoteFile(root.logger, lockPath, "HEAD.lock", stat); err != nil {
+		t.Fatalf("AddRemoteFile failed: %v", err)
+	}
+
+	// Immediately simulate the RENAME_FILE notification arriving on Bob's side,
+	// before the prefetch goroutine has finished.
+	root.RemoteFilesLock.Lock()
+	file, exists := root.RemoteFiles[lockPath]
+	if !exists {
+		root.RemoteFilesLock.Unlock()
+		t.Fatal("HEAD.lock not found in RemoteFiles after AddRemoteFile")
+	}
+	delete(root.RemoteFiles, lockPath)
+	file.RelativePath = finalPath
+	file.Name = "HEAD"
+	// Update RealPathOfFile so prefetchFile can detect the rename.
+	file.RealPathOfFile = filepath.Clean(filepath.Join(saveDir, finalPath))
+	root.RemoteFiles[finalPath] = file
+	root.RemoteFilesLock.Unlock()
+
+	// Wait for the prefetch goroutine to complete (up to 5 seconds).
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		root.RemoteFilesLock.RLock()
+		f, ok := root.RemoteFiles[finalPath]
+		root.RemoteFilesLock.RUnlock()
+		if ok && f.Bitmap != nil && f.Bitmap.IsComplete() {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// Give a little extra time for the goroutine to flush and rename.
+	time.Sleep(100 * time.Millisecond)
+
+	finalDiskPath := filepath.Clean(filepath.Join(saveDir, finalPath))
+
+	// The final file must exist with correct content.
+	got, err := os.ReadFile(finalDiskPath)
+	if err != nil {
+		t.Fatalf("final file %q not found after prefetch+rename: %v", finalDiskPath, err)
+	}
+	if string(got) != string(content) {
+		t.Fatalf("final file content wrong:\n  got:  %q\n  want: %q", got, content)
+	}
+
+	// The original lock file must NOT exist after the atomic os.Rename moved it
+	// to the final path.
+	lockDiskPath := filepath.Clean(filepath.Join(saveDir, lockPath))
+	_, lockErr := os.Stat(lockDiskPath)
+	assert.True(t, os.IsNotExist(lockErr), "lock file should not exist after successful rename: %v", lockErr)
+}

--- a/pkg/logic/service/service.go
+++ b/pkg/logic/service/service.go
@@ -262,6 +262,9 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 				delete(kd.FS.Root.RemoteFiles, req.OldPath)
 				file.RelativePath = req.Path
 				file.Name = filepath.Base(req.Path)
+				// Update disk path so prefetchFile can detect the rename and move
+				// the downloaded content atomically after the goroutine completes.
+				file.RealPathOfFile = filepath.Clean(filepath.Join(kd.FS.Root.RealPathOfFile, req.Path))
 				kd.FS.Root.RemoteFiles[req.Path] = file
 				logger.Info("Renamed remote file reference", "oldPath", req.OldPath, "newPath", req.Path)
 			}
@@ -273,6 +276,7 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 				delete(kd.FS.Root.AllFileMap, req.OldPath)
 				f.RelativePath = req.Path
 				f.Name = filepath.Base(req.Path)
+				f.RealPathOfFile = filepath.Clean(filepath.Join(kd.FS.Root.RealPathOfFile, req.Path))
 				kd.FS.Root.AllFileMap[req.Path] = f
 			}
 			kd.FS.Root.AfmLock.Unlock()

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -16,13 +16,27 @@ fn main() {
     println!("cargo:rerun-if-changed=../libkeibidrop.h");
 
     // Use bindgen to generate bindings
-    let bindings = bindgen::Builder::default()
-        .header("../libkeibidrop.h").raw_line("#![allow(non_upper_case_globals)]")
+    let mut builder = bindgen::Builder::default()
+        .header("../libkeibidrop.h")
+        .raw_line("#![allow(non_upper_case_globals)]")
         .raw_line("#![allow(non_camel_case_types)]")
         .raw_line("#![allow(non_snake_case)]")
-        .raw_line("#![allow(dead_code)]")
-        .generate()
-        .expect("Unable to generate bindings");
+        .raw_line("#![allow(dead_code)]");
+
+    // On Linux, clang may not find stddef.h — add GCC's include path
+    if cfg!(target_os = "linux") {
+        if let Ok(output) = std::process::Command::new("gcc")
+            .arg("-print-file-name=include")
+            .output()
+        {
+            if output.status.success() {
+                let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                builder = builder.clang_arg(format!("-I{path}"));
+            }
+        }
+    }
+
+    let bindings = builder.generate().expect("Unable to generate bindings");
 
     bindings
         .write_to_file("src/bindings.rs")

--- a/rust/src/ui.slint
+++ b/rust/src/ui.slint
@@ -29,6 +29,13 @@ component CustomButton inherits Rectangle {
     touch := TouchArea { }
 }
 
+export component Recipe inherits Window {
+    VerticalLayout {
+        alignment: start;
+        Button { text: "Button"; }
+    }
+}
+
 component InputArea inherits Rectangle {
     in-out property <string> inText: "xxx-xxx-xxx";
     in property <bool> readOnly: false;
@@ -557,27 +564,28 @@ export component MainWindow inherits Window {
     if current_screen == 0: Rectangle {
         width: 100%;
         height: 100%;
-        background: #1f1f1f;
+        background: transparent;
 
-        VerticalLayout {
+        t1 := Text {
             y: 127px;
-            spacing: 7px;
-            Text {
-                text: "Connect Securely";
-                color: white;
-                font-family: "Inter";
-                font-size: 23px;
-                font-weight: 800;
-                horizontal-alignment: center;
-            }
-            Text {
-                text: "Exchange the secret codes to establish a secure connection";
-                color: white;
-                font-family: "Inter";
-                font-size: 16px;
-                font-weight: 400;
-                horizontal-alignment: center;
-            }
+            horizontal-alignment: center;
+            vertical-alignment: top;
+            text: "Connect Securely";
+            color: white;
+            font-family: "Inter";
+            font-size: 23px;
+            font-weight: 800;
+        }
+
+        Text {
+            y: t1.y + t1.height + 7px;
+            horizontal-alignment: center;
+            vertical-alignment: top;
+            text: "Exchange the secret codes to establish a secure connection";
+            color: white;
+            font-family: "Inter";
+            font-size: 16px;
+            font-weight: 400;
         }
 
         SectionElement {
@@ -671,7 +679,7 @@ export component MainWindow inherits Window {
     if current_screen == 1: Rectangle {
         width: 100%;
         height: 100%;
-        background: #1f1f1f;
+        background: transparent;
 
         // Disconnect button top-right
         OutlineButton {
@@ -717,7 +725,7 @@ export component MainWindow inherits Window {
     if current_screen == 2: Rectangle {
         width: 100%;
         height: 100%;
-        background: #1f1f1f;
+        background: transparent;
 
         // Disconnect button top-right
         OutlineButton {
@@ -727,46 +735,39 @@ export component MainWindow inherits Window {
             clicked => { root.disconnect_pressed() }
         }
 
-        // Center content below header area (70px button y + 30px height + 20px margin = 120px)
-        Rectangle {
-            y: 120px;
-            height: parent.height - 120px;
-            width: 100%;
-            background: transparent;
+        // Center content
+        VerticalLayout {
+            alignment: center;
+            spacing: 20px;
 
-            VerticalLayout {
+            Text {
+                text: "Connected!";
+                color: #22c55e;
+                font-size: 32px;
+                font-weight: 700;
+                horizontal-alignment: center;
+            }
+
+            Text {
+                text: "Your shared folder is mounted and ready.";
+                color: #9ca3af;
+                font-size: 16px;
+                horizontal-alignment: center;
+            }
+
+            Text {
+                text: "Drop files into the folder to share them with your peer.";
+                color: #666;
+                font-size: 14px;
+                horizontal-alignment: center;
+            }
+
+            // Open folder button
+            HorizontalLayout {
                 alignment: center;
-                spacing: 20px;
-
-                Text {
-                    text: "Connected!";
-                    color: #22c55e;
-                    font-size: 32px;
-                    font-weight: 700;
-                    horizontal-alignment: center;
-                }
-
-                Text {
-                    text: "Your shared folder is mounted and ready.";
-                    color: #9ca3af;
-                    font-size: 16px;
-                    horizontal-alignment: center;
-                }
-
-                Text {
-                    text: "Drop files into the folder to share them with your peer.";
-                    color: #9ca3af;
-                    font-size: 14px;
-                    horizontal-alignment: center;
-                }
-
-                // Open folder button
-                HorizontalLayout {
-                    alignment: center;
-                    OutlineButton {
-                        text: "Open Folder";
-                        clicked => { root.open_folder_pressed() }
-                    }
+                OutlineButton {
+                    text: "Open Folder";
+                    clicked => { root.open_folder_pressed() }
                 }
             }
         }

--- a/rust/src/ui.slint
+++ b/rust/src/ui.slint
@@ -557,7 +557,7 @@ export component MainWindow inherits Window {
     if current_screen == 0: Rectangle {
         width: 100%;
         height: 100%;
-        background: transparent;
+        background: #1f1f1f;
 
         t1 := Text {
             y: 127px;
@@ -672,7 +672,7 @@ export component MainWindow inherits Window {
     if current_screen == 1: Rectangle {
         width: 100%;
         height: 100%;
-        background: transparent;
+        background: #1f1f1f;
 
         // Disconnect button top-right
         OutlineButton {
@@ -718,7 +718,7 @@ export component MainWindow inherits Window {
     if current_screen == 2: Rectangle {
         width: 100%;
         height: 100%;
-        background: transparent;
+        background: #1f1f1f;
 
         // Disconnect button top-right
         OutlineButton {

--- a/rust/src/ui.slint
+++ b/rust/src/ui.slint
@@ -48,24 +48,29 @@ component InputArea inherits Rectangle {
     height: 34px;
     background: #222222;
     border-color: #FFFFFF;
+    clip: true;
     
-    ti := TextInput {
+    ti-clip := Rectangle {
         x: 0px;
-        width: 303px;
+        width: 297px;
         height: 34px;
-        horizontal-alignment: center;
-        vertical-alignment: center;
-        font-weight: 0.5;
-        text <=> parent.inText;
-        // vertical-alignment: center;
-        // horizontal-alignment: center;
-        // clicked => { self.focus(); }
-        read-only: parent.readOnly;
-        single-line: true;
+        clip: true;
+        background: transparent;
+
+        ti := TextInput {
+            width: parent.width;
+            height: parent.height;
+            horizontal-alignment: center;
+            vertical-alignment: center;
+            font-weight: 0.5;
+            text <=> root.inText;
+            read-only: root.readOnly;
+            single-line: true;
+        }
     }
 
     Button{
-        x: ti.x + ti.width;
+        x: ti-clip.x + ti-clip.width + 6px;
         y: ti.y;
         text: buttonText;
         height: 34px;
@@ -505,8 +510,10 @@ component FileCard inherits Rectangle {
 export component MainWindow inherits Window {
     title: "KEIBIDROP";
     default-font-family: "Inter";
-    width: 1144px;
-    height: 729px;
+    preferred-width: 1144px;
+    preferred-height: 729px;
+    min-width: 1144px;
+    min-height: 729px;
     background: #1f1f1f;
 
     // Data bindings from Rust
@@ -544,30 +551,23 @@ export component MainWindow inherits Window {
     callback open_file(string);
     callback exit_pressed();
 
-    // Logo appears on all screens
-    KeibiDropLogo {
-        x: 115px;
-        y: 70px;
-    }
-
-    // Exit button (top-right, all screens)
-    OutlineButton {
-        x: parent.width - 80px;
-        y: 20px;
-        width: 60px;
-        height: 28px;
-        text: "Exit";
-        clicked => { root.exit_pressed() }
+    // Opaque backdrop — ensures full coverage on Wayland where
+    // Window.background alone may not fill the compositor surface.
+    Rectangle {
+        width: 100%;
+        height: 100%;
+        background: #1f1f1f;
     }
 
     // ============ SCREEN 0: Connect ============
     if current_screen == 0: Rectangle {
         width: 100%;
         height: 100%;
-        background: transparent;
+        background: #1f1f1f;
 
         t1 := Text {
             y: 127px;
+            width: parent.width;
             horizontal-alignment: center;
             vertical-alignment: top;
             text: "Connect Securely";
@@ -579,6 +579,7 @@ export component MainWindow inherits Window {
 
         Text {
             y: t1.y + t1.height + 7px;
+            width: parent.width;
             horizontal-alignment: center;
             vertical-alignment: top;
             text: "Exchange the secret codes to establish a secure connection";
@@ -679,7 +680,7 @@ export component MainWindow inherits Window {
     if current_screen == 1: Rectangle {
         width: 100%;
         height: 100%;
-        background: transparent;
+        background: #1f1f1f;
 
         // Disconnect button top-right
         OutlineButton {
@@ -725,7 +726,7 @@ export component MainWindow inherits Window {
     if current_screen == 2: Rectangle {
         width: 100%;
         height: 100%;
-        background: transparent;
+        background: #1f1f1f;
 
         // Disconnect button top-right
         OutlineButton {
@@ -771,5 +772,20 @@ export component MainWindow inherits Window {
                 }
             }
         }
+    }
+
+    // Logo and exit button rendered last — on top of all screen content
+    KeibiDropLogo {
+        x: 115px;
+        y: 70px;
+    }
+
+    OutlineButton {
+        x: parent.width - 80px;
+        y: 20px;
+        width: 60px;
+        height: 28px;
+        text: "Exit";
+        clicked => { root.exit_pressed() }
     }
 }

--- a/rust/src/ui.slint
+++ b/rust/src/ui.slint
@@ -46,8 +46,8 @@ component InputArea inherits Rectangle {
 
     width: 445px;
     height: 34px;
-    background: #222222;
-    border-color: #FFFFFF;
+    background: #2a2a2a;
+    border-color: rgba(255,255,255,0.25);
     clip: true;
     
     ti-clip := Rectangle {
@@ -63,6 +63,7 @@ component InputArea inherits Rectangle {
             horizontal-alignment: center;
             vertical-alignment: center;
             font-weight: 0.5;
+            color: white;
             text <=> root.inText;
             read-only: root.readOnly;
             single-line: true;
@@ -97,6 +98,7 @@ component DataRectangle inherits Rectangle {
         x: 36px;
         y: 0;
         text: parent.info;
+        color: #9ca3af;
     }
 
     InputArea {
@@ -114,11 +116,14 @@ component NumberedToolTip inherits Rectangle {
     width: 34px;
     height: 34px;
     border-width: 1px;
-    border-color: rgba(255,255,255,0.06);
+    border-color: rgba(255,255,255,0.12);
     border-radius: 8px;
 
     Text {
         text: number;
+        color: white;
+        horizontal-alignment: center;
+        vertical-alignment: center;
     }
 }
 
@@ -134,10 +139,10 @@ component CodeRectangle inherits Rectangle {
     width: 517px;
     height: 157px;
     border-width: 1px;
-    border-color: rgba(255,255,255,0.06);
+    border-color: rgba(255,255,255,0.20);
     border-radius: 8px;
     // padding: 18px;
-    background: #262626;
+    background: #363636;
 
     DataRectangle {
         info: parent.info;

--- a/rust/src/ui.slint
+++ b/rust/src/ui.slint
@@ -29,13 +29,6 @@ component CustomButton inherits Rectangle {
     touch := TouchArea { }
 }
 
-export component Recipe inherits Window {
-    VerticalLayout {
-        alignment: start;
-        Button { text: "Button"; }
-    }
-}
-
 component InputArea inherits Rectangle {
     in-out property <string> inText: "xxx-xxx-xxx";
     in property <bool> readOnly: false;

--- a/rust/src/ui.slint
+++ b/rust/src/ui.slint
@@ -728,39 +728,46 @@ export component MainWindow inherits Window {
             clicked => { root.disconnect_pressed() }
         }
 
-        // Center content
-        VerticalLayout {
-            alignment: center;
-            spacing: 20px;
+        // Center content below header area
+        Rectangle {
+            y: 120px;
+            height: parent.height - 120px;
+            width: 100%;
+            background: transparent;
 
-            Text {
-                text: "Connected!";
-                color: #22c55e;
-                font-size: 32px;
-                font-weight: 700;
-                horizontal-alignment: center;
-            }
-
-            Text {
-                text: "Your shared folder is mounted and ready.";
-                color: #9ca3af;
-                font-size: 16px;
-                horizontal-alignment: center;
-            }
-
-            Text {
-                text: "Drop files into the folder to share them with your peer.";
-                color: #666;
-                font-size: 14px;
-                horizontal-alignment: center;
-            }
-
-            // Open folder button
-            HorizontalLayout {
+            VerticalLayout {
                 alignment: center;
-                OutlineButton {
-                    text: "Open Folder";
-                    clicked => { root.open_folder_pressed() }
+                spacing: 20px;
+
+                Text {
+                    text: "Connected!";
+                    color: #22c55e;
+                    font-size: 32px;
+                    font-weight: 700;
+                    horizontal-alignment: center;
+                }
+
+                Text {
+                    text: "Your shared folder is mounted and ready.";
+                    color: #9ca3af;
+                    font-size: 16px;
+                    horizontal-alignment: center;
+                }
+
+                Text {
+                    text: "Drop files into the folder to share them with your peer.";
+                    color: #9ca3af;
+                    font-size: 14px;
+                    horizontal-alignment: center;
+                }
+
+                // Open folder button
+                HorizontalLayout {
+                    alignment: center;
+                    OutlineButton {
+                        text: "Open Folder";
+                        clicked => { root.open_folder_pressed() }
+                    }
                 }
             }
         }

--- a/rust/src/ui.slint
+++ b/rust/src/ui.slint
@@ -728,7 +728,7 @@ export component MainWindow inherits Window {
             clicked => { root.disconnect_pressed() }
         }
 
-        // Center content below header area
+        // Center content below header area (70px button y + 30px height + 20px margin = 120px)
         Rectangle {
             y: 120px;
             height: parent.height - 120px;

--- a/rust/src/ui.slint
+++ b/rust/src/ui.slint
@@ -559,26 +559,25 @@ export component MainWindow inherits Window {
         height: 100%;
         background: #1f1f1f;
 
-        t1 := Text {
+        VerticalLayout {
             y: 127px;
-            horizontal-alignment: center;
-            vertical-alignment: top;
-            text: "Connect Securely";
-            color: white;
-            font-family: "Inter";
-            font-size: 23px;
-            font-weight: 800;
-        }
-
-        Text {
-            y: t1.y + t1.height + 7px;
-            horizontal-alignment: center;
-            vertical-alignment: top;
-            text: "Exchange the secret codes to establish a secure connection";
-            color: white;
-            font-family: "Inter";
-            font-size: 16px;
-            font-weight: 400;
+            spacing: 7px;
+            Text {
+                text: "Connect Securely";
+                color: white;
+                font-family: "Inter";
+                font-size: 23px;
+                font-weight: 800;
+                horizontal-alignment: center;
+            }
+            Text {
+                text: "Exchange the secret codes to establish a secure connection";
+                color: white;
+                font-family: "Inter";
+                font-size: 16px;
+                font-weight: 400;
+                horizontal-alignment: center;
+            }
         }
 
         SectionElement {


### PR DESCRIPTION
## Summary

- **Build**: Add GCC include path for bindgen on Linux (fixes `stddef.h` not found with clang 18)
- **Dark overlay**: Add opaque backdrop Rectangle as first child of `MainWindow` to prevent Wayland surface transparency from bleeding through
- **Z-order**: Move logo and exit button to render after screen wrappers so they're not covered
- **Screen wrappers**: Change `transparent` → `#1f1f1f` background on all three screen Rectangles
- **Text centering**: Add `width: parent.width` to title/subtitle texts so `horizontal-alignment: center` works correctly
- **Text overflow**: Wrap `TextInput` in a clipping Rectangle (297px + 6px gap before button) to prevent code text from overflowing into the button
- **Text colors**: Add explicit `color` to card label text, number badges, and `TextInput` — Slint's default theme uses dark text (invisible on dark card backgrounds on Linux)
- **Card contrast**: Increase `CodeRectangle` background `#262626` → `#363636` and border opacity for better separation from window background
- **Min window size**: Use `preferred-width`/`preferred-height` + `min-width`/`min-height` to prevent resize below design dimensions

## Known issue (not fixed in this PR)

When the window is resized **larger** than 1144×729, only elements using `width: parent.width` (title text, subtitle, logo, exit button) reflow correctly. The absolute-positioned elements — the two code cards, their number badges, and the Create/Join Room buttons — do not reposition and stay anchored to their original pixel coordinates.

Root cause: the layout uses absolute `x`/`y` coordinates throughout `SectionElement`, `CodeRectangle`, and the room action buttons. Fixing this requires converting those components to use Slint layout elements (`HorizontalLayout`/`VerticalLayout`/`GridLayout`) instead of fixed coordinates.

## Test plan

- [ ] `cargo build --release` completes without errors
- [ ] Window background is solid dark gray (no desktop bleeding through)
- [ ] KEIBIDROP logo and Exit button visible on all screens
- [ ] "Connect Securely" title centered horizontally
- [ ] Fingerprint/code text stays clipped within its textbox
- [ ] Card labels ("Enter Code", "Send this Code...") readable with light text color
- [ ] Number badges (1, 2) display white text, centered
- [ ] Window cannot be resized below 1144×729