### PR TITLE
perf(tests): add end-to-end transfer benchmarks

### DIFF
--- a/docs/benchmarks/2026-03-16-transfer-benchmark-results.md
+++ b/docs/benchmarks/2026-03-16-transfer-benchmark-results.md
@@ -85,22 +85,74 @@ issues parallel readahead — multiple chunks in flight simultaneously.
 
 ---
 
+## Simulated Network Transfer (tc netem on loopback)
+
+These numbers represent real-world transfer speeds more accurately than
+localhost benchmarks. Run with `sudo -E KEIBIDROP_BENCH_NETEM=1`.
+
+### LAN 1ms RTT (Gigabit, no bandwidth limit)
+
+| Size | MB/s | Duration |
+|------|------|----------|
+| 10 MB | 65.8 | 152 ms |
+| 100 MB | 66.9 | 1.49 s |
+| 600 MB | 65.9 | 9.10 s |
+
+Throughput plateaus at ~66 MB/s — latency-bound, not bandwidth-bound.
+With 512 KiB chunks and ~1ms RTT, theoretical max with sequential reads
+is 512 KiB / 1ms = 500 MB/s. Getting 66 MB/s suggests ~7.5 round-trips
+worth of latency per chunk (stream mutex serialization + gRPC framing).
+
+### WiFi 5ms RTT (no bandwidth limit)
+
+| Size | MB/s | Duration |
+|------|------|----------|
+| 10 MB | 16.2 | 618 ms |
+| 100 MB | 17.0 | 5.88 s |
+| 600 MB | 17.7 | 34.0 s |
+
+5x slower than LAN — nearly proportional to the 5x RTT increase.
+Confirms latency is the dominant bottleneck, not bandwidth.
+
+### LAN 1ms RTT + 100 Mbps bandwidth limit
+
+| Size | MB/s | Duration |
+|------|------|----------|
+| 10 MB | 5.3 | 1.88 s |
+| 100 MB | 5.6 | 17.8 s |
+| 600 MB | 5.6 | 1m47s |
+
+Bandwidth-limited at ~5.6 MB/s (45 Mbps effective out of 100 Mbps).
+The ~55% utilization overhead comes from gRPC framing + protobuf
+serialization + encryption per chunk.
+
+---
+
 ## Key Findings
 
 1. **Stream mutex fix (#70) was critical** — c1bfca0 cannot complete FUSE
    reads at all due to stream corruption from concurrent readahead.
 
-2. **Encrypted gRPC is 2-3x slower than raw gRPC** (361 vs 810 MB/s at
-   100 MB) — encryption overhead is significant but not dominant.
+2. **Latency is the dominant bottleneck, not bandwidth** — LAN (1ms RTT)
+   gets 66 MB/s, WiFi (5ms RTT) gets 17 MB/s. The 5x RTT increase
+   causes a nearly proportional 4x throughput drop. Bandwidth is not
+   the limiting factor on gigabit links.
 
-3. **E2E is ~15-25x slower than raw disk** — the pipeline overhead is
-   dominated by gRPC round-trips per chunk, not disk I/O.
+3. **Encrypted gRPC is 2-3x slower than raw gRPC** (361 vs 810 MB/s at
+   100 MB on localhost) — encryption overhead is measurable but secondary
+   to latency in real-world scenarios.
 
-4. **Chunk parallelism helps** — sum of chunk times (221 ms) vs wall-clock
-   (98 ms) shows ~2.3x parallelism from FUSE readahead, despite the
-   stream mutex serializing actual gRPC sends.
+4. **Per-chunk round-trip overhead is ~7.5x theoretical minimum** —
+   at 1ms RTT with 512 KiB chunks, theoretical max is ~500 MB/s but we
+   get 66 MB/s. The stream mutex, gRPC framing, protobuf serialization,
+   and encryption each add latency per chunk.
 
-5. **Biggest optimization opportunity**: pipelining prefetch (send multiple
-   ReadRequests before waiting for responses) could eliminate the
-   per-chunk round-trip latency (~2 ms median × 100 chunks = 200 ms
-   serialized vs ~2 ms pipelined).
+5. **Chunk parallelism helps on localhost** — sum of chunk times (221 ms)
+   vs wall-clock (98 ms) shows ~2.3x parallelism from FUSE readahead,
+   but the stream mutex serializes the actual gRPC sends.
+
+6. **Biggest optimization opportunity**: pipelining prefetch — send
+   multiple ReadRequests without waiting for each response. Current
+   sequential pattern means each chunk pays the full RTT. Pipelining
+   could bring LAN throughput from 66 MB/s closer to the 360 MB/s
+   seen in the encrypted-gRPC-without-FUSE benchmark.

--- a/docs/benchmarks/2026-03-16-transfer-benchmark-results.md
+++ b/docs/benchmarks/2026-03-16-transfer-benchmark-results.md
@@ -128,6 +128,134 @@ serialization + encryption per chunk.
 
 ---
 
+## macOS Results (Intel Mac)
+
+**Machine**: Intel i7-9750H @ 2.60GHz, macOS 26.3, 32 GB RAM, localhost only
+**Date**: 2026-03-28
+
+### E2E Transfer Throughput (Bob shares, Alice reads via FUSE)
+
+| Size | MB/s | Duration |
+|------|------|----------|
+| 1 MB | 86 | 12 ms |
+| 10 MB | 156 | 64 ms |
+| 100 MB | 203 | 492 ms |
+| 1 GB | 225 | 4.5 s |
+
+Throughput increases with size, peaking at 225 MB/s for 1 GB. Significantly
+faster than Linux (138 MB/s at 100 MB), likely due to macFUSE readahead
+tuning and faster CPU.
+
+### Encrypted gRPC Throughput (no FUSE)
+
+| Size | MB/s | Duration |
+|------|------|----------|
+| 1 MB | 155 | 6 ms |
+| 10 MB | 330 | 30 ms |
+| 100 MB | 445 | 225 ms |
+| 1 GB | 437 | 2.3 s |
+
+Peaks at ~440 MB/s for large files. FUSE adds ~2x overhead (225 vs 437 MB/s
+at 1 GB) from kernel context switches, VFS layer, and bitmap tracking.
+
+### Raw gRPC Baseline (no encryption, localhost)
+
+| Size | MB/s |
+|------|------|
+| 1 MB | 247 |
+| 10 MB | 842 |
+| 100 MB | 954 |
+| 1 GB | 981 |
+
+Raw gRPC peaks at ~1 GB/s. Encryption (ChaCha20-Poly1305) adds ~2.2x overhead
+(981 vs 437 MB/s at 1 GB).
+
+### Per-Chunk Latency (10 MB)
+
+| Metric | Value |
+|--------|-------|
+| Chunks recorded | 25 |
+| Total wall-clock | 59 ms |
+| Sum of chunk times | 95 ms |
+| Effective MB/s | 169 |
+| Min | 1.02 ms |
+| Median | 2.71 ms |
+| P95 | 8.1 ms |
+| Max | 14.1 ms |
+
+Fewer chunks recorded (25 vs 100 on Linux) because macFUSE uses larger
+readahead buffers. 1.6x parallelism (sum 95 ms vs wall 59 ms).
+
+### Overhead Ratio (E2E vs Raw Disk)
+
+| Size | Raw Disk | E2E Transfer | Overhead | Ratio |
+|------|----------|-------------|----------|-------|
+| 1 MB | 1 ms | 9 ms | 8 ms | 8.7x |
+| 10 MB | 4 ms | 60 ms | 56 ms | 14.2x |
+| 100 MB | 47 ms | 379 ms | 333 ms | 8.1x |
+| 1 GB | 475 ms | 4.16 s | 3.68 s | 8.7x |
+
+Lower overhead ratio than Linux (8.7x vs 14-24x). The ratio stays
+relatively constant at ~8-9x for larger files on macOS.
+
+### Raw Disk I/O Baseline
+
+| Size | Write MB/s | Read MB/s |
+|------|-----------|----------|
+| 1 KB | 6 | 15 |
+| 10 KB | 23 | 202 |
+| 100 KB | 467 | 1,575 |
+| 1 MB | 3,025 | 5,308 |
+| 10 MB | 3,403 | 4,815 |
+| 100 MB | 3,331 | 6,132 |
+| 1 GB | 3,292 | 4,929 |
+
+### FUSE Write Throughput (copy files INTO mount)
+
+**Single file:**
+
+| Size | MB/s | Duration |
+|------|------|----------|
+| 1 MB | 354 | 3 ms |
+| 10 MB | 749 | 13 ms |
+| 100 MB | 1,149 | 87 ms |
+| 1 GB | 1,171 | 875 ms |
+
+**Multi-file (directory copies):**
+
+| Test | Total | MB/s | Duration | Per-file avg |
+|------|-------|------|----------|-------------|
+| 10 x 1 MB | 10 MB | 621 | 16 ms | 2 ms |
+| 10 x 10 MB | 100 MB | 1,000 | 100 ms | 10 ms |
+| 100 x 1 MB | 100 MB | 642 | 156 ms | 2 ms |
+| 100 x 10 MB | 1,000 MB | 989 | 1.01 s | 10 ms |
+
+FUSE writes are fast (1.1 GB/s for large files) because they go straight
+to local disk via syscall.Pwrite. The per-file overhead is ~2 ms (Create +
+Release + peer notification). Multi-file writes scale linearly.
+Write throughput is NOT the bottleneck. Read-from-remote is.
+
+### FUSE Latency (local operations)
+
+| Size | Create+Write | Read | Total |
+|------|-------------|------|-------|
+| 1 KB | 1.5 ms | 1.1 ms | 2.6 ms |
+| 10 KB | 2.0 ms | 1.2 ms | 3.2 ms |
+| 100 KB | 3.1 ms | 1.2 ms | 4.3 ms |
+| 1 MB | 3.2 ms | 1.3 ms | 4.5 ms |
+
+Local disk baseline: 0.2-0.6 ms for same operations. FUSE adds ~2 ms
+per operation from kernel-userspace context switches.
+
+### Open/Close Latency (100 iterations)
+
+| Operation | Average |
+|-----------|---------|
+| Open | 164 µs |
+| Close | 56 µs |
+
+---
+
 ## Key Findings
 
 1. **Stream mutex fix (#70) was critical** — c1bfca0 cannot complete FUSE
@@ -138,21 +266,34 @@ serialization + encryption per chunk.
    causes a nearly proportional 4x throughput drop. Bandwidth is not
    the limiting factor on gigabit links.
 
-3. **Encrypted gRPC is 2-3x slower than raw gRPC** (361 vs 810 MB/s at
-   100 MB on localhost) — encryption overhead is measurable but secondary
-   to latency in real-world scenarios.
+3. **Encrypted gRPC is ~2x slower than raw gRPC** — 437 vs 981 MB/s at
+   1 GB on macOS (similar ratio on Linux). ChaCha20-Poly1305 encryption
+   is measurable but secondary to latency in real-world scenarios.
 
-4. **Per-chunk round-trip overhead is ~7.5x theoretical minimum** —
+4. **FUSE read-from-remote adds ~2x over encrypted gRPC** — 225 vs
+   437 MB/s at 1 GB on macOS. The overhead comes from: kernel-userspace
+   context switches, bitmap tracking, local cache writes, FUSE readahead
+   coordination. This is the read path bottleneck.
+
+5. **FUSE writes are fast (not a bottleneck)** — 1.1 GB/s for large files,
+   ~2 ms per-file overhead. Writes go straight to disk via syscall.Pwrite.
+   The bottleneck is exclusively in the remote read path.
+
+6. **macOS is ~60% faster than Linux** for E2E FUSE reads (225 vs 138 MB/s
+   at 100 MB). Likely from macFUSE readahead tuning and faster CPU
+   (i7-9750H @ 2.6GHz vs i5-8265U @ 1.6GHz).
+
+7. **Chunk parallelism helps on localhost (Linux)** — sum of chunk times
+   (221 ms) vs wall-clock (98 ms) shows ~2.3x parallelism from FUSE
+   readahead, but the stream mutex serializes the actual gRPC sends.
+
+8. **Per-chunk round-trip overhead is ~7.5x theoretical minimum** —
    at 1ms RTT with 512 KiB chunks, theoretical max is ~500 MB/s but we
    get 66 MB/s. The stream mutex, gRPC framing, protobuf serialization,
    and encryption each add latency per chunk.
 
-5. **Chunk parallelism helps on localhost** — sum of chunk times (221 ms)
-   vs wall-clock (98 ms) shows ~2.3x parallelism from FUSE readahead,
-   but the stream mutex serializes the actual gRPC sends.
-
-6. **Biggest optimization opportunity**: pipelining prefetch — send
+9. **Biggest optimization opportunity**: pipelining prefetch — send
    multiple ReadRequests without waiting for each response. Current
-   sequential pattern means each chunk pays the full RTT. Pipelining
-   could bring LAN throughput from 66 MB/s closer to the 360 MB/s
-   seen in the encrypted-gRPC-without-FUSE benchmark.
+   sequential pattern means each chunk pays the full RTT. Stream
+   multiplexing (follow-up PR) should bring LAN throughput from
+   66 MB/s closer to the 437 MB/s encrypted-gRPC baseline.

--- a/docs/benchmarks/2026-03-16-transfer-benchmark-results.md
+++ b/docs/benchmarks/2026-03-16-transfer-benchmark-results.md
@@ -1,0 +1,106 @@
+# Transfer Benchmark Results — 2026-03-16
+
+**Machine**: Intel i5-8265U @ 1.60GHz, Linux 6.17.0, localhost only
+**Methodology**: 3 iterations for `testing.B`, single run for `testing.T`
+
+## Commits Compared
+
+| Label | Commit | Description |
+|-------|--------|-------------|
+| **c1bfca0** | `c1bfca08eb` | fix(reconnect): prevent crash and stale state (#64) |
+| **main** | `58be1cc` | Current HEAD — includes stream mutex fix (#70) |
+
+Key change between them: `5cca7fe fix(grpc): serialize concurrent stream reads (#70)`
+
+---
+
+## End-to-End Transfer Throughput (Bob → Alice via FUSE)
+
+| Size | c1bfca0 | main | Delta |
+|------|---------|------|-------|
+| 1 MB | **FAIL** (stream corruption) | 63 MB/s | — |
+| 10 MB | **FAIL** | 145 MB/s | — |
+| 100 MB | **FAIL** | 138 MB/s | — |
+
+c1bfca0 FUSE reads fail with "Max retries exceeded for remote read" because
+concurrent FUSE readahead corrupts the unserialized gRPC stream. The stream
+mutex fix (#70) resolved this.
+
+## Encrypted gRPC Throughput (no FUSE)
+
+| Size | c1bfca0 | main | Delta |
+|------|---------|------|-------|
+| 1 MB | 71 MB/s | 98 MB/s | **+38%** |
+| 10 MB | 155 MB/s | 263 MB/s | **+70%** |
+| 100 MB | 116 MB/s | 361 MB/s | **+211%** |
+
+Massive improvement on main, likely from the stream serialization fix
+preventing corruption and retries even in the non-FUSE path.
+
+## Raw gRPC Baseline (no encryption, localhost)
+
+| Size | c1bfca0 | main | Delta |
+|------|---------|------|-------|
+| 1 MB | 247 MB/s | 424 MB/s | +72% |
+| 10 MB | 346 MB/s | 782 MB/s | +126% |
+| 100 MB | 374 MB/s | 810 MB/s | +117% |
+
+Variance between runs is high for this test (CPU load dependent).
+Both use the same bare gRPC server — difference is likely system load.
+
+## Per-Chunk Latency (10 MB, main only)
+
+| Metric | Value |
+|--------|-------|
+| Chunks recorded | 100 |
+| Total wall-clock | 98 ms |
+| Sum of chunk times | 221 ms |
+| Effective MB/s | 102 |
+| Min | 828 µs |
+| Median | 2.09 ms |
+| P95 | 3.73 ms |
+| Max | 5.14 ms |
+
+Sum of chunk times (221 ms) > wall-clock (98 ms) because the FUSE kernel
+issues parallel readahead — multiple chunks in flight simultaneously.
+
+## Overhead Ratio (main, E2E vs Raw Disk)
+
+| Size | Raw Disk | E2E Transfer | Overhead | Ratio |
+|------|----------|-------------|----------|-------|
+| 1 MB | 1 ms | 12 ms | 11 ms | 14.5x |
+| 10 MB | 4 ms | 68 ms | 64 ms | 15.9x |
+| 100 MB | 35 ms | 861 ms | 826 ms | 24.5x |
+
+## Raw Disk I/O Baseline (main)
+
+| Size | Write MB/s | Read MB/s |
+|------|-----------|----------|
+| 1 KB | 27 | 42 |
+| 10 KB | 204 | 797 |
+| 100 KB | 1,502 | 2,472 |
+| 1 MB | 4,131 | 2,880 |
+| 10 MB | 2,572 | 2,733 |
+| 100 MB | 2,753 | 3,405 |
+
+---
+
+## Key Findings
+
+1. **Stream mutex fix (#70) was critical** — c1bfca0 cannot complete FUSE
+   reads at all due to stream corruption from concurrent readahead.
+
+2. **Encrypted gRPC is 2-3x slower than raw gRPC** (361 vs 810 MB/s at
+   100 MB) — encryption overhead is significant but not dominant.
+
+3. **E2E is ~15-25x slower than raw disk** — the pipeline overhead is
+   dominated by gRPC round-trips per chunk, not disk I/O.
+
+4. **Chunk parallelism helps** — sum of chunk times (221 ms) vs wall-clock
+   (98 ms) shows ~2.3x parallelism from FUSE readahead, despite the
+   stream mutex serializing actual gRPC sends.
+
+5. **Biggest optimization opportunity**: pipelining prefetch (send multiple
+   ReadRequests before waiting for responses) could eliminate the
+   per-chunk round-trip latency (~2 ms median × 100 chunks = 200 ms
+   serialized vs ~2 ms pipelined).

--- a/tests/benchmark_test.go
+++ b/tests/benchmark_test.go
@@ -84,6 +84,11 @@ func TestTransferThroughput(t *testing.T) {
 			require.NoError(err)
 			require.Equal(len(data), len(readData), "size mismatch")
 
+			// Verify content integrity for smallest size (comparing 100MB is slow).
+			if s.size <= 1*1024*1024 {
+				require.Equal(data, readData, "content mismatch")
+			}
+
 			mbps := float64(s.size) / elapsed.Seconds() / (1024 * 1024)
 			t.Logf("%-8s | %-12.2f | %s", s.name, mbps, elapsed.Round(time.Millisecond))
 		})
@@ -169,7 +174,7 @@ func TestTransferThroughputNetem(t *testing.T) {
 			waitForFUSEMount(t, tp.AliceMountDir, 15*time.Second)
 
 			cleanup := applyNetem(t, profile)
-			defer cleanup()
+			t.Cleanup(cleanup)
 
 			desc := fmt.Sprintf("delay=%s jitter=%s", profile.delay, profile.jitter)
 			if profile.rate != "" {
@@ -285,7 +290,9 @@ func TestChunkLatency(t *testing.T) {
 	tp := SetupFUSEPeerPair(t, 120*time.Second)
 	waitForFUSEMount(t, tp.AliceMountDir, 15*time.Second)
 
-	// Inject timed stream provider into Alice's FUSE root
+	// Inject timed stream provider into Alice's FUSE root.
+	// Safe to mutate after mount: no remote files exist yet, so no streams
+	// are open. The factory is called lazily when a remote file is opened.
 	recorder := &chunkRecorder{}
 	originalFactory := tp.Alice.FS.Root.OpenStreamProvider
 	tp.Alice.FS.Root.OpenStreamProvider = func() types.FileStreamProvider {
@@ -382,9 +389,10 @@ func BenchmarkLocalDisk(b *testing.B) {
 
 		b.Run(fmt.Sprintf("Write_%s", s.name), func(b *testing.B) {
 			b.SetBytes(int64(s.size))
+			// Reuse same path to avoid filling disk on large sizes.
+			writePath := filepath.Join(tmpDir, fmt.Sprintf("bench_w_%s.bin", s.name))
 			for i := 0; i < b.N; i++ {
-				path := filepath.Join(tmpDir, fmt.Sprintf("bench_w_%s_%d.bin", s.name, i))
-				if err := os.WriteFile(path, data, 0644); err != nil {
+				if err := os.WriteFile(writePath, data, 0644); err != nil {
 					b.Fatal(err)
 				}
 			}

--- a/tests/benchmark_test.go
+++ b/tests/benchmark_test.go
@@ -113,6 +113,9 @@ var netemProfiles = []netemProfile{
 func applyNetem(t *testing.T, p netemProfile) func() {
 	t.Helper()
 
+	// Remove any stale qdisc from a previous run before adding ours.
+	exec.Command("tc", "qdisc", "del", "dev", "lo", "root").Run()
+
 	args := []string{"qdisc", "add", "dev", "lo", "root", "handle", "1:", "netem",
 		"delay", p.delay}
 	if p.jitter != "" {
@@ -121,7 +124,7 @@ func applyNetem(t *testing.T, p netemProfile) func() {
 
 	out, err := exec.Command("tc", args...).CombinedOutput()
 	if err != nil {
-		t.Skipf("tc netem failed (need sudo or CAP_NET_ADMIN): %s: %v", string(out), err)
+		t.Skipf("tc netem failed (need sudo): %s: %v", string(out), err)
 	}
 
 	// If bandwidth limit requested, add a child tbf qdisc

--- a/tests/benchmark_test.go
+++ b/tests/benchmark_test.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
 	"sync"
@@ -85,6 +86,122 @@ func TestTransferThroughput(t *testing.T) {
 
 			mbps := float64(s.size) / elapsed.Seconds() / (1024 * 1024)
 			t.Logf("%-8s | %-12.2f | %s", s.name, mbps, elapsed.Round(time.Millisecond))
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Benchmark 1b: Transfer Throughput With Simulated Network Latency
+// ---------------------------------------------------------------------------
+
+// netemProfile defines a simulated network condition applied via tc netem.
+type netemProfile struct {
+	name    string
+	delay   string // one-way delay (RTT = 2x)
+	jitter  string // optional jitter
+	rate    string // optional bandwidth limit
+}
+
+var netemProfiles = []netemProfile{
+	{"LAN_1ms", "500us", "100us", ""},             // ~1ms RTT, gigabit LAN
+	{"WiFi_5ms", "2500us", "500us", ""},            // ~5ms RTT, WiFi on same network
+	{"LAN_1ms_100Mbps", "500us", "100us", "100mbit"}, // ~1ms RTT, 100 Mbps link
+}
+
+// applyNetem adds a tc netem qdisc to the loopback interface.
+// Returns a cleanup function that removes it.
+func applyNetem(t *testing.T, p netemProfile) func() {
+	t.Helper()
+
+	args := []string{"qdisc", "add", "dev", "lo", "root", "handle", "1:", "netem",
+		"delay", p.delay}
+	if p.jitter != "" {
+		args = append(args, p.jitter)
+	}
+
+	out, err := exec.Command("tc", args...).CombinedOutput()
+	if err != nil {
+		t.Skipf("tc netem failed (need sudo or CAP_NET_ADMIN): %s: %v", string(out), err)
+	}
+
+	// If bandwidth limit requested, add a child tbf qdisc
+	if p.rate != "" {
+		tbfArgs := []string{"qdisc", "add", "dev", "lo", "parent", "1:", "handle", "2:",
+			"tbf", "rate", p.rate, "burst", "256kb", "latency", "50ms"}
+		out, err := exec.Command("tc", tbfArgs...).CombinedOutput()
+		if err != nil {
+			// Clean up the netem qdisc before skipping
+			exec.Command("tc", "qdisc", "del", "dev", "lo", "root").Run()
+			t.Skipf("tc tbf failed: %s: %v", string(out), err)
+		}
+	}
+
+	return func() {
+		exec.Command("tc", "qdisc", "del", "dev", "lo", "root").Run()
+	}
+}
+
+// TestTransferThroughputNetem measures E2E transfer with simulated network
+// conditions. Requires KEIBIDROP_BENCH_NETEM=1 and sudo/CAP_NET_ADMIN.
+//
+// Run with: sudo -E KEIBIDROP_BENCH_NETEM=1 go test -run=TestTransferThroughputNetem -v -timeout=600s ./tests/...
+func TestTransferThroughputNetem(t *testing.T) {
+	if os.Getenv("KEIBIDROP_BENCH_NETEM") != "1" {
+		t.Skip("set KEIBIDROP_BENCH_NETEM=1 to run (requires sudo or CAP_NET_ADMIN)")
+	}
+	skipIfNoFUSE(t)
+
+	sizes := []struct {
+		name string
+		size int
+	}{
+		{"10MB", 10 * 1024 * 1024},
+		{"100MB", 100 * 1024 * 1024},
+		{"600MB", 600 * 1024 * 1024},
+	}
+
+	for _, profile := range netemProfiles {
+		t.Run(profile.name, func(t *testing.T) {
+			tp := SetupFUSEPeerPair(t, 600*time.Second)
+			waitForFUSEMount(t, tp.AliceMountDir, 15*time.Second)
+
+			cleanup := applyNetem(t, profile)
+			defer cleanup()
+
+			desc := fmt.Sprintf("delay=%s jitter=%s", profile.delay, profile.jitter)
+			if profile.rate != "" {
+				desc += fmt.Sprintf(" rate=%s", profile.rate)
+			}
+			t.Logf("\n=== Transfer with netem: %s (%s) ===", profile.name, desc)
+			t.Logf("%-8s | %-12s | %-10s", "Size", "MB/s", "Duration")
+			t.Logf("---------|--------------|----------")
+
+			for _, s := range sizes {
+				t.Run(s.name, func(t *testing.T) {
+					require := require.New(t)
+
+					data := make([]byte, s.size)
+					_, err := rand.Read(data)
+					require.NoError(err)
+
+					fileName := fmt.Sprintf("bench_netem_%s_%s.bin", profile.name, s.name)
+					bobPath := filepath.Join(tp.BobSaveDir, fileName)
+					require.NoError(os.WriteFile(bobPath, data, 0644))
+					require.NoError(tp.Bob.AddFile(bobPath))
+
+					alicePath := filepath.Join(tp.AliceMountDir, fileName)
+					WaitForFileOnMount(t, alicePath, 60*time.Second)
+
+					start := time.Now()
+					readData, err := os.ReadFile(alicePath)
+					elapsed := time.Since(start)
+					require.NoError(err)
+					require.Equal(len(data), len(readData), "size mismatch")
+
+					mbps := float64(s.size) / elapsed.Seconds() / (1024 * 1024)
+					t.Logf("%-8s | %-12.2f | %s", s.name, mbps, elapsed.Round(time.Millisecond))
+				})
+			}
 		})
 	}
 }

--- a/tests/benchmark_test.go
+++ b/tests/benchmark_test.go
@@ -42,7 +42,7 @@ func TestTransferThroughput(t *testing.T) {
 		t.Skip("skipping transfer throughput in short mode")
 	}
 
-	tp := SetupFUSEPeerPair(t, 180*time.Second)
+	tp := SetupFUSEPeerPair(t, 300*time.Second)
 	waitForFUSEMount(t, tp.AliceMountDir, 15*time.Second)
 
 	sizes := []struct {
@@ -52,6 +52,7 @@ func TestTransferThroughput(t *testing.T) {
 		{"1MB", 1 * 1024 * 1024},
 		{"10MB", 10 * 1024 * 1024},
 		{"100MB", 100 * 1024 * 1024},
+		{"1GB", 1024 * 1024 * 1024},
 	}
 
 	t.Log("\n=== End-to-End Transfer Throughput ===")
@@ -381,6 +382,7 @@ func BenchmarkLocalDisk(b *testing.B) {
 		{"1MB", 1 * 1024 * 1024},
 		{"10MB", 10 * 1024 * 1024},
 		{"100MB", 100 * 1024 * 1024},
+		{"1GB", 1024 * 1024 * 1024},
 	}
 
 	for _, s := range sizes {
@@ -472,6 +474,7 @@ func BenchmarkGRPCBaseline(b *testing.B) {
 		{"1MB", 1 * 1024 * 1024},
 		{"10MB", 10 * 1024 * 1024},
 		{"100MB", 100 * 1024 * 1024},
+		{"1GB", 1024 * 1024 * 1024},
 	}
 
 	// Create temp dir with test files
@@ -556,7 +559,7 @@ func TestEncryptedGRPC(t *testing.T) {
 	}
 
 	// No FUSE needed — just the encrypted gRPC channel between peers.
-	tp := SetupPeerPairWithTimeout(t, false, 180*time.Second)
+	tp := SetupPeerPairWithTimeout(t, false, 300*time.Second)
 
 	sizes := []struct {
 		name string
@@ -565,6 +568,7 @@ func TestEncryptedGRPC(t *testing.T) {
 		{"1MB", 1 * 1024 * 1024},
 		{"10MB", 10 * 1024 * 1024},
 		{"100MB", 100 * 1024 * 1024},
+		{"1GB", 1024 * 1024 * 1024},
 	}
 
 	chunkSize := filesystem.ChunkSize
@@ -628,7 +632,7 @@ func TestBaselineComparison(t *testing.T) {
 		t.Skip("skipping baseline comparison in short mode")
 	}
 
-	tp := SetupFUSEPeerPair(t, 180*time.Second)
+	tp := SetupFUSEPeerPair(t, 300*time.Second)
 	waitForFUSEMount(t, tp.AliceMountDir, 15*time.Second)
 
 	sizes := []struct {
@@ -638,6 +642,7 @@ func TestBaselineComparison(t *testing.T) {
 		{"1MB", 1 * 1024 * 1024},
 		{"10MB", 10 * 1024 * 1024},
 		{"100MB", 100 * 1024 * 1024},
+		{"1GB", 1024 * 1024 * 1024},
 	}
 
 	type result struct {
@@ -692,6 +697,112 @@ func TestBaselineComparison(t *testing.T) {
 			r.e2e.Round(time.Millisecond),
 			overhead.Round(time.Millisecond),
 			ratio)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Benchmark 5: FUSE Write Throughput (copy files INTO the mounted filesystem)
+// ---------------------------------------------------------------------------
+
+// TestFUSEWriteThroughput measures how fast files can be written into the FUSE
+// mount from outside (simulating drag-and-drop or cp). This exercises Create,
+// Write, Flush, Release, and the peer notification path.
+func TestFUSEWriteThroughput(t *testing.T) {
+	skipIfNoFUSE(t)
+	if testing.Short() {
+		t.Skip("skipping FUSE write throughput in short mode")
+	}
+
+	tp := SetupFUSEPeerPair(t, 300*time.Second)
+	waitForFUSEMount(t, tp.AliceMountDir, 15*time.Second)
+
+	// Single file write throughput at various sizes.
+	sizes := []struct {
+		name string
+		size int
+	}{
+		{"1MB", 1 * 1024 * 1024},
+		{"10MB", 10 * 1024 * 1024},
+		{"100MB", 100 * 1024 * 1024},
+		{"1GB", 1024 * 1024 * 1024},
+	}
+
+	t.Log("\n=== FUSE Write Throughput (single file) ===")
+	t.Logf("%-8s | %-12s | %-10s", "Size", "MB/s", "Duration")
+	t.Logf("---------|--------------|----------")
+
+	for _, s := range sizes {
+		t.Run("Single_"+s.name, func(t *testing.T) {
+			require := require.New(t)
+
+			data := make([]byte, s.size)
+			_, err := rand.Read(data)
+			require.NoError(err)
+
+			destPath := filepath.Join(tp.AliceMountDir, fmt.Sprintf("write_bench_%s.bin", s.name))
+
+			start := time.Now()
+			err = os.WriteFile(destPath, data, 0644)
+			elapsed := time.Since(start)
+			require.NoError(err)
+
+			mbps := float64(s.size) / elapsed.Seconds() / (1024 * 1024)
+			t.Logf("%-8s | %-12.2f | %s", s.name, mbps, elapsed.Round(time.Millisecond))
+
+			// Verify
+			readBack, err := os.ReadFile(destPath)
+			require.NoError(err)
+			require.Equal(len(data), len(readBack), "size mismatch")
+		})
+	}
+
+	// Multi-file write: copy N files of a given size into the mount.
+	multiTests := []struct {
+		name      string
+		fileCount int
+		fileSize  int
+	}{
+		{"10x1MB", 10, 1 * 1024 * 1024},
+		{"10x10MB", 10, 10 * 1024 * 1024},
+		{"100x1MB", 100, 1 * 1024 * 1024},
+		{"100x10MB", 100, 10 * 1024 * 1024},
+	}
+
+	t.Log("\n=== FUSE Write Throughput (multi-file) ===")
+	t.Logf("%-12s | %-8s | %-12s | %-10s | %-12s", "Test", "Total", "MB/s", "Duration", "Per-file avg")
+	t.Logf("-------------|----------|--------------|------------|------------")
+
+	for _, mt := range multiTests {
+		t.Run("Multi_"+mt.name, func(t *testing.T) {
+			require := require.New(t)
+
+			totalBytes := mt.fileCount * mt.fileSize
+			data := make([]byte, mt.fileSize)
+			_, err := rand.Read(data)
+			require.NoError(err)
+
+			// Create a subdirectory for this batch.
+			batchDir := filepath.Join(tp.AliceMountDir, "batch_"+mt.name)
+			require.NoError(os.MkdirAll(batchDir, 0755))
+
+			start := time.Now()
+			for i := 0; i < mt.fileCount; i++ {
+				destPath := filepath.Join(batchDir, fmt.Sprintf("file_%04d.bin", i))
+				err := os.WriteFile(destPath, data, 0644)
+				require.NoError(err)
+			}
+			elapsed := time.Since(start)
+
+			totalMB := float64(totalBytes) / (1024 * 1024)
+			mbps := totalMB / elapsed.Seconds()
+			perFile := elapsed / time.Duration(mt.fileCount)
+			t.Logf("%-12s | %-8s | %-12.2f | %-10s | %s",
+				mt.name,
+				fmt.Sprintf("%.0fMB", totalMB),
+				mbps,
+				elapsed.Round(time.Millisecond),
+				perFile.Round(time.Millisecond))
+		})
 	}
 }
 

--- a/tests/benchmark_test.go
+++ b/tests/benchmark_test.go
@@ -1,3 +1,6 @@
+// ABOUTME: End-to-end transfer benchmarks and baseline performance measurements.
+// ABOUTME: Measures peer-to-peer throughput, per-chunk latency, and overhead ratios.
+
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (c) 2025 KeibiSoft S.R.L.
 // This Source Code Form is subject to the terms of the Mozilla Public
@@ -7,15 +10,233 @@
 package tests
 
 import (
+	"context"
 	"crypto/rand"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
+	"sort"
+	"sync"
 	"testing"
 	"time"
+
+	bindings "github.com/KeibiSoft/KeibiDrop/grpc_bindings"
+	"github.com/KeibiSoft/KeibiDrop/pkg/filesystem"
+	"github.com/KeibiSoft/KeibiDrop/pkg/types"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
-// BenchmarkLocalDisk provides baseline for comparison
+// ---------------------------------------------------------------------------
+// Benchmark 1: End-to-End Transfer Throughput
+// ---------------------------------------------------------------------------
+
+// TestTransferThroughput measures the actual peer-to-peer transfer speed that
+// users experience: Bob shares a file, Alice reads it through her FUSE mount.
+func TestTransferThroughput(t *testing.T) {
+	skipIfNoFUSE(t)
+	if testing.Short() {
+		t.Skip("skipping transfer throughput in short mode")
+	}
+
+	tp := SetupFUSEPeerPair(t, 180*time.Second)
+	waitForFUSEMount(t, tp.AliceMountDir, 15*time.Second)
+
+	sizes := []struct {
+		name string
+		size int
+	}{
+		{"1MB", 1 * 1024 * 1024},
+		{"10MB", 10 * 1024 * 1024},
+		{"100MB", 100 * 1024 * 1024},
+	}
+
+	t.Log("\n=== End-to-End Transfer Throughput ===")
+	t.Logf("%-8s | %-12s | %-10s", "Size", "MB/s", "Duration")
+	t.Logf("---------|--------------|----------")
+
+	for _, s := range sizes {
+		t.Run(s.name, func(t *testing.T) {
+			require := require.New(t)
+
+			// Generate random payload
+			data := make([]byte, s.size)
+			_, err := rand.Read(data)
+			require.NoError(err)
+
+			// Bob writes file to his save dir and shares it
+			fileName := fmt.Sprintf("bench_e2e_%s.bin", s.name)
+			bobPath := filepath.Join(tp.BobSaveDir, fileName)
+			require.NoError(os.WriteFile(bobPath, data, 0644))
+			require.NoError(tp.Bob.AddFile(bobPath))
+
+			// Wait for Alice to see the file on her FUSE mount
+			alicePath := filepath.Join(tp.AliceMountDir, fileName)
+			WaitForFileOnMount(t, alicePath, 30*time.Second)
+
+			// Timed read — this is the number users experience
+			start := time.Now()
+			readData, err := os.ReadFile(alicePath)
+			elapsed := time.Since(start)
+			require.NoError(err)
+			require.Equal(len(data), len(readData), "size mismatch")
+
+			mbps := float64(s.size) / elapsed.Seconds() / (1024 * 1024)
+			t.Logf("%-8s | %-12.2f | %s", s.name, mbps, elapsed.Round(time.Millisecond))
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Benchmark 2: Per-Component Latency Breakdown
+// ---------------------------------------------------------------------------
+
+// chunkTiming records the duration of a single ReadAt call.
+type chunkTiming struct {
+	Offset   int64
+	Size     int64
+	Duration time.Duration
+}
+
+// timedStream wraps a RemoteFileStream and records per-chunk timing.
+type timedStream struct {
+	inner    types.RemoteFileStream
+	recorder *chunkRecorder
+}
+
+func (ts *timedStream) ReadAt(ctx context.Context, offset int64, size int64) ([]byte, error) {
+	start := time.Now()
+	data, err := ts.inner.ReadAt(ctx, offset, size)
+	elapsed := time.Since(start)
+	if err == nil {
+		ts.recorder.record(chunkTiming{Offset: offset, Size: size, Duration: elapsed})
+	}
+	return data, err
+}
+
+func (ts *timedStream) Close() error {
+	return ts.inner.Close()
+}
+
+// chunkRecorder collects chunk timings from concurrent streams.
+type chunkRecorder struct {
+	mu     sync.Mutex
+	chunks []chunkTiming
+}
+
+func (cr *chunkRecorder) record(ct chunkTiming) {
+	cr.mu.Lock()
+	cr.chunks = append(cr.chunks, ct)
+	cr.mu.Unlock()
+}
+
+func (cr *chunkRecorder) results() []chunkTiming {
+	cr.mu.Lock()
+	defer cr.mu.Unlock()
+	out := make([]chunkTiming, len(cr.chunks))
+	copy(out, cr.chunks)
+	return out
+}
+
+// timedStreamProvider wraps a FileStreamProvider factory and injects timing.
+type timedStreamProvider struct {
+	inner    types.FileStreamProvider
+	recorder *chunkRecorder
+}
+
+func (tsp *timedStreamProvider) OpenRemoteFile(ctx context.Context, inode uint64, path string) (types.RemoteFileStream, error) {
+	stream, err := tsp.inner.OpenRemoteFile(ctx, inode, path)
+	if err != nil {
+		return nil, err
+	}
+	return &timedStream{inner: stream, recorder: tsp.recorder}, nil
+}
+
+// TestChunkLatency measures per-chunk ReadAt latency during a transfer,
+// reporting min/median/p95/max statistics.
+func TestChunkLatency(t *testing.T) {
+	skipIfNoFUSE(t)
+	if testing.Short() {
+		t.Skip("skipping chunk latency in short mode")
+	}
+
+	tp := SetupFUSEPeerPair(t, 120*time.Second)
+	waitForFUSEMount(t, tp.AliceMountDir, 15*time.Second)
+
+	// Inject timed stream provider into Alice's FUSE root
+	recorder := &chunkRecorder{}
+	originalFactory := tp.Alice.FS.Root.OpenStreamProvider
+	tp.Alice.FS.Root.OpenStreamProvider = func() types.FileStreamProvider {
+		return &timedStreamProvider{inner: originalFactory(), recorder: recorder}
+	}
+
+	// Bob shares a 10 MB file
+	require := require.New(t)
+	fileSize := 10 * 1024 * 1024
+	data := make([]byte, fileSize)
+	_, err := rand.Read(data)
+	require.NoError(err)
+
+	bobPath := filepath.Join(tp.BobSaveDir, "bench_latency.bin")
+	require.NoError(os.WriteFile(bobPath, data, 0644))
+	require.NoError(tp.Bob.AddFile(bobPath))
+
+	// Alice reads via FUSE — this triggers the timed ReadAt calls
+	alicePath := filepath.Join(tp.AliceMountDir, "bench_latency.bin")
+	WaitForFileOnMount(t, alicePath, 30*time.Second)
+
+	start := time.Now()
+	readData, err := os.ReadFile(alicePath)
+	totalElapsed := time.Since(start)
+	require.NoError(err)
+	require.Equal(fileSize, len(readData))
+
+	// Analyze chunk timings
+	chunks := recorder.results()
+	if len(chunks) == 0 {
+		t.Fatal("no chunk timings recorded — stream provider was not used")
+	}
+
+	durations := make([]time.Duration, len(chunks))
+	var totalChunkTime time.Duration
+	for i, c := range chunks {
+		durations[i] = c.Duration
+		totalChunkTime += c.Duration
+	}
+	sort.Slice(durations, func(i, j int) bool { return durations[i] < durations[j] })
+
+	n := len(durations)
+	pct := func(p float64) time.Duration {
+		idx := int(float64(n-1) * p)
+		if idx >= n {
+			idx = n - 1
+		}
+		return durations[idx]
+	}
+
+	mbps := float64(fileSize) / totalElapsed.Seconds() / (1024 * 1024)
+
+	t.Log("\n=== Per-Chunk Latency Breakdown (10 MB transfer) ===")
+	t.Logf("Chunks recorded:    %d", n)
+	t.Logf("Total wall-clock:   %s", totalElapsed.Round(time.Millisecond))
+	t.Logf("Sum of chunk times: %s", totalChunkTime.Round(time.Millisecond))
+	t.Logf("Effective MB/s:     %.2f", mbps)
+	t.Log("")
+	t.Logf("%-10s | %-15s", "Percentile", "Latency")
+	t.Logf("-----------|----------------")
+	t.Logf("%-10s | %s", "Min", durations[0].Round(time.Microsecond))
+	t.Logf("%-10s | %s", "Median", pct(0.50).Round(time.Microsecond))
+	t.Logf("%-10s | %s", "P95", pct(0.95).Round(time.Microsecond))
+	t.Logf("%-10s | %s", "Max", durations[n-1].Round(time.Microsecond))
+}
+
+// ---------------------------------------------------------------------------
+// Benchmark 3a: Raw Local Disk I/O Baseline
+// ---------------------------------------------------------------------------
+
+// BenchmarkLocalDisk measures raw local disk throughput for comparison.
 func BenchmarkLocalDisk(b *testing.B) {
 	tmpDir, err := os.MkdirTemp("", "keibidrop-bench-*")
 	if err != nil {
@@ -23,28 +244,37 @@ func BenchmarkLocalDisk(b *testing.B) {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	sizes := []int{1024, 10 * 1024, 100 * 1024, 1024 * 1024}
+	sizes := []struct {
+		name string
+		size int
+	}{
+		{"1KB", 1024},
+		{"10KB", 10 * 1024},
+		{"100KB", 100 * 1024},
+		{"1MB", 1 * 1024 * 1024},
+		{"10MB", 10 * 1024 * 1024},
+		{"100MB", 100 * 1024 * 1024},
+	}
 
-	for _, size := range sizes {
-		data := make([]byte, size)
+	for _, s := range sizes {
+		data := make([]byte, s.size)
 		rand.Read(data)
 
-		b.Run(fmt.Sprintf("Write_%dKB", size/1024), func(b *testing.B) {
-			b.SetBytes(int64(size))
+		b.Run(fmt.Sprintf("Write_%s", s.name), func(b *testing.B) {
+			b.SetBytes(int64(s.size))
 			for i := 0; i < b.N; i++ {
-				path := filepath.Join(tmpDir, fmt.Sprintf("bench_%d_%d.bin", size, i))
+				path := filepath.Join(tmpDir, fmt.Sprintf("bench_w_%s_%d.bin", s.name, i))
 				if err := os.WriteFile(path, data, 0644); err != nil {
 					b.Fatal(err)
 				}
 			}
 		})
 
-		// Create file for read benchmark
-		readPath := filepath.Join(tmpDir, fmt.Sprintf("read_%d.bin", size))
+		readPath := filepath.Join(tmpDir, fmt.Sprintf("bench_r_%s.bin", s.name))
 		os.WriteFile(readPath, data, 0644)
 
-		b.Run(fmt.Sprintf("Read_%dKB", size/1024), func(b *testing.B) {
-			b.SetBytes(int64(size))
+		b.Run(fmt.Sprintf("Read_%s", s.name), func(b *testing.B) {
+			b.SetBytes(int64(s.size))
 			for i := 0; i < b.N; i++ {
 				if _, err := os.ReadFile(readPath); err != nil {
 					b.Fatal(err)
@@ -54,62 +284,304 @@ func BenchmarkLocalDisk(b *testing.B) {
 	}
 }
 
-// BenchmarkFUSEMount measures FUSE overhead (requires mounted filesystem)
-// Run with: go test -bench=BenchmarkFUSEMount -benchtime=10s ./tests/...
-// Make sure MountAlice is mounted first!
-func BenchmarkFUSEMount(b *testing.B) {
-	mountPath := "/Users/marius/work/code/KeibiDrop/MountAlice"
+// ---------------------------------------------------------------------------
+// Benchmark 3b: gRPC Roundtrip Without Encryption
+// ---------------------------------------------------------------------------
 
-	// Check if mount exists
-	if _, err := os.Stat(mountPath); os.IsNotExist(err) {
-		b.Skip("MountAlice not mounted, skipping FUSE benchmark")
+// bareReadServer is a minimal KeibiService that serves Read requests from a
+// directory on disk, with no encryption or session management.
+type bareReadServer struct {
+	bindings.UnimplementedKeibiServiceServer
+	dir string
+}
+
+func (s *bareReadServer) Read(stream bindings.KeibiService_ReadServer) error {
+	var fh *os.File
+	defer func() {
+		if fh != nil {
+			fh.Close()
+		}
+	}()
+
+	buf := make([]byte, filesystem.ChunkSize)
+
+	for {
+		req, err := stream.Recv()
+		if err != nil {
+			return nil // client closed
+		}
+
+		if fh == nil {
+			fh, err = os.Open(filepath.Join(s.dir, req.Path))
+			if err != nil {
+				return err
+			}
+		}
+
+		readSize := int(req.Size)
+		if readSize > len(buf) {
+			readSize = len(buf)
+		}
+
+		n, err := fh.ReadAt(buf[:readSize], int64(req.Offset))
+		if err != nil && n == 0 {
+			return err
+		}
+
+		if err := stream.Send(&bindings.ReadResponse{Data: buf[:n]}); err != nil {
+			return err
+		}
+	}
+}
+
+// BenchmarkGRPCBaseline measures raw gRPC bidi-stream throughput over
+// localhost without encryption, using the KeibiService Read RPC.
+func BenchmarkGRPCBaseline(b *testing.B) {
+	sizes := []struct {
+		name string
+		size int
+	}{
+		{"1MB", 1 * 1024 * 1024},
+		{"10MB", 10 * 1024 * 1024},
+		{"100MB", 100 * 1024 * 1024},
 	}
 
-	sizes := []int{1024, 10 * 1024, 100 * 1024}
+	// Create temp dir with test files
+	tmpDir, err := os.MkdirTemp("", "keibidrop-grpc-bench-*")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
 
-	for _, size := range sizes {
-		data := make([]byte, size)
+	for _, s := range sizes {
+		data := make([]byte, s.size)
 		rand.Read(data)
+		os.WriteFile(filepath.Join(tmpDir, s.name+".bin"), data, 0644)
+	}
 
-		b.Run(fmt.Sprintf("Write_%dKB", size/1024), func(b *testing.B) {
-			b.SetBytes(int64(size))
+	// Start bare gRPC server
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		b.Fatal(err)
+	}
+	srv := grpc.NewServer()
+	bindings.RegisterKeibiServiceServer(srv, &bareReadServer{dir: tmpDir})
+	go srv.Serve(lis)
+	defer srv.Stop()
+
+	// Connect client
+	conn, err := grpc.NewClient(
+		lis.Addr().String(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer conn.Close()
+	cli := bindings.NewKeibiServiceClient(conn)
+
+	chunkSize := filesystem.ChunkSize
+
+	for _, s := range sizes {
+		b.Run(fmt.Sprintf("Read_%s", s.name), func(b *testing.B) {
+			b.SetBytes(int64(s.size))
 			for i := 0; i < b.N; i++ {
-				path := filepath.Join(mountPath, fmt.Sprintf("bench_%d_%d.bin", size, i))
-				if err := os.WriteFile(path, data, 0644); err != nil {
+				stream, err := cli.Read(context.Background())
+				if err != nil {
 					b.Fatal(err)
 				}
-				// Clean up
-				os.Remove(path)
-			}
-		})
 
-		// Create file for read benchmark
-		readPath := filepath.Join(mountPath, fmt.Sprintf("read_%d.bin", size))
-		os.WriteFile(readPath, data, 0644)
-		defer os.Remove(readPath)
-
-		b.Run(fmt.Sprintf("Read_%dKB", size/1024), func(b *testing.B) {
-			b.SetBytes(int64(size))
-			for i := 0; i < b.N; i++ {
-				if _, err := os.ReadFile(readPath); err != nil {
-					b.Fatal(err)
+				offset := 0
+				for offset < s.size {
+					reqSize := chunkSize
+					if offset+reqSize > s.size {
+						reqSize = s.size - offset
+					}
+					if err := stream.Send(&bindings.ReadRequest{
+						Path:   s.name + ".bin",
+						Offset: uint64(offset),
+						Size:   uint32(reqSize),
+					}); err != nil {
+						b.Fatal(err)
+					}
+					resp, err := stream.Recv()
+					if err != nil {
+						b.Fatal(err)
+					}
+					offset += len(resp.Data)
 				}
+				stream.CloseSend()
 			}
 		})
 	}
 }
 
-// MeasureLatency provides human-readable latency measurements
-// Run with: go test -run=MeasureLatency -v ./tests/...
-func TestMeasureLatency(t *testing.T) {
+// ---------------------------------------------------------------------------
+// Benchmark 3c: gRPC Over Encrypted SecureConn
+// ---------------------------------------------------------------------------
+
+// TestEncryptedGRPC measures gRPC throughput through the full encrypted
+// peer connection (no FUSE). Bob has the file, Alice reads via KDClient.
+func TestEncryptedGRPC(t *testing.T) {
 	if testing.Short() {
-		t.Skip("Skipping latency test in short mode")
+		t.Skip("skipping encrypted gRPC throughput in short mode")
 	}
 
-	mountPath := "/Users/marius/work/code/KeibiDrop/MountAlice"
-	if _, err := os.Stat(mountPath); os.IsNotExist(err) {
-		t.Skip("MountAlice not mounted, skipping latency test")
+	// No FUSE needed — just the encrypted gRPC channel between peers.
+	tp := SetupPeerPairWithTimeout(t, false, 180*time.Second)
+
+	sizes := []struct {
+		name string
+		size int
+	}{
+		{"1MB", 1 * 1024 * 1024},
+		{"10MB", 10 * 1024 * 1024},
+		{"100MB", 100 * 1024 * 1024},
 	}
+
+	chunkSize := filesystem.ChunkSize
+
+	t.Log("\n=== Encrypted gRPC Throughput (no FUSE) ===")
+	t.Logf("%-8s | %-12s | %-10s", "Size", "MB/s", "Duration")
+	t.Logf("---------|--------------|----------")
+
+	for _, s := range sizes {
+		t.Run(s.name, func(t *testing.T) {
+			require := require.New(t)
+
+			data := make([]byte, s.size)
+			_, err := rand.Read(data)
+			require.NoError(err)
+
+			fileName := fmt.Sprintf("bench_enc_%s.bin", s.name)
+			bobPath := filepath.Join(tp.BobSaveDir, fileName)
+			require.NoError(os.WriteFile(bobPath, data, 0644))
+			require.NoError(tp.Bob.AddFile(bobPath))
+
+			// Read directly via encrypted gRPC (no FUSE)
+			start := time.Now()
+			stream, err := tp.Alice.KDClient.Read(context.Background())
+			require.NoError(err)
+
+			totalRead := 0
+			for totalRead < s.size {
+				reqSize := chunkSize
+				if totalRead+reqSize > s.size {
+					reqSize = s.size - totalRead
+				}
+				require.NoError(stream.Send(&bindings.ReadRequest{
+					Path:   fileName,
+					Offset: uint64(totalRead),
+					Size:   uint32(reqSize),
+				}))
+				resp, err := stream.Recv()
+				require.NoError(err)
+				totalRead += len(resp.Data)
+			}
+			stream.CloseSend()
+			elapsed := time.Since(start)
+
+			mbps := float64(s.size) / elapsed.Seconds() / (1024 * 1024)
+			t.Logf("%-8s | %-12.2f | %s", s.name, mbps, elapsed.Round(time.Millisecond))
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Overhead Ratio Comparison
+// ---------------------------------------------------------------------------
+
+// TestBaselineComparison runs a single transfer at each size and prints
+// a ratio table showing how much overhead the full pipeline adds compared
+// to raw disk and raw gRPC.
+func TestBaselineComparison(t *testing.T) {
+	skipIfNoFUSE(t)
+	if testing.Short() {
+		t.Skip("skipping baseline comparison in short mode")
+	}
+
+	tp := SetupFUSEPeerPair(t, 180*time.Second)
+	waitForFUSEMount(t, tp.AliceMountDir, 15*time.Second)
+
+	sizes := []struct {
+		name string
+		size int
+	}{
+		{"1MB", 1 * 1024 * 1024},
+		{"10MB", 10 * 1024 * 1024},
+		{"100MB", 100 * 1024 * 1024},
+	}
+
+	type result struct {
+		disk    time.Duration
+		e2e     time.Duration
+	}
+
+	t.Log("\n=== Baseline Comparison: E2E vs Raw Disk ===")
+	t.Logf("%-8s | %-12s | %-12s | %-10s | %-8s",
+		"Size", "Raw Disk", "E2E Transfer", "Overhead", "Ratio")
+	t.Logf("---------|--------------|--------------|------------|--------")
+
+	tmpDir := t.TempDir()
+
+	for _, s := range sizes {
+		require := require.New(t)
+		data := make([]byte, s.size)
+		_, err := rand.Read(data)
+		require.NoError(err)
+
+		// Measure raw disk read
+		diskPath := filepath.Join(tmpDir, fmt.Sprintf("baseline_%s.bin", s.name))
+		require.NoError(os.WriteFile(diskPath, data, 0644))
+
+		diskStart := time.Now()
+		_, err = os.ReadFile(diskPath)
+		diskDur := time.Since(diskStart)
+		require.NoError(err)
+
+		// Measure E2E transfer
+		fileName := fmt.Sprintf("bench_cmp_%s.bin", s.name)
+		bobPath := filepath.Join(tp.BobSaveDir, fileName)
+		require.NoError(os.WriteFile(bobPath, data, 0644))
+		require.NoError(tp.Bob.AddFile(bobPath))
+
+		alicePath := filepath.Join(tp.AliceMountDir, fileName)
+		WaitForFileOnMount(t, alicePath, 30*time.Second)
+
+		e2eStart := time.Now()
+		readData, err := os.ReadFile(alicePath)
+		e2eDur := time.Since(e2eStart)
+		require.NoError(err)
+		require.Equal(s.size, len(readData))
+
+		r := result{disk: diskDur, e2e: e2eDur}
+		ratio := float64(r.e2e) / float64(r.disk)
+		overhead := r.e2e - r.disk
+
+		t.Logf("%-8s | %-12s | %-12s | %-10s | %.1fx",
+			s.name,
+			r.disk.Round(time.Millisecond),
+			r.e2e.Round(time.Millisecond),
+			overhead.Round(time.Millisecond),
+			ratio)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Legacy portable benchmarks (fixed from hardcoded Mac paths)
+// ---------------------------------------------------------------------------
+
+// TestMeasureLatency provides human-readable latency measurements for
+// local FUSE operations (write + read at various sizes).
+func TestMeasureLatency(t *testing.T) {
+	skipIfNoFUSE(t)
+	if testing.Short() {
+		t.Skip("skipping latency test in short mode")
+	}
+
+	tp := SetupFUSEPeerPair(t, 60*time.Second)
+	waitForFUSEMount(t, tp.AliceMountDir, 15*time.Second)
+	mountPath := tp.AliceMountDir
 
 	sizes := []struct {
 		name string
@@ -121,57 +593,51 @@ func TestMeasureLatency(t *testing.T) {
 		{"1MB", 1024 * 1024},
 	}
 
-	t.Log("\n=== FUSE Mount Latency Measurements ===\n")
-	t.Logf("%-10s | %-15s | %-15s | %-15s\n", "Size", "Create+Write", "Read", "Total")
-	t.Logf("%s\n", "----------|-----------------|-----------------|----------------")
+	t.Log("\n=== FUSE Mount Latency Measurements ===")
+	t.Logf("%-10s | %-15s | %-15s | %-15s", "Size", "Create+Write", "Read", "Total")
+	t.Logf("%s", "----------|-----------------|-----------------|----------------")
 
 	for _, s := range sizes {
 		data := make([]byte, s.size)
 		rand.Read(data)
 		path := filepath.Join(mountPath, fmt.Sprintf("latency_%s.bin", s.name))
 
-		// Measure create + write
 		startWrite := time.Now()
 		if err := os.WriteFile(path, data, 0644); err != nil {
-			t.Logf("%-10s | WRITE ERROR: %v\n", s.name, err)
+			t.Logf("%-10s | WRITE ERROR: %v", s.name, err)
 			continue
 		}
 		writeLatency := time.Since(startWrite)
 
-		// Small delay to ensure file is committed
 		time.Sleep(100 * time.Millisecond)
 
-		// Measure read
 		startRead := time.Now()
 		readData, err := os.ReadFile(path)
 		if err != nil {
-			t.Logf("%-10s | OK | READ ERROR: %v\n", s.name, err)
+			t.Logf("%-10s | OK | READ ERROR: %v", s.name, err)
 			os.Remove(path)
 			continue
 		}
 		readLatency := time.Since(startRead)
 
-		// Verify data
 		if len(readData) != len(data) {
-			t.Logf("%-10s | Size mismatch: wrote %d, read %d\n", s.name, len(data), len(readData))
+			t.Logf("%-10s | Size mismatch: wrote %d, read %d", s.name, len(data), len(readData))
 		}
 
-		t.Logf("%-10s | %-15s | %-15s | %-15s\n",
+		t.Logf("%-10s | %-15s | %-15s | %-15s",
 			s.name,
 			writeLatency.Round(time.Microsecond),
 			readLatency.Round(time.Microsecond),
 			(writeLatency + readLatency).Round(time.Microsecond))
 
-		// Cleanup
 		os.Remove(path)
 	}
 
-	t.Log("\n=== Local Disk Baseline ===\n")
-	tmpDir, _ := os.MkdirTemp("", "latency-baseline-*")
-	defer os.RemoveAll(tmpDir)
+	t.Log("\n=== Local Disk Baseline ===")
+	tmpDir := t.TempDir()
 
-	t.Logf("%-10s | %-15s | %-15s | %-15s\n", "Size", "Create+Write", "Read", "Total")
-	t.Logf("%s\n", "----------|-----------------|-----------------|----------------")
+	t.Logf("%-10s | %-15s | %-15s | %-15s", "Size", "Create+Write", "Read", "Total")
+	t.Logf("%s", "----------|-----------------|-----------------|----------------")
 
 	for _, s := range sizes {
 		data := make([]byte, s.size)
@@ -186,7 +652,7 @@ func TestMeasureLatency(t *testing.T) {
 		os.ReadFile(path)
 		readLatency := time.Since(startRead)
 
-		t.Logf("%-10s | %-15s | %-15s | %-15s\n",
+		t.Logf("%-10s | %-15s | %-15s | %-15s",
 			s.name,
 			writeLatency.Round(time.Microsecond),
 			readLatency.Round(time.Microsecond),
@@ -194,70 +660,24 @@ func TestMeasureLatency(t *testing.T) {
 	}
 }
 
-// TestThroughput measures sustained throughput
-func TestThroughput(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping throughput test in short mode")
-	}
-
-	mountPath := "/Users/marius/work/code/KeibiDrop/MountAlice"
-	if _, err := os.Stat(mountPath); os.IsNotExist(err) {
-		t.Skip("MountAlice not mounted, skipping throughput test")
-	}
-
-	// 10MB test file
-	size := 10 * 1024 * 1024
-	data := make([]byte, size)
-	rand.Read(data)
-
-	path := filepath.Join(mountPath, "throughput_test.bin")
-	defer os.Remove(path)
-
-	t.Log("\n=== Throughput Test (10MB file) ===\n")
-
-	// Write throughput
-	start := time.Now()
-	if err := os.WriteFile(path, data, 0644); err != nil {
-		t.Fatalf("Write failed: %v", err)
-	}
-	writeDuration := time.Since(start)
-	writeMBps := float64(size) / writeDuration.Seconds() / 1024 / 1024
-
-	t.Logf("Write: %.2f MB/s (%.2f seconds for 10MB)\n", writeMBps, writeDuration.Seconds())
-
-	time.Sleep(500 * time.Millisecond)
-
-	// Read throughput
-	start = time.Now()
-	readData, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("Read failed: %v", err)
-	}
-	readDuration := time.Since(start)
-	readMBps := float64(len(readData)) / readDuration.Seconds() / 1024 / 1024
-
-	t.Logf("Read:  %.2f MB/s (%.2f seconds for 10MB)\n", readMBps, readDuration.Seconds())
-}
-
-// TestOpenCloseLatency measures file handle operations
+// TestOpenCloseLatency measures file handle open/close operations on
+// the FUSE mount.
 func TestOpenCloseLatency(t *testing.T) {
+	skipIfNoFUSE(t)
 	if testing.Short() {
-		t.Skip("Skipping open/close latency test in short mode")
+		t.Skip("skipping open/close latency test in short mode")
 	}
 
-	mountPath := "/Users/marius/work/code/KeibiDrop/MountAlice"
-	if _, err := os.Stat(mountPath); os.IsNotExist(err) {
-		t.Skip("MountAlice not mounted, skipping latency test")
-	}
+	tp := SetupFUSEPeerPair(t, 60*time.Second)
+	waitForFUSEMount(t, tp.AliceMountDir, 15*time.Second)
 
-	// Create a test file
-	path := filepath.Join(mountPath, "openclose_test.txt")
+	path := filepath.Join(tp.AliceMountDir, "openclose_test.txt")
 	os.WriteFile(path, []byte("test content"), 0644)
 	defer os.Remove(path)
 
 	time.Sleep(500 * time.Millisecond)
 
-	t.Log("\n=== Open/Close Latency (100 iterations) ===\n")
+	t.Log("\n=== Open/Close Latency (100 iterations) ===")
 
 	iterations := 100
 	var totalOpen, totalClose time.Duration
@@ -275,7 +695,7 @@ func TestOpenCloseLatency(t *testing.T) {
 		totalClose += time.Since(startClose)
 	}
 
-	t.Logf("Average Open:  %v\n", totalOpen/time.Duration(iterations))
-	t.Logf("Average Close: %v\n", totalClose/time.Duration(iterations))
-	t.Logf("Total for %d iterations: Open=%v, Close=%v\n", iterations, totalOpen, totalClose)
+	t.Logf("Average Open:  %v", totalOpen/time.Duration(iterations))
+	t.Logf("Average Close: %v", totalClose/time.Duration(iterations))
+	t.Logf("Total for %d iterations: Open=%v, Close=%v", iterations, totalOpen, totalClose)
 }


### PR DESCRIPTION
## Summary
- Add 5 new benchmarks measuring peer-to-peer transfer performance at 1/10/100 MB
- Fix all hardcoded Mac paths in existing benchmarks → fully portable
- Timed stream decorator pattern for per-chunk latency (no production code changes)

### Benchmarks added
| Test | What it measures |
|------|-----------------|
| `TestTransferThroughput` | E2E: Bob shares → Alice reads via FUSE mount (MB/s) |
| `TestChunkLatency` | Per-chunk ReadAt latency: min/median/p95/max |
| `BenchmarkGRPCBaseline` | Raw gRPC bidi-stream, no encryption |
| `TestEncryptedGRPC` | gRPC through SecureConn (no FUSE) |
| `TestBaselineComparison` | Overhead ratio table: E2E vs raw disk |

### Initial results (i5-8265U, localhost)
```
E2E Transfer:     95-173 MB/s
Encrypted gRPC:   110-390 MB/s
Raw gRPC:         324-570 MB/s
Raw Disk:         3.3-5.4 GB/s
Overhead ratio:   16-21x vs raw disk
Chunk latency:    median 1.4ms, p95 2.4ms (10 MB, 100 chunks)
```

Closes #78

## Test plan
- [x] `go test -run=TestTransferThroughput -v ./tests/...`
- [x] `go test -run=TestChunkLatency -v ./tests/...`
- [x] `go test -bench=BenchmarkGRPCBaseline -benchtime=1x ./tests/...`
- [x] `go test -bench=BenchmarkLocalDisk -benchtime=1x ./tests/...`
- [x] `go test -run=TestEncryptedGRPC -v ./tests/...`
- [x] `go test -run=TestBaselineComparison -v ./tests/...`
- [x] `go vet ./tests/` — clean