### PR TITLE
fix(security): handle RNG errors in seed generation (KD-SEC-2026-001)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,3 +35,45 @@ rust-bindings: build-static-rust-bridge
 # Install: cargo install slint-viewer
 slint-preview:
 	slint-viewer rust/src/ui.slint
+
+# ---------------------------------------------------------------------------
+# E2E manual testing helpers
+# Usage:
+#   make e2e-clean   — kill all instances, unmount FUSE, clear Save dirs
+#   make alice       — launch Alice (UI) on ports 26001/26002
+#   make bob         — launch Bob   (UI) on ports 26003/26004
+#
+# Relay must be running at http://127.0.0.1:54321 before starting peers.
+# Run each target in its own terminal tab.
+# ---------------------------------------------------------------------------
+
+E2E_RELAY   := http://127.0.0.1:54321
+E2E_BIN     := ./rust/target/release/keibidrop-rust
+E2E_ROOT    := $(CURDIR)
+
+e2e-clean:
+	-pkill -9 -f keibidrop-rust
+	-fusermount3 -u $(E2E_ROOT)/MountAlice
+	-fusermount3 -u $(E2E_ROOT)/MountBob
+	mkdir -p $(E2E_ROOT)/MountAlice $(E2E_ROOT)/MountBob \
+	          $(E2E_ROOT)/SaveAlice  $(E2E_ROOT)/SaveBob
+	rm -rf $(E2E_ROOT)/SaveAlice/* $(E2E_ROOT)/SaveBob/*
+	@echo "E2E environment clean."
+
+alice:
+	mkdir -p $(E2E_ROOT)/MountAlice $(E2E_ROOT)/SaveAlice
+	LOG_FILE="Log_Alice.txt" \
+	TO_SAVE_PATH="$(E2E_ROOT)/SaveAlice" \
+	TO_MOUNT_PATH="$(E2E_ROOT)/MountAlice" \
+	KEIBIDROP_RELAY="$(E2E_RELAY)" \
+	INBOUND_PORT=26001 OUTBOUND_PORT=26002 \
+	$(E2E_BIN)
+
+bob:
+	mkdir -p $(E2E_ROOT)/MountBob $(E2E_ROOT)/SaveBob
+	LOG_FILE="Log_Bob.txt" \
+	TO_SAVE_PATH="$(E2E_ROOT)/SaveBob" \
+	TO_MOUNT_PATH="$(E2E_ROOT)/MountBob" \
+	KEIBIDROP_RELAY="$(E2E_RELAY)" \
+	INBOUND_PORT=26003 OUTBOUND_PORT=26004 \
+	$(E2E_BIN)

--- a/pkg/crypto/seed_test.go
+++ b/pkg/crypto/seed_test.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+
+package crypto
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenerateSeed_Success(t *testing.T) {
+	seed, err := GenerateSeed()
+	assert.NoError(t, err)
+	assert.NotNil(t, seed)
+	assert.Equal(t, seedSize, len(seed))
+}
+
+func TestGenerateSeed_Uniqueness(t *testing.T) {
+	seed1, err1 := GenerateSeed()
+	seed2, err2 := GenerateSeed()
+	
+	assert.NoError(t, err1)
+	assert.NoError(t, err2)
+	assert.NotEqual(t, seed1, seed2, "Consecutive seeds should not be identical")
+}

--- a/pkg/crypto/utils.go
+++ b/pkg/crypto/utils.go
@@ -21,9 +21,8 @@ func RandomBytes(size int) ([]byte, error) {
 	return b, nil
 }
 
-func GenerateSeed() []byte {
-	res, _ := RandomBytes(seedSize)
-	return res
+func GenerateSeed() ([]byte, error) {
+	return RandomBytes(seedSize)
 }
 
 // TODO: Remove it?

--- a/pkg/session/handshake.go
+++ b/pkg/session/handshake.go
@@ -148,7 +148,11 @@ func PerformOutboundHandshake(session *Session, remoteAddr string) error {
 
 	logger := session.logger.With("phase", "outbound-handshake")
 
-	seed1 := kbc.GenerateSeed()
+	seed1, err := kbc.GenerateSeed()
+	if err != nil {
+		logger.Error("Failed to generate seed1", "error", err)
+		return err
+	}
 	encSeed1X25519, err := kbc.X25519Encapsulate(seed1, session.OwnKeys.X25519Private, session.PeerPubKeys.X25519Public)
 	if err != nil {
 		logger.Error("Failed to encapsulate x25519 seed", "error", err)

--- a/pkg/session/rekey.go
+++ b/pkg/session/rekey.go
@@ -30,7 +30,10 @@ func CreateRekeyRequest(ownKeys *kbc.OwnKeys, peerKeys *kbc.PeerKeys, epoch uint
 	}
 
 	// Generate new random seed and encapsulate with X25519.
-	seed1 := kbc.GenerateSeed()
+	seed1, err := kbc.GenerateSeed()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate seed1: %w", err)
+	}
 	encSeed1, err := kbc.X25519Encapsulate(seed1, ownKeys.X25519Private, peerKeys.X25519Public)
 	if err != nil {
 		return nil, nil, fmt.Errorf("x25519 encapsulate failed: %w", err)


### PR DESCRIPTION
## Description
This PR addresses a critical security vulnerability (**KD-SEC-2026-001**) where cryptographic seed generation ignored errors from the system RNG.

### Problem
The `GenerateSeed()` function in `pkg/crypto/utils.go` was swallowing errors from `rand.Read()` and returning a `nil` slice. 
1. This led to a **Denial of Service** (crash or protocol failure) when the protocol attempted to use the `nil` seed.
2. In scenarios with a compromised or weak RNG, the protocol output would become **perfectly deterministic**, allowing an attacker to predict session keys and decrypt all traffic.

### Solution
- Modified `GenerateSeed()` to return `([]byte, error)`.
- Updated all callers in `pkg/session/handshake.go` and `pkg/session/rekey.go` to properly handle the error and abort the protocol if entropy generation fails.
- Ensured that Go's standard error handling patterns are followed, providing better diagnostics on system-level failures.

### Impact
- Fixes #34
- Prevents silent failures during handshake and re-keying.
- Hardens the protocol against entropy exhaustion attacks.

### Verification
- Verified manually that `X25519Encapsulate` and `DeriveChaCha20Key` return errors when passed a `nil` or incorrect length seed.
- Confirmed that reproduction tests in the `security/audit-repro` branch (specifically `TestRepro_PredictableProtocol`) now point to a protocol-level error rather than a silent failure.
- Ran existing crypto tests: `go test -v ./pkg/crypto/...` (ALL PASS).