### PR TITLE
fix(filesystem): block path traversal in MkdirFromPeer (KD-2026-001)

### DIFF
--- a/pkg/filesystem/fuse_directory.go
+++ b/pkg/filesystem/fuse_directory.go
@@ -777,10 +777,24 @@ func (d *Dir) MkdirFromPeer(path string, mode uint32) (errCode int) {
 	return d.mkdirInternal(path, mode, false)
 }
 
+// secureJoin resolves path relative to base and verifies the result stays within
+// base. Returns an error if the resolved path escapes base (KD-2026-001).
+func secureJoin(base, path string) (string, error) {
+	result := filepath.Clean(filepath.Join(base, path))
+	if result != base && !strings.HasPrefix(result, base+string(os.PathSeparator)) {
+		return "", fmt.Errorf("path %q escapes base directory %q", path, base)
+	}
+	return result, nil
+}
+
 func (d *Dir) mkdirInternal(path string, mode uint32, notifyPeer bool) (errCode int) {
 	logger := d.logger.With("method", "mkdir", "path", path, "mode", mode)
-	cleanPath := filepath.Clean(filepath.Join(d.LocalDownloadFolder, path))
-	err := syscall.Mkdir(cleanPath, mode)
+	cleanPath, err := secureJoin(d.LocalDownloadFolder, path)
+	if err != nil {
+		logger.Error("Path traversal attempt blocked", "path", path, "error", err)
+		return -int(syscall.EPERM)
+	}
+	err = syscall.Mkdir(cleanPath, mode)
 	if err != nil {
 		logger.Error("Failed to mkdir", "path", cleanPath, "error", err)
 		return int(convertOsErrToSyscallErrno("mkdir", err))

--- a/pkg/filesystem/mkdir_traversal_test.go
+++ b/pkg/filesystem/mkdir_traversal_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"syscall"
 	"testing"
 )
 
@@ -44,8 +45,9 @@ func TestMkdirFromPeer_TraversalBlocked(t *testing.T) {
 
 	errCode := d.MkdirFromPeer("../../escape", 0o755)
 
-	if errCode == 0 {
-		t.Errorf("expected non-zero errCode for traversal path, got %d", errCode)
+	wantCode := -int(syscall.EPERM)
+	if errCode != wantCode {
+		t.Errorf("expected errCode %d (EPERM) for traversal path, got %d", wantCode, errCode)
 	}
 
 	escapedPath := filepath.Join(saveDir, "..", "..", "escape")

--- a/pkg/filesystem/mkdir_traversal_test.go
+++ b/pkg/filesystem/mkdir_traversal_test.go
@@ -1,0 +1,73 @@
+// ABOUTME: Unit tests for path traversal protection in MkdirFromPeer (KD-2026-001).
+// ABOUTME: Verifies secureJoin blocks directory escape attempts from malicious peers.
+
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+
+package filesystem
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+// newTestDir builds a minimal Dir rooted at saveDir suitable for unit tests.
+func newTestDir(saveDir string) *Dir {
+	d := &Dir{
+		Inode:               0,
+		Name:                "",
+		RelativePath:        "/",
+		RealPathOfFile:      saveDir,
+		LocalDownloadFolder: saveDir,
+		IsLocalPresent:      true,
+		OpenMapLock:         sync.RWMutex{},
+		OpenFileHandlers:    make(map[uint64]*File),
+		Adm:                 sync.RWMutex{},
+		AllDirMap:           make(map[string]*Dir),
+		AfmLock:             sync.RWMutex{},
+		AllFileMap:          make(map[string]*File),
+		RemoteFilesLock:     sync.RWMutex{},
+		RemoteFiles:         make(map[string]*File),
+	}
+	d.Root = d
+	d.logger = nopLogger()
+	return d
+}
+
+// TestMkdirFromPeer_TraversalBlocked verifies that a peer-supplied path containing
+// ".." components cannot escape LocalDownloadFolder (KD-2026-001).
+func TestMkdirFromPeer_TraversalBlocked(t *testing.T) {
+	saveDir := t.TempDir()
+	d := newTestDir(saveDir)
+
+	errCode := d.MkdirFromPeer("../../escape", 0o755)
+
+	if errCode == 0 {
+		t.Errorf("expected non-zero errCode for traversal path, got %d", errCode)
+	}
+
+	escapedPath := filepath.Join(saveDir, "..", "..", "escape")
+	if _, err := os.Stat(escapedPath); err == nil {
+		t.Errorf("traversal directory must not exist at %q", escapedPath)
+	}
+}
+
+// TestMkdirFromPeer_ValidPath verifies that a legitimate peer-supplied sub-directory
+// path is created correctly inside LocalDownloadFolder.
+func TestMkdirFromPeer_ValidPath(t *testing.T) {
+	saveDir := t.TempDir()
+	d := newTestDir(saveDir)
+
+	errCode := d.MkdirFromPeer("subdir", 0o755)
+
+	if errCode != 0 {
+		t.Errorf("expected errCode 0 for valid path, got %d", errCode)
+	}
+
+	expectedPath := filepath.Join(saveDir, "subdir")
+	if _, err := os.Stat(expectedPath); err != nil {
+		t.Errorf("expected directory to exist at %q: %v", expectedPath, err)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `secureJoin(base, path string)` helper that validates the resolved path stays within `LocalDownloadFolder` before any `syscall.Mkdir` call
- `mkdirInternal` now returns `EPERM` if a peer-supplied path tries to escape via `..` components
- No other FUSE operations were touched (kernel-supplied paths are already sanitised by the kernel)

## Security Impact

Fixes **KD-2026-001** (Critical, OWASP A01/A03): a malicious peer could previously send `Notify ADD_DIR` with a path like `../../escape` to create directories outside the designated download folder, potentially writing to `~/.ssh/authorized_keys` or `~/.bashrc`.

Closes #28

## Test Plan

- [x] `TestMkdirFromPeer_TraversalBlocked` — traversal path returns `EPERM`, escaped dir does not exist
- [x] `TestMkdirFromPeer_ValidPath` — legitimate sub-path creates dir inside `saveDir`
- [x] All 13 `pkg/filesystem` tests pass (`go test -v ./pkg/filesystem/...`)
- [x] `go build ./...` clean

## Follow-up

`rmdirInternal` and `unlinkInternal` use the same unguarded pattern but are not currently reachable via peer-controlled Notify paths (service.go only deletes from in-memory maps on REMOVE_DIR/REMOVE_FILE). A follow-up issue should track this.