### PR TITLE
fix(crypto): add per-call random salt to X25519Encapsulate

### DIFF
--- a/pkg/crypto/asymmetric.go
+++ b/pkg/crypto/asymmetric.go
@@ -21,6 +21,7 @@ import (
 )
 
 const seedSize = 32
+const saltSize = 32 // random salt prepended to ciphertext: salt || encrypted_seed
 
 func GenerateMLKEMKeypair() (*mlkem.DecapsulationKey1024, *mlkem.EncapsulationKey1024, error) {
 	priv, err := mlkem.GenerateKey1024()
@@ -46,7 +47,7 @@ func X25519Encapsulate(seed []byte, senderPriv *ecdh.PrivateKey, recipientPub *e
 		return nil, errors.New("seed must be 32 bytes")
 	}
 
-	salt := make([]byte, seedSize)
+	salt := make([]byte, saltSize)
 	if _, err := io.ReadFull(rand.Reader, salt); err != nil {
 		return nil, err
 	}
@@ -70,12 +71,12 @@ func X25519Encapsulate(seed []byte, senderPriv *ecdh.PrivateKey, recipientPub *e
 }
 
 func X25519Decapsulate(ciphertext []byte, recipientPriv *ecdh.PrivateKey, senderPub *ecdh.PublicKey) ([]byte, error) {
-	if len(ciphertext) != 2*seedSize {
-		return nil, errors.New("ciphertext must be 64 bytes")
+	if len(ciphertext) != saltSize+seedSize {
+		return nil, fmt.Errorf("ciphertext must be %d bytes", saltSize+seedSize)
 	}
 
-	salt := ciphertext[:seedSize]
-	ct := ciphertext[seedSize:]
+	salt := ciphertext[:saltSize]
+	ct := ciphertext[saltSize:]
 
 	shared, err := recipientPriv.ECDH(senderPub)
 	if err != nil {

--- a/pkg/crypto/asymmetric.go
+++ b/pkg/crypto/asymmetric.go
@@ -46,28 +46,36 @@ func X25519Encapsulate(seed []byte, senderPriv *ecdh.PrivateKey, recipientPub *e
 		return nil, errors.New("seed must be 32 bytes")
 	}
 
+	salt := make([]byte, seedSize)
+	if _, err := io.ReadFull(rand.Reader, salt); err != nil {
+		return nil, err
+	}
+
 	shared, err := senderPriv.ECDH(recipientPub)
 	if err != nil {
 		return nil, err
 	}
 
 	mask := make([]byte, seedSize)
-	hkdfReader := hkdf.New(sha512.New, shared, nil, []byte("x25519-shared-seed-wrap"))
+	hkdfReader := hkdf.New(sha512.New, shared, salt, []byte("x25519-shared-seed-wrap"))
 	if _, err := io.ReadFull(hkdfReader, mask); err != nil {
 		return nil, err
 	}
 
-	ciphertext := make([]byte, seedSize)
+	ct := make([]byte, seedSize)
 	for i := 0; i < seedSize; i++ {
-		ciphertext[i] = seed[i] ^ mask[i]
+		ct[i] = seed[i] ^ mask[i]
 	}
-	return ciphertext, nil
+	return append(salt, ct...), nil
 }
 
 func X25519Decapsulate(ciphertext []byte, recipientPriv *ecdh.PrivateKey, senderPub *ecdh.PublicKey) ([]byte, error) {
-	if len(ciphertext) != seedSize {
-		return nil, errors.New("ciphertext must be 32 bytes")
+	if len(ciphertext) != 2*seedSize {
+		return nil, errors.New("ciphertext must be 64 bytes")
 	}
+
+	salt := ciphertext[:seedSize]
+	ct := ciphertext[seedSize:]
 
 	shared, err := recipientPriv.ECDH(senderPub)
 	if err != nil {
@@ -75,14 +83,14 @@ func X25519Decapsulate(ciphertext []byte, recipientPriv *ecdh.PrivateKey, sender
 	}
 
 	mask := make([]byte, seedSize)
-	hkdfReader := hkdf.New(sha512.New, shared, nil, []byte("x25519-shared-seed-wrap"))
+	hkdfReader := hkdf.New(sha512.New, shared, salt, []byte("x25519-shared-seed-wrap"))
 	if _, err := io.ReadFull(hkdfReader, mask); err != nil {
 		return nil, err
 	}
 
 	seed := make([]byte, seedSize)
 	for i := range seedSize {
-		seed[i] = ciphertext[i] ^ mask[i]
+		seed[i] = ct[i] ^ mask[i]
 	}
 
 	return seed, nil

--- a/pkg/crypto/crypto_test.go
+++ b/pkg/crypto/crypto_test.go
@@ -11,6 +11,7 @@ import (
 	"encoding/base64"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -75,7 +76,7 @@ func TestProtocolEndToEndStream(t *testing.T) {
 	// Bob encapsulates
 	seedKEM, ctKEM := alicePubMLKEM.Encapsulate()
 	seedCurve := randomBytes(t, seedSize)
-	ctCurve, err := X25519Decapsulate(seedCurve, bobPrivCurve, alicePubCurve)
+	ctCurve, err := X25519Encapsulate(seedCurve, bobPrivCurve, alicePubCurve)
 	req.NoError(err)
 
 	// Alice decapsulates
@@ -137,4 +138,73 @@ func TestProtocolMimic(t *testing.T) {
 	req.Equal(fpAlice, fpAliceCheck, "Fingerprint mismatch")
 
 	t.Logf("Fingerprint: %s", base64.RawURLEncoding.EncodeToString([]byte(fpAlice)))
+}
+
+// TestX25519EncapsulateDifferentOutputEachCall verifies that two calls with the same
+// keys and same seed produce different ciphertexts (non-deterministic due to random salt).
+func TestX25519EncapsulateDifferentOutputEachCall(t *testing.T) {
+	privKey, pubKey, err := GenerateX25519Keypair()
+	require.NoError(t, err)
+
+	seed := randomBytes(t, seedSize)
+
+	ct1, err := X25519Encapsulate(seed, privKey, pubKey)
+	require.NoError(t, err)
+
+	ct2, err := X25519Encapsulate(seed, privKey, pubKey)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, ct1, ct2, "two encapsulations of the same seed must produce different ciphertexts")
+}
+
+// TestX25519RoundTrip_WithSalt verifies that encapsulate + decapsulate recovers the original seed.
+func TestX25519RoundTrip_WithSalt(t *testing.T) {
+	senderPriv, _, err := GenerateX25519Keypair()
+	require.NoError(t, err)
+	recipientPriv, recipientPub, err := GenerateX25519Keypair()
+	require.NoError(t, err)
+	senderPub := senderPriv.PublicKey()
+
+	seed := randomBytes(t, seedSize)
+
+	ct, err := X25519Encapsulate(seed, senderPriv, recipientPub)
+	require.NoError(t, err)
+
+	recovered, err := X25519Decapsulate(ct, recipientPriv, senderPub)
+	require.NoError(t, err)
+
+	assert.Equal(t, seed, recovered, "decapsulated seed must equal original seed")
+}
+
+// TestX25519KeystreamReuseAttackFails verifies that XOR-ing two ciphertexts no longer
+// reveals the XOR of the two plaintexts (the attack that worked before the salt fix).
+func TestX25519KeystreamReuseAttackFails(t *testing.T) {
+	privKey, pubKey, err := GenerateX25519Keypair()
+	require.NoError(t, err)
+
+	seed1 := randomBytes(t, seedSize)
+	seed2 := randomBytes(t, seedSize)
+
+	ct1, err := X25519Encapsulate(seed1, privKey, pubKey)
+	require.NoError(t, err)
+
+	ct2, err := X25519Encapsulate(seed2, privKey, pubKey)
+	require.NoError(t, err)
+
+	// An attacker XORs the two 64-byte blobs and XORs with the known seed1,
+	// hoping to recover seed2. With unique salts, the masks differ, so this fails.
+	xorBlob := make([]byte, len(ct1))
+	for i := range ct1 {
+		xorBlob[i] = ct1[i] ^ ct2[i]
+	}
+
+	// Attempt the attack using only the ciphertext portions (bytes 32..64).
+	attackGuess := make([]byte, seedSize)
+	ct1Payload := ct1[32:]
+	ct2Payload := ct2[32:]
+	for i := range seedSize {
+		attackGuess[i] = ct1Payload[i] ^ ct2Payload[i] ^ seed1[i]
+	}
+
+	assert.NotEqual(t, seed2, attackGuess, "keystream reuse attack must not recover seed2")
 }

--- a/pkg/crypto/crypto_test.go
+++ b/pkg/crypto/crypto_test.go
@@ -191,12 +191,8 @@ func TestX25519KeystreamReuseAttackFails(t *testing.T) {
 	ct2, err := X25519Encapsulate(seed2, privKey, pubKey)
 	require.NoError(t, err)
 
-	// An attacker XORs the two 64-byte blobs and XORs with the known seed1,
-	// hoping to recover seed2. With unique salts, the masks differ, so this fails.
-	xorBlob := make([]byte, len(ct1))
-	for i := range ct1 {
-		xorBlob[i] = ct1[i] ^ ct2[i]
-	}
+	// Verify salts are unique
+	assert.NotEqual(t, ct1[:32], ct2[:32], "salts must be unique")
 
 	// Attempt the attack using only the ciphertext portions (bytes 32..64).
 	attackGuess := make([]byte, seedSize)
@@ -207,4 +203,15 @@ func TestX25519KeystreamReuseAttackFails(t *testing.T) {
 	}
 
 	assert.NotEqual(t, seed2, attackGuess, "keystream reuse attack must not recover seed2")
+}
+
+func TestX25519DecapsulateWrongLength(t *testing.T) {
+	privKey, pubKey, err := GenerateX25519Keypair()
+	require.NoError(t, err)
+
+	// Test with 32-byte ciphertext (old format)
+	badCt := make([]byte, 32)
+	_, err = X25519Decapsulate(badCt, privKey, pubKey)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ciphertext must be 64 bytes")
 }


### PR DESCRIPTION
Resolves KD-2026-002. 

### Problem
Without a random salt, the HKDF output was constant for the same key pair, making multiple encapsulations a one-time-pad reuse (keystream reuse attack).

### Fix
- Added a 32-byte random salt to each  call.
- The salt is prepended to the ciphertext, resulting in a 64-byte blob.
-  extracts the salt to correctly derive the mask.

### Validation
- Unit tests in  (including attack failure confirmation).
- End-to-end rekeying tests in .
- Verified attack prevention with a custom simulation script.
- Confirmed project builds successfully with golangci-lint run ./....

Closes #29