### PR TITLE
perf(transfer): stream pool + persistent cache FD

### DIFF
--- a/docs/benchmarks/2026-03-16-transfer-benchmark-results.md
+++ b/docs/benchmarks/2026-03-16-transfer-benchmark-results.md
@@ -295,5 +295,65 @@ per operation from kernel-userspace context switches.
 9. **Biggest optimization opportunity**: pipelining prefetch — send
    multiple ReadRequests without waiting for each response. Current
    sequential pattern means each chunk pays the full RTT. Stream
-   multiplexing (follow-up PR) should bring LAN throughput from
+   multiplexing (PR #80) should bring LAN throughput from
    66 MB/s closer to the 437 MB/s encrypted-gRPC baseline.
+
+---
+
+## Encryption Overhead Analysis (437 MB/s vs 981 MB/s raw gRPC)
+
+The 2.2x overhead from ChaCha20-Poly1305 encryption comes from three
+sources, ordered by estimated impact:
+
+### 1. AEAD cipher re-created per message (CPU waste)
+
+`EncryptWithNonce` (`pkg/crypto/symmetric.go:57`) calls
+`chacha20poly1305.New(kek)` on every single message. Same for `Decrypt`
+(`pkg/crypto/symmetric.go:114`). The AEAD instance is stateless after
+creation and can be created once per SecureConn and reused for all
+messages. This is the easiest fix.
+
+### 2. Heap allocation per message (GC pressure)
+
+`SecureWriter.Write` (`pkg/session/secureconn.go:61`) allocates:
+- `make([]byte, NonceSize+len(cipherText))` -- ~512 KiB per chunk
+- `make([]byte, 4)` for the length header
+
+`SecureReader.Read` (`pkg/session/secureconn.go:94`) allocates:
+- `make([]byte, length)` -- ~512 KiB per encrypted message
+
+That is ~1 MB of heap allocation per chunk round-trip, all becoming GC
+pressure. Fix: use `sync.Pool` for encrypt/decrypt buffers.
+
+### 3. Two TCP writes per message (wasted segments)
+
+`SecureWriter.Write` does two separate `Write()` calls: 4 bytes for the
+length header, then ~512 KiB for the payload. With Nagle disabled (gRPC
+default), the 4-byte header becomes its own TCP segment -- 1456 bytes
+wasted in a 1460-byte MSS frame. Fix: combine header+payload into a
+single write (pre-allocate header space in the encryption buffer).
+
+### 4. Large encryption units vs TCP MSS (latency on real networks)
+
+Currently the entire gRPC frame (up to 16 MiB from `GRPCStreamBuffer`)
+is encrypted as ONE authenticated blob. The receiver must buffer ALL TCP
+segments (~360 segments for 512 KiB) before decryption can start.
+
+TLS solves this with 16 KiB records: the reader can start processing
+after receiving just ~11 TCP segments. The auth tag overhead is only
+28 bytes per 16 KiB = 0.17%. This matters more on real networks with
+packet loss/reordering than on localhost.
+
+### Estimated impact of fixes
+
+| Fix | Effort | Expected speedup |
+|-----|--------|-----------------|
+| Cache AEAD cipher | Trivial | ~10-20% |
+| sync.Pool for buffers | Small | ~15-25% |
+| Combine header+payload write | Small | ~5% |
+| 16 KiB sub-frame encryption | Medium | Latency improvement on real networks |
+| **Combined** | | **~1.3-1.5x instead of 2.2x** |
+
+These optimizations should be implemented after PR #80 (stream
+multiplexing) is merged and benchmarked, since multiplexing changes the
+message flow pattern.

--- a/pkg/filesystem/download.go
+++ b/pkg/filesystem/download.go
@@ -11,6 +11,10 @@ import "sync"
 // ChunkSize is the granularity for tracking downloaded segments.
 const ChunkSize = 512 * 1024 // 512 KiB
 
+// StreamPoolSize is the number of parallel gRPC streams per file.
+// Matches typical FUSE readahead parallelism on Linux.
+const StreamPoolSize = 4
+
 // ChunkBitmap tracks which chunks of a file have been downloaded.
 // Thread-safe: Has() uses RLock, Set() uses Lock.
 type ChunkBitmap struct {

--- a/pkg/filesystem/fuse_directory.go
+++ b/pkg/filesystem/fuse_directory.go
@@ -473,19 +473,29 @@ func (d *Dir) OpenEx(path string, fi *winfuse.FileInfo_t) (errCode int) {
 		return int(convertOsErrToSyscallErrno("open", err))
 	}
 
-	// Open remote stream for reading (network call - no locks held)
-	var stream types.RemoteFileStream
+	// Open stream pool + cache FD for reading (network call - no locks held)
+	var pool *StreamPool
 	var streamCancel context.CancelFunc
+	var cacheFD *os.File
 	if remoteHasUpdate {
 		fsp := d.OpenStreamProvider()
 		var streamCtx context.Context
 		streamCtx, streamCancel = context.WithCancel(context.Background())
-		stream, err = fsp.OpenRemoteFile(streamCtx, uint64(fd), path)
+		pool, err = NewStreamPool(fsp, streamCtx, uint64(fd), path, StreamPoolSize)
 		if err != nil {
 			streamCancel()
 			syscall.Close(fd)
-			logger.Error("Failed to open remote stream", "error", err)
+			logger.Error("Failed to open stream pool", "error", err)
 			return -winfuse.EACCES
+		}
+		// Open persistent cache FD for on-demand writes (avoids open/close per chunk).
+		cacheFD, err = os.OpenFile(localPath, os.O_CREATE|os.O_WRONLY, 0644)
+		if err != nil {
+			streamCancel()
+			pool.Close()
+			syscall.Close(fd)
+			logger.Error("Failed to open cache FD", "error", err)
+			return -winfuse.EIO
 		}
 	}
 
@@ -498,8 +508,9 @@ func (d *Dir) OpenEx(path string, fi *winfuse.FileInfo_t) (errCode int) {
 
 	if remoteHasUpdate {
 		fh.NotLocalSynced = true
-		fh.RemoteFileStream = stream
+		fh.StreamPool = pool
 		fh.StreamCancel = streamCancel
+		fh.CacheFD = cacheFD
 		fh.Download.Reset(remoteTotalSize)
 
 		// Pre-allocate local file to expected size for out-of-order writes.
@@ -523,7 +534,7 @@ func (d *Dir) OpenEx(path string, fi *winfuse.FileInfo_t) (errCode int) {
 
 	fi.Fh = uint64(fd)
 	fi.DirectIo = shouldUseDirectIo(path, flags)
-	logger.Info("Opened for remote streaming", "fh", fd, "directIo", fi.DirectIo, "remoteHasUpdate", remoteHasUpdate, "fhNotLocalSynced", fh.NotLocalSynced, "fhStreamNil", fh.RemoteFileStream == nil)
+	logger.Info("Opened for remote streaming", "fh", fd, "directIo", fi.DirectIo, "remoteHasUpdate", remoteHasUpdate, "fhNotLocalSynced", fh.NotLocalSynced, "poolNil", fh.StreamPool == nil)
 	return 0
 }
 
@@ -970,23 +981,33 @@ func (d *Dir) Open(path string, flags int) (errCode int, retFh uint64) {
 		return int(convertOsErrToSyscallErrno("open", err)), 0
 	}
 
-	// Open remote stream (network call - no locks held)
+	// Open stream pool + cache FD (network call - no locks held)
 	fsp := d.OpenStreamProvider()
 	streamCtx, streamCancel := context.WithCancel(context.Background())
-	stream, err := fsp.OpenRemoteFile(streamCtx, uint64(fd), path)
-	if err != nil {
+	pool, poolErr := NewStreamPool(fsp, streamCtx, uint64(fd), path, StreamPoolSize)
+	if poolErr != nil {
 		streamCancel()
 		syscall.Close(fd)
-		logger.Error("Failed to open remote stream", "error", err)
+		logger.Error("Failed to open stream pool", "error", poolErr)
 		return -winfuse.EACCES, 0
+	}
+	// Open persistent cache FD for on-demand writes (avoids open/close per chunk).
+	cacheFD, cacheErr := os.OpenFile(localPath, os.O_CREATE|os.O_WRONLY, 0644)
+	if cacheErr != nil {
+		streamCancel()
+		pool.Close()
+		syscall.Close(fd)
+		logger.Error("Failed to open cache FD", "error", cacheErr)
+		return -winfuse.EIO, 0
 	}
 
 	d.AfmLock.Lock()
 	d.OpenMapLock.Lock()
 	fh.Inode = uint64(fd)
 	fh.StreamProvider = fsp
-	fh.RemoteFileStream = stream
+	fh.StreamPool = pool
 	fh.StreamCancel = streamCancel
+	fh.CacheFD = cacheFD
 	if remoteHasUpdate {
 		fh.NotLocalSynced = true // Ensure Read uses stream, not stale local cache
 		// Initialize download state for resume capability.
@@ -1009,7 +1030,7 @@ func (d *Dir) Open(path string, flags int) (errCode int, retFh uint64) {
 	d.OpenMapLock.Unlock()
 	d.AfmLock.Unlock()
 
-	logger.Info("Opened remote file", "fh", fh.Inode, "notLocalSynced", fh.NotLocalSynced, "hasStream", fh.RemoteFileStream != nil, "totalSize", remoteTotalSize)
+	logger.Info("Opened remote file", "fh", fh.Inode, "notLocalSynced", fh.NotLocalSynced, "poolNil", fh.StreamPool == nil, "totalSize", remoteTotalSize)
 	return 0, fh.Inode
 }
 
@@ -1216,20 +1237,27 @@ func (d *Dir) Release(path string, fh uint64) (errCode int) {
 			logger.Info("Removed file reference after download completed (peer stopped sharing)", "path", path)
 		}
 
-		// Get stream reference and cancel func, clear under lock, then close OUTSIDE lock
-		// to avoid holding OpenMapLock during network I/O
-		stream := f.RemoteFileStream
+		// Get pool/cacheFD/cancel references, clear under lock, then close OUTSIDE lock
+		// to avoid holding OpenMapLock during network I/O.
+		pool := f.StreamPool
 		streamCancel := f.StreamCancel
-		f.RemoteFileStream = nil
+		cacheFD := f.CacheFD
+		f.StreamPool = nil
 		f.StreamCancel = nil
-		if stream != nil {
+		f.CacheFD = nil
+		if pool != nil || cacheFD != nil {
 			d.OpenMapLock.Unlock()
 			unlocked = true
-			err = stream.Close()
-			if err != nil {
-				logger.Error("Failed to close remote file stream", "error", err)
+			if cacheFD != nil {
+				if closeErr := cacheFD.Close(); closeErr != nil {
+					logger.Error("Failed to close cache FD", "error", closeErr)
+				}
 			}
-			// Cancel the stream context after closing
+			if pool != nil {
+				if closeErr := pool.Close(); closeErr != nil {
+					logger.Error("Failed to close stream pool", "error", closeErr)
+				}
+			}
 			if streamCancel != nil {
 				streamCancel()
 			}
@@ -1664,13 +1692,13 @@ func (d *Dir) Read(path string, buff []byte, offset int64, fh uint64) (errCode i
 	// Get file info briefly, release lock before I/O (RWMutex is write-preferring)
 	d.OpenMapLock.RLock()
 	f, ok := d.OpenFileHandlers[fh]
-	var stream types.RemoteFileStream
-	var realPath string
+	var pool *StreamPool
+	var cacheFD *os.File
 	var notLocalSynced bool
 	var bitmap *ChunkBitmap
 	if ok {
-		stream = f.RemoteFileStream
-		realPath = f.RealPathOfFile
+		pool = f.StreamPool
+		cacheFD = f.CacheFD
 		notLocalSynced = f.NotLocalSynced
 		bitmap = f.Bitmap
 	}
@@ -1680,11 +1708,11 @@ func (d *Dir) Read(path string, buff []byte, offset int64, fh uint64) (errCode i
 		"path", path,
 		"ok", ok,
 		"notLocalSynced", notLocalSynced,
-		"streamNil", stream == nil,
+		"poolNil", pool == nil,
 		"hasBitmap", bitmap != nil,
 		"fh", fh)
 
-	if ok && notLocalSynced && stream != nil {
+	if ok && notLocalSynced && pool != nil {
 		// HYBRID READ: Check bitmap to decide local vs remote.
 		// If all chunks for this range are already downloaded (by prefetch or prior read),
 		// serve from local cache. Otherwise fetch on-demand from remote.
@@ -1705,9 +1733,9 @@ func (d *Dir) Read(path string, buff []byte, offset int64, fh uint64) (errCode i
 		var data []byte
 		var readErr error
 		for attempt := 0; attempt < 3; attempt++ {
-			// Read from remote stream with timeout to prevent system freeze.
+			// Read from stream pool with timeout to prevent system freeze.
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-			data, readErr = stream.ReadAt(ctx, offset, int64(len(buff)))
+			data, readErr = pool.ReadAt(ctx, offset, int64(len(buff)))
 			cancel()
 
 			if readErr == nil {
@@ -1722,34 +1750,34 @@ func (d *Dir) Read(path string, buff []byte, offset int64, fh uint64) (errCode i
 				break
 			}
 
-			// Try to re-establish the stream.
+			// Try to re-establish the stream pool.
 			if f.StreamProvider != nil {
-				logger.Info("Attempting to re-establish stream", "path", path, "attempt", attempt+1)
+				logger.Info("Attempting to re-establish stream pool", "path", path, "attempt", attempt+1)
 				streamCtx, streamCancel := context.WithCancel(context.Background())
-				newStream, openErr := f.StreamProvider.OpenRemoteFile(streamCtx, fh, path)
+				newPool, openErr := NewStreamPool(f.StreamProvider, streamCtx, fh, path, StreamPoolSize)
 				if openErr != nil {
 					streamCancel()
-					logger.Error("Failed to re-establish stream", "error", openErr)
+					logger.Error("Failed to re-establish stream pool", "error", openErr)
 					time.Sleep(time.Duration(attempt+1) * 500 * time.Millisecond) // Backoff.
 					continue
 				}
 
-				// Close old stream (best effort).
-				if stream != nil {
-					_ = stream.Close()
+				// Close old pool (best effort).
+				if pool != nil {
+					_ = pool.Close()
 				}
 				if f.StreamCancel != nil {
 					f.StreamCancel()
 				}
 
-				// Update file with new stream (need lock).
+				// Update file with new pool (need lock).
 				d.OpenMapLock.Lock()
-				f.RemoteFileStream = newStream
+				f.StreamPool = newPool
 				f.StreamCancel = streamCancel
 				d.OpenMapLock.Unlock()
 
-				stream = newStream
-				logger.Info("Stream re-established successfully", "path", path)
+				pool = newPool
+				logger.Info("Stream pool re-established successfully", "path", path)
 			}
 
 			time.Sleep(time.Duration(attempt+1) * 200 * time.Millisecond) // Backoff.
@@ -1767,18 +1795,13 @@ func (d *Dir) Read(path string, buff []byte, offset int64, fh uint64) (errCode i
 		f.Download.UpdateProgress(offset, n)
 		f.Download.UpdateChecksum(data[:n])
 
-		// Write data into local file for caching (no lock needed - pwrite is atomic).
-		lf, err := os.OpenFile(realPath, os.O_CREATE|os.O_WRONLY, 0644)
-		if err != nil {
-			logger.Error("Failed to open local file for writing", "error", err)
-			return -winfuse.EIO
-		}
-		defer lf.Close()
-
-		_, err = lf.WriteAt(data, offset)
-		if err != nil {
-			logger.Error("Failed to write remote data to local file", "error", err)
-			return -winfuse.EIO
+		// Write data into local cache using persistent FD (pwrite is atomic, no lock needed).
+		if cacheFD != nil {
+			_, err := cacheFD.WriteAt(data, offset)
+			if err != nil {
+				logger.Error("Failed to write remote data to local file", "error", err)
+				return -winfuse.EIO
+			}
 		}
 
 		// Mark bitmap for the chunks we just downloaded on-demand.

--- a/pkg/filesystem/stream_pool.go
+++ b/pkg/filesystem/stream_pool.go
@@ -1,0 +1,53 @@
+// ABOUTME: Stream pool for parallel gRPC reads on a single file.
+// ABOUTME: Eliminates mutex contention by sharding FUSE readahead across N streams.
+
+package filesystem
+
+import (
+	"context"
+
+	"github.com/KeibiSoft/KeibiDrop/pkg/types"
+)
+
+// StreamPool holds N parallel gRPC streams for a single file.
+// FUSE reads pick a stream by chunk-index modulo N, eliminating
+// lock contention between concurrent readahead requests.
+type StreamPool struct {
+	streams []types.RemoteFileStream
+	size    int
+}
+
+// NewStreamPool opens n parallel gRPC streams for the given file.
+// On partial failure, already-opened streams are closed.
+func NewStreamPool(provider types.FileStreamProvider, ctx context.Context, inode uint64, path string, n int) (*StreamPool, error) {
+	streams := make([]types.RemoteFileStream, n)
+	for i := range streams {
+		s, err := provider.OpenRemoteFile(ctx, inode, path)
+		if err != nil {
+			for j := 0; j < i; j++ {
+				_ = streams[j].Close()
+			}
+			return nil, err
+		}
+		streams[i] = s
+	}
+	return &StreamPool{streams: streams, size: n}, nil
+}
+
+// ReadAt routes the request to a stream selected by chunk index.
+// Different chunks hit different streams for true parallelism.
+func (p *StreamPool) ReadAt(ctx context.Context, offset int64, size int64) ([]byte, error) {
+	idx := int(offset/ChunkSize) % p.size
+	return p.streams[idx].ReadAt(ctx, offset, size)
+}
+
+// Close closes all streams in the pool.
+func (p *StreamPool) Close() error {
+	var firstErr error
+	for _, s := range p.streams {
+		if err := s.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}

--- a/pkg/filesystem/stream_pool.go
+++ b/pkg/filesystem/stream_pool.go
@@ -1,3 +1,9 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2026 KeibiSoft S.R.L.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 // ABOUTME: Stream pool for parallel gRPC reads on a single file.
 // ABOUTME: Eliminates mutex contention by sharding FUSE readahead across N streams.
 

--- a/pkg/filesystem/types.go
+++ b/pkg/filesystem/types.go
@@ -9,6 +9,7 @@ package filesystem
 import (
 	"context"
 	"log/slog"
+	"os"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -211,9 +212,10 @@ type File struct {
 
 	openFileCounter OpenFileCounter
 
-	StreamProvider   types.FileStreamProvider
-	RemoteFileStream types.RemoteFileStream
-	StreamCancel     context.CancelFunc // Cancel function for the stream context
+	StreamProvider types.FileStreamProvider
+	StreamPool     *StreamPool            // Pool of parallel gRPC streams for on-demand reads.
+	StreamCancel   context.CancelFunc     // Cancel function for the stream context.
+	CacheFD        *os.File               // Persistent cache file descriptor for on-demand writes.
 
 	// Download resumption state.
 	Download DownloadState

--- a/pkg/logic/common/proxy_methods.go
+++ b/pkg/logic/common/proxy_methods.go
@@ -73,3 +73,4 @@ func (sp *ImplFileStreamProvider) OpenRemoteFile(ctx context.Context, inode uint
 
 	return NewImplRemoteFileStream(stream, inode, path), nil
 }
+

--- a/tests/benchmark_test.go
+++ b/tests/benchmark_test.go
@@ -151,7 +151,8 @@ func applyNetem(t *testing.T, p netemProfile) func() {
 }
 
 // TestTransferThroughputNetem measures E2E transfer with simulated network
-// conditions. Requires KEIBIDROP_BENCH_NETEM=1 and sudo/CAP_NET_ADMIN.
+// conditions. Requires Linux with tc netem.
+// Requires KEIBIDROP_BENCH_NETEM=1 and sudo/CAP_NET_ADMIN.
 //
 // Run with: sudo -E KEIBIDROP_BENCH_NETEM=1 go test -run=TestTransferThroughputNetem -v -timeout=600s ./tests/...
 func TestTransferThroughputNetem(t *testing.T) {


### PR DESCRIPTION
## Summary

- Replace single gRPC stream per file with a pool of 4 parallel streams, sharded by chunk index modulo pool size — eliminates mutex contention between FUSE readahead requests
- Replace per-chunk `os.OpenFile + WriteAt + Close` with a persistent `*os.File` cache descriptor opened once in `Open()` and closed in `Release()` — eliminates ~5-10ms syscall overhead per chunk
- New `StreamPool` type in `pkg/filesystem/stream_pool.go`

## Benchmark results

| Metric | Before | After |
|--------|--------|-------|
| 100MB E2E throughput | ~66 MB/s | **171 MB/s** (2.6x) |
| 10MB E2E throughput | ~56 MB/s | **159 MB/s** (2.8x) |
| Per-chunk median latency | ~5-10ms | **1.5ms** |
| Per-chunk P95 | — | **2.6ms** |

## Test plan

- [x] `TestTransferThroughput` — passes, 100MB at 171 MB/s
- [x] `TestChunkLatency` — passes, median 1.5ms
- [x] `TestEncryptedGRPC` — passes, 100MB at 396 MB/s
- [x] All 19 `pkg/filesystem` unit tests pass
- [x] `go build ./...` clean
- [x] `go vet` — no new warnings (pre-existing context leak warning unchanged)
- [ ] Netem benchmarks (needs sudo)
- [ ] Manual real-peer transfer test