### PR TITLE
fix(cross-platform): text colors for Ubuntu/Wayland + portable run scripts

### DIFF
--- a/example_run_cli.sh
+++ b/example_run_cli.sh
@@ -1,1 +1,12 @@
-LOG_FILE="Log_Alice.txt" TO_SAVE_PATH="/Users/marius/work/code/KeibiDrop/SaveAlice" TO_MOUNT_PATH="/Users/marius/work/code/KeibiDrop/MountAlice" KEIBIDROP_RELAY="http://0.0.0.0:54321" INBOUND_PORT=26001 OUTBOUND_PORT=26002 go run cmd/cli/keibidrop-cli.go
+#!/usr/bin/env bash
+# ABOUTME: Launches Alice peer via Go CLI (FUSE mode).
+# ABOUTME: Uses project-relative paths so it works on any machine.
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+mkdir -p "$ROOT/SaveAlice" "$ROOT/MountAlice"
+LOG_FILE="Log_Alice.txt" \
+  TO_SAVE_PATH="$ROOT/SaveAlice" \
+  TO_MOUNT_PATH="$ROOT/MountAlice" \
+  KEIBIDROP_RELAY="http://127.0.0.1:54321" \
+  INBOUND_PORT=26001 \
+  OUTBOUND_PORT=26002 \
+  go run "$ROOT/cmd/cli/keibidrop-cli.go"

--- a/example_run_peer_cli.sh
+++ b/example_run_peer_cli.sh
@@ -1,2 +1,12 @@
-LOG_FILE="Log_Bob.txt" TO_SAVE_PATH="/Users/marius/work/code/KeibiDrop/SaveBob" TO_MOUNT_PATH="/Users/marius/work/code/KeibiDrop/MountBob" KEIBIDROP_RELAY="http://0.0.0.0:54321" INBOUND_PORT=26003 OUTBOUND_PORT=26004 go run cmd/cli/keibidrop-cli.go
-
+#!/usr/bin/env bash
+# ABOUTME: Launches Bob peer via Go CLI (FUSE mode).
+# ABOUTME: Uses project-relative paths so it works on any machine.
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+mkdir -p "$ROOT/SaveBob" "$ROOT/MountBob"
+LOG_FILE="Log_Bob.txt" \
+  TO_SAVE_PATH="$ROOT/SaveBob" \
+  TO_MOUNT_PATH="$ROOT/MountBob" \
+  KEIBIDROP_RELAY="http://127.0.0.1:54321" \
+  INBOUND_PORT=26003 \
+  OUTBOUND_PORT=26004 \
+  go run "$ROOT/cmd/cli/keibidrop-cli.go"

--- a/example_run_rust_ui.sh
+++ b/example_run_rust_ui.sh
@@ -1,1 +1,12 @@
-LOG_FILE="Log_Bob.txt" TO_SAVE_PATH="/Users/marius/work/code/KeibiDrop/SaveBob" TO_MOUNT_PATH="/Users/marius/work/code/KeibiDrop/MountBob" KEIBIDROP_RELAY="http://0.0.0.0:54321" INBOUND_PORT=26003 OUTBOUND_PORT=26004 ./rust/target/release/keibidrop-rust
+#!/usr/bin/env bash
+# ABOUTME: Launches the KeibiDrop Rust UI (FUSE mode, Bob peer).
+# ABOUTME: Uses project-relative paths so it works on any machine.
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+mkdir -p "$ROOT/SaveBob" "$ROOT/MountBob"
+LOG_FILE="Log_Bob.txt" \
+  TO_SAVE_PATH="$ROOT/SaveBob" \
+  TO_MOUNT_PATH="$ROOT/MountBob" \
+  KEIBIDROP_RELAY="http://127.0.0.1:54321" \
+  INBOUND_PORT=26003 \
+  OUTBOUND_PORT=26004 \
+  "$ROOT/rust/target/release/keibidrop-rust"

--- a/example_run_rust_ui_nofuse.sh
+++ b/example_run_rust_ui_nofuse.sh
@@ -1,1 +1,13 @@
-LOG_FILE="Log_Alice.txt" NO_FUSE=1 TO_SAVE_PATH="/Users/marius/work/code/KeibiDrop/SaveAlice" TO_MOUNT_PATH="/Users/marius/work/code/KeibiDrop/MountAlice" KEIBIDROP_RELAY="http://0.0.0.0:54321" INBOUND_PORT=26001 OUTBOUND_PORT=26002 ./rust/target/release/keibidrop-rust
+#!/usr/bin/env bash
+# ABOUTME: Launches the KeibiDrop Rust UI (no-FUSE mode, Alice peer).
+# ABOUTME: Uses project-relative paths so it works on any machine.
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+mkdir -p "$ROOT/SaveAlice" "$ROOT/MountAlice"
+LOG_FILE="Log_Alice.txt" \
+  NO_FUSE=1 \
+  TO_SAVE_PATH="$ROOT/SaveAlice" \
+  TO_MOUNT_PATH="$ROOT/MountAlice" \
+  KEIBIDROP_RELAY="http://127.0.0.1:54321" \
+  INBOUND_PORT=26001 \
+  OUTBOUND_PORT=26002 \
+  "$ROOT/rust/target/release/keibidrop-rust"

--- a/example_run_ui.sh
+++ b/example_run_ui.sh
@@ -1,1 +1,12 @@
-NO_FUSE="" TO_SAVE_PATH="/Users/marius/work/code/KeibiDrop/SaveAlice" TO_MOUNT_PATH="/Users/marius/work/code/KeibiDrop/MountAlice" KEIBIDROP_RELAY="http://0.0.0.0:54321" INBOUND_PORT=26001 OUTBOUND_PORT=26002 go run cmd/keibidrop.go
+#!/usr/bin/env bash
+# ABOUTME: Launches Alice peer via Go GUI (no-FUSE mode).
+# ABOUTME: Uses project-relative paths so it works on any machine.
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+mkdir -p "$ROOT/SaveAlice" "$ROOT/MountAlice"
+NO_FUSE="" \
+  TO_SAVE_PATH="$ROOT/SaveAlice" \
+  TO_MOUNT_PATH="$ROOT/MountAlice" \
+  KEIBIDROP_RELAY="http://127.0.0.1:54321" \
+  INBOUND_PORT=26001 \
+  OUTBOUND_PORT=26002 \
+  go run "$ROOT/cmd/keibidrop.go"

--- a/rust/src/ui.slint
+++ b/rust/src/ui.slint
@@ -113,6 +113,7 @@ component DataRectangle inherits Rectangle {
         x: 36px;
         y: 0;
         text: parent.info;
+        color: #9ca3af;
     }
 
     InputArea {
@@ -934,6 +935,7 @@ export component MainWindow inherits Window {
             Text {
                 text: "📁";
                 font-size: 56px;
+                color: white;
                 horizontal-alignment: center;
             }
 


### PR DESCRIPTION
## Summary
- Add explicit `color:` to `DataRectangle` label and Screen 2 emoji — fixes invisible text on Ubuntu/Wayland (Slint default theme uses dark text). No-op on Mac.
- Replace hardcoded `/Users/marius/...` paths in all 5 `example_run_*.sh` scripts with `$(dirname "$0")` so they work on any machine.

## Tested on Ubuntu
- [x] `make build-rust` clean
- [x] Screen 0: "Peer Code" / "Your Code" labels visible
- [x] Screen 2 (FUSE): folder emoji visible
- [x] Multiple disconnect→reconnect cycles work
- [x] Both FUSE and no-FUSE modes tested

## Not touched
- No Go/crypto/FUSE/network code changed
- No Mac-specific behavior altered