### PR TITLE
test(security): SecureJoin edge cases — symlink escape fix + edge case tests (#46)

### DIFF
--- a/pkg/filesystem/api.go
+++ b/pkg/filesystem/api.go
@@ -37,6 +37,19 @@ func NewFS(logger *slog.Logger) *FS {
 	}
 }
 
+// resolveDownloadPath returns the real (symlink-resolved) absolute path for the
+// download directory. If resolution fails it falls back to filepath.Clean so the
+// application can still start, logging a warning.
+func resolveDownloadPath(logger *slog.Logger, downloadPath string) string {
+	resolved, err := filepath.EvalSymlinks(downloadPath)
+	if err != nil {
+		logger.Warn("Could not resolve symlinks in download path; using cleaned path",
+			"downloadPath", downloadPath, "error", err)
+		return filepath.Clean(downloadPath)
+	}
+	return resolved
+}
+
 func (fs *FS) Mount(mountPoint string, isSecond bool, downloadPath string) {
 	fs.logger.Warn("FUSE Mount starting",
 		"mountPoint", mountPoint,
@@ -62,8 +75,9 @@ func (fs *FS) Mount(mountPoint string, isSecond bool, downloadPath string) {
 		PeerLastEdit:   0,
 		Parent:         nil,
 
-		// IDK about this one.
-		LocalDownloadFolder: filepath.Clean(downloadPath),
+		// Resolve symlinks so SecureJoin prefix checks work correctly when
+		// downloadPath is itself a symlink (e.g. a home directory behind /home → /data).
+		LocalDownloadFolder: resolveDownloadPath(fs.logger, downloadPath),
 
 		OpenMapLock:      sync.RWMutex{},
 		OpenFileHandlers: make(map[uint64]*File),

--- a/pkg/filesystem/fuse_directory.go
+++ b/pkg/filesystem/fuse_directory.go
@@ -801,15 +801,9 @@ func (d *Dir) MkdirFromPeer(path string, mode uint32) (errCode int) {
 	return d.mkdirInternal(path, mode, false)
 }
 
-// secureJoin resolves path relative to base and verifies the result stays within
-// base. Returns an error if the resolved path escapes base (KD-SEC-2026-004).
-func secureJoin(base, path string) (string, error) {
-	return SecureJoin(base, path)
-}
-
 func (d *Dir) mkdirInternal(path string, mode uint32, notifyPeer bool) (errCode int) {
 	logger := d.logger.With("method", "mkdir", "path", path, "mode", mode)
-	cleanPath, err := secureJoin(d.LocalDownloadFolder, path)
+	cleanPath, err := SecureJoin(d.LocalDownloadFolder, path)
 	if err != nil {
 		logger.Error("Path traversal attempt blocked", "path", path, "error", err)
 		return -int(syscall.EACCES)

--- a/pkg/filesystem/securejoin_edge_test.go
+++ b/pkg/filesystem/securejoin_edge_test.go
@@ -138,6 +138,11 @@ func TestSecureJoin_EmptyAndDotPaths(t *testing.T) {
 			assert.NoError(t, err, "path %q should not escape base", tc.path)
 			assert.True(t, got == absBase || strings.HasPrefix(got, absBase+string(filepath.Separator)),
 				"path %q resolved to %q, expected within %q", tc.path, got, absBase)
+			// For paths with a concrete leaf, verify the exact resolved path.
+			if tc.name == "dot-slash-file" {
+				assert.Equal(t, absBase+string(filepath.Separator)+"file.txt", got,
+					"dot-slash-file must resolve to exactly base/file.txt")
+			}
 		})
 	}
 }
@@ -175,12 +180,14 @@ func TestSecureJoin_UnicodeNormalization(t *testing.T) {
 	}
 }
 
-// TestSecureJoin_CaseSensitiveLinux verifies that on Linux (case-sensitive FS),
-// a path using a different case for the base directory name is treated as a distinct
-// path and correctly rejected when it escapes.
-func TestSecureJoin_CaseSensitiveLinux(t *testing.T) {
+// TestSecureJoin_UpperCasedParentEscapeIsRejected verifies that a path using `..`
+// to escape base is rejected even when the sibling directory name happens to differ
+// only in case from the base directory. The rejection occurs because `..` lands
+// outside base — not because of any filesystem case-sensitivity logic in SecureJoin
+// itself. Skipped on non-Linux where temp dir name patterns differ.
+func TestSecureJoin_UpperCasedParentEscapeIsRejected(t *testing.T) {
 	if runtime.GOOS != "linux" {
-		t.Skip("Case-sensitivity test targets Linux only")
+		t.Skip("Temp dir naming is OS-specific; this test targets Linux only")
 	}
 
 	base, err := os.MkdirTemp("", "keibidrop-CaseTest")
@@ -191,10 +198,10 @@ func TestSecureJoin_CaseSensitiveLinux(t *testing.T) {
 		}
 	})
 
-	// Attempt escape using upper-cased base directory name.
+	// `..` escapes base; the uppercased sibling name is a different path.
 	upperBase := strings.ToUpper(filepath.Base(base))
 	escapePath := "../" + upperBase + "/outside.txt"
 
 	_, err = SecureJoin(base, escapePath)
-	assert.Error(t, err, "Path %q should be rejected even if it only differs in case from base", escapePath)
+	assert.Error(t, err, "Path %q must be rejected because `..` escapes base", escapePath)
 }

--- a/pkg/filesystem/securejoin_edge_test.go
+++ b/pkg/filesystem/securejoin_edge_test.go
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+
+package filesystem
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSecureJoin_SymlinkEscape verifies that SecureJoin rejects paths that escape
+// via a symlink pointing outside the base directory (KD-SEC-2026-004).
+func TestSecureJoin_SymlinkEscape(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks require elevated privileges on Windows")
+	}
+
+	base, err := os.MkdirTemp("", "keibidrop-symlink-base")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if err := os.RemoveAll(base); err != nil {
+			t.Logf("cleanup: failed to remove base dir: %v", err)
+		}
+	})
+
+	outside, err := os.MkdirTemp("", "keibidrop-symlink-outside")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if err := os.RemoveAll(outside); err != nil {
+			t.Logf("cleanup: failed to remove outside dir: %v", err)
+		}
+	})
+
+	// Symlink inside base → points to a directory outside base.
+	symlinkPath := filepath.Join(base, "escape-link")
+	require.NoError(t, os.Symlink(outside, symlinkPath))
+
+	_, err = SecureJoin(base, "escape-link")
+	assert.Error(t, err, "SecureJoin must reject a path that resolves via symlink to outside base")
+}
+
+// TestSecureJoin_SymlinkFileEscape verifies that a symlink to a file outside base
+// is also rejected.
+func TestSecureJoin_SymlinkFileEscape(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks require elevated privileges on Windows")
+	}
+
+	base, err := os.MkdirTemp("", "keibidrop-symlink-file-base")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if err := os.RemoveAll(base); err != nil {
+			t.Logf("cleanup: failed to remove base dir: %v", err)
+		}
+	})
+
+	// Create a real file outside base.
+	outsideFile, err := os.CreateTemp("", "keibidrop-outside-file")
+	require.NoError(t, err)
+	require.NoError(t, outsideFile.Close())
+	t.Cleanup(func() {
+		if err := os.Remove(outsideFile.Name()); err != nil {
+			t.Logf("cleanup: failed to remove outside file: %v", err)
+		}
+	})
+
+	symlinkPath := filepath.Join(base, "escape-file-link")
+	require.NoError(t, os.Symlink(outsideFile.Name(), symlinkPath))
+
+	_, err = SecureJoin(base, "escape-file-link")
+	assert.Error(t, err, "SecureJoin must reject a path that symlinks to a file outside base")
+}
+
+// TestSecureJoin_SymlinkWithinBase verifies that a symlink pointing to a directory
+// within base is accepted and resolves correctly.
+func TestSecureJoin_SymlinkWithinBase(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks require elevated privileges on Windows")
+	}
+
+	base, err := os.MkdirTemp("", "keibidrop-symlink-within")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if err := os.RemoveAll(base); err != nil {
+			t.Logf("cleanup: failed to remove base dir: %v", err)
+		}
+	})
+
+	subdir := filepath.Join(base, "subdir")
+	require.NoError(t, os.MkdirAll(subdir, 0o755))
+
+	symlinkPath := filepath.Join(base, "safe-link")
+	require.NoError(t, os.Symlink(subdir, symlinkPath))
+
+	absBase, err := filepath.Abs(base)
+	require.NoError(t, err)
+
+	got, err := SecureJoin(base, "safe-link")
+	assert.NoError(t, err, "SecureJoin must allow a symlink that resolves within base")
+	assert.True(t, got == absBase || strings.HasPrefix(got, absBase+string(filepath.Separator)),
+		"resolved path %q must be within %q", got, absBase)
+}
+
+// TestSecureJoin_EmptyAndDotPaths verifies that empty, dot, and dot-slash paths
+// resolve to base (or within base) without escaping.
+func TestSecureJoin_EmptyAndDotPaths(t *testing.T) {
+	base, err := os.MkdirTemp("", "keibidrop-dot-paths")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if err := os.RemoveAll(base); err != nil {
+			t.Logf("cleanup: failed to remove base dir: %v", err)
+		}
+	})
+
+	absBase, err := filepath.Abs(base)
+	require.NoError(t, err)
+
+	cases := []struct {
+		name string
+		path string
+	}{
+		{"empty string", ""},
+		{"single dot", "."},
+		{"dot-slash", "./"},
+		{"dot-dot-dot", "././"},
+		{"dot-slash-file", "./file.txt"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := SecureJoin(base, tc.path)
+			assert.NoError(t, err, "path %q should not escape base", tc.path)
+			assert.True(t, got == absBase || strings.HasPrefix(got, absBase+string(filepath.Separator)),
+				"path %q resolved to %q, expected within %q", tc.path, got, absBase)
+		})
+	}
+}
+
+// TestSecureJoin_UnicodeNormalization verifies that different Unicode normalization
+// forms are treated as distinct paths on Linux (byte-exact comparison). This test
+// only runs on Linux where the filesystem does not normalize filenames.
+func TestSecureJoin_UnicodeNormalization(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Unicode normalization behaviour is OS-specific; this test targets Linux only")
+	}
+
+	base, err := os.MkdirTemp("", "keibidrop-unicode")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if err := os.RemoveAll(base); err != nil {
+			t.Logf("cleanup: failed to remove base dir: %v", err)
+		}
+	})
+
+	absBase, err := filepath.Abs(base)
+	require.NoError(t, err)
+
+	// "café" NFC (é = U+00E9, one codepoint) vs NFD (e + U+0301, two codepoints).
+	// On Linux both are valid, distinct filenames within base — neither escapes.
+	nfc := "caf\u00e9.txt"           // precomposed
+	nfd := "cafe\u0301.txt"          // decomposed
+	combined := "caf\u00e9\u0301.txt" // unusual but valid
+
+	for _, name := range []string{nfc, nfd, combined} {
+		got, err := SecureJoin(base, name)
+		assert.NoError(t, err, "Unicode filename %q should not escape base", name)
+		assert.True(t, got == absBase || strings.HasPrefix(got, absBase+string(filepath.Separator)),
+			"filename %q resolved to %q, expected within %q", name, got, absBase)
+	}
+}
+
+// TestSecureJoin_CaseSensitiveLinux verifies that on Linux (case-sensitive FS),
+// a path using a different case for the base directory name is treated as a distinct
+// path and correctly rejected when it escapes.
+func TestSecureJoin_CaseSensitiveLinux(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Case-sensitivity test targets Linux only")
+	}
+
+	base, err := os.MkdirTemp("", "keibidrop-CaseTest")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if err := os.RemoveAll(base); err != nil {
+			t.Logf("cleanup: failed to remove base dir: %v", err)
+		}
+	})
+
+	// Attempt escape using upper-cased base directory name.
+	upperBase := strings.ToUpper(filepath.Base(base))
+	escapePath := "../" + upperBase + "/outside.txt"
+
+	_, err = SecureJoin(base, escapePath)
+	assert.Error(t, err, "Path %q should be rejected even if it only differs in case from base", escapePath)
+}

--- a/pkg/filesystem/utils.go
+++ b/pkg/filesystem/utils.go
@@ -20,6 +20,7 @@ import (
 
 // SecureJoin resolves path relative to base and verifies the result stays within
 // base. Returns an error if the resolved path escapes base (KD-SEC-2026-004).
+// Symlinks are resolved when the path exists to prevent symlink-escape attacks.
 func SecureJoin(base, path string) (string, error) {
 	absBase, err := filepath.Abs(base)
 	if err != nil {
@@ -30,10 +31,25 @@ func SecureJoin(base, path string) (string, error) {
 	// e.g. Join("/base", "/foo") -> "/base/foo"
 	result := filepath.Clean(filepath.Join(absBase, path))
 
-	// Verify the result is still within absBase.
+	// Verify the result is still within absBase before resolving symlinks.
 	if result != absBase && !strings.HasPrefix(result, absBase+string(os.PathSeparator)) {
 		return "", fmt.Errorf("path %q escapes base directory %q", path, absBase)
 	}
+
+	// Resolve symlinks if the path exists. A symlink inside base could point
+	// to a location outside base, bypassing the prefix check above.
+	// If EvalSymlinks fails (path does not exist yet), the initial check suffices.
+	if resolved, evalErr := filepath.EvalSymlinks(result); evalErr == nil {
+		absResolved, absErr := filepath.Abs(resolved)
+		if absErr != nil {
+			return "", fmt.Errorf("failed to get absolute path of resolved symlink: %w", absErr)
+		}
+		if absResolved != absBase && !strings.HasPrefix(absResolved, absBase+string(os.PathSeparator)) {
+			return "", fmt.Errorf("path %q escapes base directory via symlink", path)
+		}
+		return absResolved, nil
+	}
+
 	return result, nil
 }
 func convertOsErrToSyscallErrno(name string, err error) syscall.Errno {

--- a/pkg/filesystem/utils.go
+++ b/pkg/filesystem/utils.go
@@ -21,6 +21,12 @@ import (
 // SecureJoin resolves path relative to base and verifies the result stays within
 // base. Returns an error if the resolved path escapes base (KD-SEC-2026-004).
 // Symlinks are resolved when the path exists to prevent symlink-escape attacks.
+//
+// Threat model: local write access to base is assumed to be trusted. A TOCTOU
+// window exists between EvalSymlinks validation and the caller's subsequent
+// syscall; closing it requires kernel-level openat(2)/O_NOFOLLOW chains, which
+// is out of scope for this guard. In KeibiDrop, the FUSE Symlink handler returns
+// EPERM so no remote peer can introduce symlinks inside base.
 func SecureJoin(base, path string) (string, error) {
 	absBase, err := filepath.Abs(base)
 	if err != nil {
@@ -52,6 +58,7 @@ func SecureJoin(base, path string) (string, error) {
 
 	return result, nil
 }
+
 func convertOsErrToSyscallErrno(name string, err error) syscall.Errno {
 	if err == nil {
 		return 0


### PR DESCRIPTION
## Summary

Closes #46

- **Symlink escape fix**: `SecureJoin` now calls `filepath.EvalSymlinks` on the resolved path when it exists, re-checking the prefix after resolution. A symlink inside base pointing outside is now correctly rejected.
- **Non-existent paths unaffected**: `EvalSymlinks` failure (path doesn't exist yet) is silently ignored — initial Clean+HasPrefix check is sufficient for new file creation paths.
- **Edge case tests added** (`securejoin_edge_test.go`):
  - `TestSecureJoin_SymlinkEscape` — dir symlink outside base → error
  - `TestSecureJoin_SymlinkFileEscape` — file symlink outside base → error
  - `TestSecureJoin_SymlinkWithinBase` — symlink to subdir inside base → accepted
  - `TestSecureJoin_EmptyAndDotPaths` — `""`, `"."`, `"./"`, `"././"` → all within base
  - `TestSecureJoin_UnicodeNormalization` — NFC/NFD treated as distinct filenames on Linux, no escape
  - `TestSecureJoin_CaseSensitiveLinux` — different-case base dir name treated as distinct path, escape rejected

## Test plan

- [x] `TestSecureJoin_SymlinkEscape` / `SymlinkFileEscape` confirmed RED before fix, GREEN after
- [x] All existing `TestSecureJoin` subtests still pass
- [x] `go test -timeout 300s ./...` — all green
- [x] `make lint` — no new issues
- [x] `make sec` — no new issues