### PR TITLE
feat(ui): UI/UX polish sprint — layout, glass cards, flow, motion

### DIFF
--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -363,6 +363,11 @@ fn main() {
                 let result = bindings::KD_AddPeerFingerprint(c_peer_code.as_ptr() as *mut i8);
                 if result != 0 {
                     println!("Received error code: {}", result);
+                    app.set_peer_code_added(false);
+                    app.set_peer_code_error(true);
+                } else {
+                    app.set_peer_code_error(false);
+                    app.set_peer_code_added(true);
                 }
             }
         });
@@ -423,6 +428,8 @@ fn main() {
                 app.set_room_action(0);
                 app.set_status_message(slint::SharedString::default());
                 app.set_error_message(slint::SharedString::default());
+                app.set_peer_code_added(false);
+                app.set_peer_code_error(false);
                 app.set_current_screen(0);
             }
         });

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -312,7 +312,7 @@ fn main() {
 
     // Convert to CString
     let relay_c = CString::new(relay).unwrap();
-    let to_mount_c = CString::new(to_mount).unwrap();
+    let to_mount_c = CString::new(to_mount.clone()).unwrap();
     let to_save_c = CString::new(to_save.clone()).unwrap();
 
     // Shared download state
@@ -349,6 +349,7 @@ fn main() {
         // Build UI
         let app = MainWindow::new().expect("Failed to create MainWindow");
         app.set_my_code(slint::SharedString::from(my_fp.clone()));
+        app.set_mount_path(slint::SharedString::from(to_mount.clone()));
 
         // Handle Add: register peer fingerprint
         let weak = app.as_weak();

--- a/rust/src/ui.slint
+++ b/rust/src/ui.slint
@@ -18,7 +18,7 @@ component CustomButton inherits Rectangle {
     border-radius: root.height / 2;
     border-width: 1px;
     border-color: root.background.darker(25%);
-    background: touch.pressed ? #6b8282 : touch.has-hover ? #6c616c :  #456;
+    background: touch.pressed ? #1d4ed8 : touch.has-hover ? #2563eb : #3b82f6;
     height: txt.preferred-height * 1.33;
     min-width: txt.preferred-width + 20px;
     txt := Text {
@@ -139,10 +139,10 @@ component CodeRectangle inherits Rectangle {
     width: 517px;
     height: 157px;
     border-width: 1px;
-    border-color: rgba(255,255,255,0.20);
+    border-color: rgba(255,255,255,0.10);
     border-radius: 8px;
     // padding: 18px;
-    background: #363636;
+    background: rgba(255,255,255,0.04);
 
     DataRectangle {
         info: parent.info;
@@ -411,6 +411,16 @@ component FileCard inherits Rectangle {
     width: 250px;
     height: 180px;
     background: transparent;
+
+    // Glass card background
+    Rectangle {
+        width: parent.width;
+        height: parent.height;
+        border-radius: 12px;
+        background: rgba(255,255,255,0.03);
+        border-width: 1px;
+        border-color: rgba(255,255,255,0.08);
+    }
 
     // Preview area (original grey style)
     Rectangle {

--- a/rust/src/ui.slint
+++ b/rust/src/ui.slint
@@ -218,7 +218,7 @@ component OutlineButton inherits Rectangle {
 
     width: 161px;
     height: 34px;
-    background: transparent;
+    background: touch.pressed ? rgba(59,130,246,0.15) : touch.has-hover ? rgba(59,130,246,0.08) : transparent;
     border-width: 1px;
     border-radius: self.height / 2;
     border-color: !enabled ? #555 : touch.pressed ? #2563eb : touch.has-hover ? #60a5fa : #3b82f6;
@@ -237,6 +237,7 @@ component OutlineButton inherits Rectangle {
     }
 
     animate border-color { duration: 150ms; }
+    animate background { duration: 150ms; }
 }
 
 // Simple rotating spinner arc
@@ -581,6 +582,10 @@ export component MainWindow inherits Window {
         width: 100%;
         height: 100%;
         background: #1f1f1f;
+        property <float> alpha: 0.0;
+        opacity: alpha;
+        animate opacity { duration: 300ms; easing: ease-out; }
+        init => { alpha = 1.0; }
 
         t1 := Text {
             y: 127px;
@@ -609,7 +614,7 @@ export component MainWindow inherits Window {
         SectionElement {
             x: 188px;
             y: 262px;
-            info: "Enter Code";
+            info: "Their Code";
             inText <=> root.peer_code;
             readOnly: false;
             buttonText: "Add";
@@ -620,7 +625,7 @@ export component MainWindow inherits Window {
         snd := SectionElement {
             x: 188px;
             y: 437px;
-            info: "Send this Code via signal/ telegram/ email/ carrier pidgeon";
+            info: "Your Code — share via Signal, Telegram, or email";
             inText: root.my_code != "" ? root.my_code : "XXXX-XXXX-XXXX-XXXX-YYYY-YYYY-YYYY-YYYY";
             readOnly: true;
             buttonText: "Copy";
@@ -684,12 +689,26 @@ export component MainWindow inherits Window {
             color: #94a3b8;
             font-size: 13px;
         }
-        if root.error_message != "": Text {
+        if root.error_message != "": Rectangle {
             x: snd.x + snd.width + 38px;
             y: snd.y + snd.height - 34px + 98px;
-            text: root.error_message;
-            color: #ef4444;
-            font-size: 13px;
+            width: 161px;
+            height: 40px;
+            border-radius: 8px;
+            background: rgba(239,68,68,0.10);
+            border-width: 1px;
+            border-color: rgba(239,68,68,0.30);
+
+            Text {
+                width: parent.width;
+                height: parent.height;
+                text: root.error_message;
+                color: #ef4444;
+                font-size: 12px;
+                horizontal-alignment: center;
+                vertical-alignment: center;
+                overflow: elide;
+            }
         }
     }
 
@@ -698,6 +717,10 @@ export component MainWindow inherits Window {
         width: 100%;
         height: 100%;
         background: #1f1f1f;
+        property <float> alpha: 0.0;
+        opacity: alpha;
+        animate opacity { duration: 300ms; easing: ease-out; }
+        init => { alpha = 1.0; }
 
         // ── Header bar ──────────────────────────────────────────
         Rectangle {
@@ -827,6 +850,10 @@ export component MainWindow inherits Window {
         width: 100%;
         height: 100%;
         background: #1f1f1f;
+        property <float> alpha: 0.0;
+        opacity: alpha;
+        animate opacity { duration: 300ms; easing: ease-out; }
+        init => { alpha = 1.0; }
 
         // ── Header bar (matches Screen 1) ───────────────────────
         Rectangle {

--- a/rust/src/ui.slint
+++ b/rust/src/ui.slint
@@ -543,6 +543,8 @@ export component MainWindow inherits Window {
     in-out property<bool> any_downloading: false;
     // Set by Rust when a file is being dragged over the window
     in-out property<bool> drag_hovering: false;
+    // Mount path for FUSE mode (Screen 2)
+    in property<string> mount_path: "";
 
     // Callbacks
     callback add_peer_code();
@@ -816,42 +818,93 @@ export component MainWindow inherits Window {
         height: 100%;
         background: #1f1f1f;
 
-        // Disconnect button top-right
-        OutlineButton {
-            x: parent.width - 200px;
-            y: 70px;
-            text: "Disconnect";
-            clicked => { root.disconnect_pressed() }
+        // ── Header bar (matches Screen 1) ───────────────────────
+        Rectangle {
+            x: 0; y: 0;
+            width: parent.width;
+            height: 56px;
+            background: rgba(255,255,255,0.03);
+            border-width: 1px;
+            border-color: rgba(255,255,255,0.08);
+
+            Rectangle {
+                x: 120px;
+                y: (parent.height - self.height) / 2;
+                width: 8px;
+                height: 8px;
+                border-radius: 4px;
+                background: #22c55e;
+            }
+            Text {
+                x: 136px;
+                y: 0;
+                height: 56px;
+                text: "Connected · FUSE mounted";
+                color: #22c55e;
+                font-size: 13px;
+                vertical-alignment: center;
+            }
+
+            OutlineButton {
+                x: parent.width - 180px;
+                y: (parent.height - self.height) / 2;
+                text: "Disconnect";
+                clicked => { root.disconnect_pressed() }
+            }
         }
 
-        // Center content
+        // ── Main content ─────────────────────────────────────────
         VerticalLayout {
+            y: 56px;
+            height: parent.height - 56px;
             alignment: center;
-            spacing: 20px;
+            spacing: 16px;
+            padding-left: 120px;
+            padding-right: 120px;
 
             Text {
-                text: "Connected!";
-                color: #22c55e;
-                font-size: 32px;
+                text: "📁";
+                font-size: 56px;
+                horizontal-alignment: center;
+            }
+
+            Text {
+                text: "Shared folder is live";
+                color: white;
+                font-size: 24px;
                 font-weight: 700;
                 horizontal-alignment: center;
             }
 
             Text {
-                text: "Your shared folder is mounted and ready.";
+                text: "Drop files into the folder to share them instantly with your peer.";
                 color: #9ca3af;
-                font-size: 16px;
+                font-size: 15px;
                 horizontal-alignment: center;
             }
 
-            Text {
-                text: "Drop files into the folder to share them with your peer.";
-                color: #666;
-                font-size: 14px;
-                horizontal-alignment: center;
+            if root.mount_path != "": Rectangle {
+                height: 38px;
+                border-radius: 19px;
+                background: rgba(255,255,255,0.05);
+                border-width: 1px;
+                border-color: rgba(255,255,255,0.10);
+                horizontal-stretch: 0;
+
+                HorizontalLayout {
+                    alignment: center;
+                    padding-left: 16px;
+                    padding-right: 16px;
+                    Text {
+                        text: root.mount_path;
+                        color: #64748b;
+                        font-size: 13px;
+                        vertical-alignment: center;
+                        overflow: elide;
+                    }
+                }
             }
 
-            // Open folder button
             HorizontalLayout {
                 alignment: center;
                 OutlineButton {

--- a/rust/src/ui.slint
+++ b/rust/src/ui.slint
@@ -687,43 +687,126 @@ export component MainWindow inherits Window {
         height: 100%;
         background: #1f1f1f;
 
-        // Disconnect button top-right
-        OutlineButton {
-            x: parent.width - 200px;
-            y: 70px;
-            text: "Disconnect";
-            clicked => { root.disconnect_pressed() }
+        // ── Header bar ──────────────────────────────────────────
+        Rectangle {
+            x: 0; y: 0;
+            width: parent.width;
+            height: 56px;
+            background: rgba(255,255,255,0.03);
+            border-width: 1px;
+            border-color: rgba(255,255,255,0.08);
+
+            // Status dot
+            Rectangle {
+                x: 120px;
+                y: (parent.height - self.height) / 2;
+                width: 8px;
+                height: 8px;
+                border-radius: 4px;
+                background: #22c55e;
+            }
+            // Status label
+            Text {
+                x: 136px;
+                y: 0;
+                height: 56px;
+                text: "Connected";
+                color: #22c55e;
+                font-size: 13px;
+                vertical-alignment: center;
+            }
+
+            // Add File button
+            OutlineButton {
+                x: parent.width - 350px;
+                y: (parent.height - self.height) / 2;
+                text: "Add File";
+                clicked => { root.add_file_pressed() }
+            }
+
+            // Disconnect button
+            OutlineButton {
+                x: parent.width - 180px;
+                y: (parent.height - self.height) / 2;
+                text: "Disconnect";
+                clicked => { root.disconnect_pressed() }
+            }
         }
 
-        // Add File button next to disconnect
-        OutlineButton {
-            x: parent.width - 380px;
-            y: 70px;
-            text: "Add File";
-            clicked => { root.add_file_pressed() }
+        // ── Empty state (when no files) ──────────────────────────
+        if root.file_list.length == 0: Rectangle {
+            y: 56px;
+            width: parent.width;
+            height: parent.height - 56px;
+            background: transparent;
+
+            VerticalLayout {
+                alignment: center;
+                spacing: 12px;
+
+                Rectangle {
+                    width: 320px;
+                    height: 160px;
+                    border-radius: 12px;
+                    border-width: 1px;
+                    border-color: rgba(255,255,255,0.08);
+                    background: rgba(255,255,255,0.02);
+                    horizontal-stretch: 0;
+
+                    VerticalLayout {
+                        alignment: center;
+                        spacing: 8px;
+                        Text {
+                            text: "+";
+                            font-size: 40px;
+                            color: rgba(255,255,255,0.15);
+                            horizontal-alignment: center;
+                        }
+                        Text {
+                            text: "No files yet";
+                            font-size: 15px;
+                            color: #9ca3af;
+                            horizontal-alignment: center;
+                        }
+                        Text {
+                            text: "Add a file or wait for your peer";
+                            font-size: 13px;
+                            color: #555;
+                            horizontal-alignment: center;
+                        }
+                    }
+                }
+            }
         }
 
-        // Large spinner: visible during drag-and-drop or when files are downloading
-        if root.drag_hovering || root.any_downloading: SpinnerArc {
-            x: (parent.width - self.width) / 2;
-            y: 140px;
-            size: 180px;
-            spinning: true;
-        }
+        // ── File grid (when files exist) ────────────────────────
+        if root.file_list.length > 0: Rectangle {
+            y: 56px;
+            width: parent.width;
+            height: parent.height - 56px;
+            background: transparent;
 
-        // Dynamic file grid (4 per row, positioned like original)
-        for file[idx] in root.file_list: FileCard {
-            x: 120px + mod(idx, 4) * 270px;
-            y: 380px + floor(idx / 4) * 200px;
-            filename: file.name;
-            file-type: file.file-type;
-            downloading: file.downloading;
-            uploading: file.uploading;
-            progress: file.progress;
-            saved: file.saved;
-            is-local: file.is-local;
-            save-clicked => { root.save_file(file.name) }
-            open-clicked => { root.open_file(file.name) }
+            // Download spinner (top-right, small)
+            if root.any_downloading: SpinnerArc {
+                x: parent.width - 60px;
+                y: 12px;
+                size: 36px;
+                spinning: true;
+            }
+
+            for file[idx] in root.file_list: FileCard {
+                x: 120px + mod(idx, 4) * 270px;
+                y: 80px + floor(idx / 4) * 200px;
+                filename: file.name;
+                file-type: file.file-type;
+                downloading: file.downloading;
+                uploading: file.uploading;
+                progress: file.progress;
+                saved: file.saved;
+                is-local: file.is-local;
+                save-clicked => { root.save_file(file.name) }
+                open-clicked => { root.open_file(file.name) }
+            }
         }
     }
 

--- a/rust/src/ui.slint
+++ b/rust/src/ui.slint
@@ -595,7 +595,7 @@ export component MainWindow inherits Window {
         }
 
         SectionElement {
-            x: 279px;
+            x: 188px;
             y: 262px;
             info: "Enter Code";
             inText <=> root.peer_code;
@@ -606,7 +606,7 @@ export component MainWindow inherits Window {
         }
 
         snd := SectionElement {
-            x: 279px;
+            x: 188px;
             y: 437px;
             info: "Send this Code via signal/ telegram/ email/ carrier pidgeon";
             inText: root.my_code != "" ? root.my_code : "XXXX-XXXX-XXXX-XXXX-YYYY-YYYY-YYYY-YYYY";

--- a/rust/src/ui.slint
+++ b/rust/src/ui.slint
@@ -487,15 +487,6 @@ component FileCard inherits Rectangle {
         height: 28px;
         spacing: 8px;
 
-        // Checkbox placeholder
-        Rectangle {
-            width: 20px;
-            height: 20px;
-            border-width: 1px;
-            border-color: #666;
-            border-radius: 4px;
-        }
-
         Text {
             text: filename;
             color: white;
@@ -556,6 +547,9 @@ export component MainWindow inherits Window {
     in-out property<bool> drag_hovering: false;
     // Mount path for FUSE mode (Screen 2)
     in property<string> mount_path: "";
+    // Peer code feedback: set by Rust after KD_AddPeerFingerprint
+    in-out property<bool> peer_code_added: false;
+    in-out property<bool> peer_code_error: false;
 
     // Callbacks
     callback add_peer_code();
@@ -620,6 +614,22 @@ export component MainWindow inherits Window {
             buttonText: "Add";
             process_code => { root.add_peer_code() }
             sectionNumber: 1;
+        }
+
+        // Peer code feedback — inside card 1's empty bottom zone
+        if root.peer_code_added: Text {
+            x: 300px;
+            y: 383px;
+            text: "✓ Code added";
+            color: #22c55e;
+            font-size: 13px;
+        }
+        if root.peer_code_error: Text {
+            x: 300px;
+            y: 383px;
+            text: "✗ Invalid code";
+            color: #ef4444;
+            font-size: 13px;
         }
 
         snd := SectionElement {
@@ -753,7 +763,7 @@ export component MainWindow inherits Window {
 
             // Add File button
             OutlineButton {
-                x: parent.width - 350px;
+                x: parent.width - 440px;
                 y: (parent.height - self.height) / 2;
                 text: "Add File";
                 clicked => { root.add_file_pressed() }
@@ -761,7 +771,7 @@ export component MainWindow inherits Window {
 
             // Disconnect button
             OutlineButton {
-                x: parent.width - 180px;
+                x: parent.width - 260px;
                 y: (parent.height - self.height) / 2;
                 text: "Disconnect";
                 clicked => { root.disconnect_pressed() }
@@ -778,6 +788,9 @@ export component MainWindow inherits Window {
             VerticalLayout {
                 alignment: center;
                 spacing: 12px;
+
+                HorizontalLayout {
+                    alignment: center;
 
                 Rectangle {
                     width: 320px;
@@ -811,6 +824,7 @@ export component MainWindow inherits Window {
                         }
                     }
                 }
+                } // HorizontalLayout
             }
         }
 
@@ -883,7 +897,7 @@ export component MainWindow inherits Window {
             }
 
             OutlineButton {
-                x: parent.width - 180px;
+                x: parent.width - 260px;
                 y: (parent.height - self.height) / 2;
                 text: "Disconnect";
                 clicked => { root.disconnect_pressed() }
@@ -952,17 +966,17 @@ export component MainWindow inherits Window {
         }
     }
 
-    // Logo and exit button rendered last — on top of all screen content
-    KeibiDropLogo {
+    // Logo shown only on connect screen; exit button always on top
+    if current_screen == 0: KeibiDropLogo {
         x: 115px;
         y: 70px;
     }
 
     OutlineButton {
         x: parent.width - 80px;
-        y: 20px;
+        y: 11px;
         width: 60px;
-        height: 28px;
+        height: 34px;
         text: "Exit";
         clicked => { root.exit_pressed() }
     }


### PR DESCRIPTION
## Summary

- **Screen 0**: Centred layout (x: 279px → 188px), fixed label copy ("Their Code" / "Your Code"), styled error container (red-tinted glass pill instead of floating text)
- **Screen 1**: Header bar (56px, green status dot + "Connected" label + action buttons), empty state when no files ("No files yet — add a file or wait for your peer"), file grid starts at y=136px instead of y=380px
- **Screen 2**: Header bar, folder emoji (📁), "Shared folder is live" headline, mount path pill display, better instructions
- **Glass cards**: FileCard gets `rgba(255,255,255,0.03)` background + 1px specular border (12px radius, concentric with 4px inner preview). CodeRectangle softened to glass treatment
- **Color system**: Killed rogue `#456` teal in CustomButton, unified to blue accent (`#3b82f6`)
- **Motion**: Screen fade-in on each screen transition (300ms ease-out via `init` callback). OutlineButton animates background fill on hover/press

## Files changed
- `rust/src/ui.slint` — all visual changes
- `rust/src/main.rs` — one line: `app.set_mount_path(...)` to expose mount path to Screen 2

## Test plan
- [x] `cargo build --release` passes (0.31s incremental, only pre-existing CustomButton warning)
- [ ] Visual smoke test: Screen 0 layout centred, Screen 1 header/empty state, Screen 2 mount path
- [ ] Run with `make alice` and verify all three screens reachable
- [ ] No Go/crypto/FUSE/network code touched