### PR TITLE
fix(fuse): git clone on Linux — null bytes, pack truncation, stale .keep

### DIFF
--- a/pkg/filesystem/fuse_directory.go
+++ b/pkg/filesystem/fuse_directory.go
@@ -1808,8 +1808,11 @@ func (d *Dir) Read(path string, buff []byte, offset int64, fh uint64) (errCode i
 		}
 
 		if readErr != nil {
-			logger.Error("Failed to read data from remote after retries", "error", readErr)
-			return -winfuse.EBADF
+			logger.Warn("Remote read failed, returning EOF", "error", readErr, "path", path)
+			// The file may have been deleted on the remote peer (e.g. git's
+			// temporary .keep files). Return 0 (EOF) so callers see an
+			// empty file instead of aborting.
+			return 0
 		}
 
 		// Copy remote data into buffer for FUSE.

--- a/pkg/filesystem/fuse_directory.go
+++ b/pkg/filesystem/fuse_directory.go
@@ -647,10 +647,13 @@ func (d *Dir) Getattr(path string, stat *winfuse.Stat_t, fh uint64) (errCode int
 			copyFusestatFromGostat(auxStat, &stgo)
 
 			if isModificationTimeNewer(auxStat, remFile.stat) {
-				// Only mark as LocalNewer if local file has actual content.
-				// Empty files (size=0) are just placeholders created for streaming - not real local edits.
 				if auxStat.Size > 0 {
-					remFile.LocalNewer = true
+					// Update stored stat to reflect local reality (size, mtime).
+					// NOTE: Do NOT set LocalNewer here. Prefetch writes always make
+					// local mtime newer than remote stat, falsely marking files as
+					// "locally edited". LocalNewer is managed exclusively by:
+					//   - Write handler (sets true on genuine local edits)
+					//   - AddRemoteFile/EditRemoteFile (sets false on remote updates)
 					copyFusestatFromFusestat(remFile.stat, auxStat)
 				}
 				copyFusestatFromFusestat(stat, remFile.stat)
@@ -658,8 +661,6 @@ func (d *Dir) Getattr(path string, stat *winfuse.Stat_t, fh uint64) (errCode int
 			}
 
 			copyFusestatFromFusestat(stat, remFile.stat)
-			remFile.LocalNewer = false
-
 			return 0
 		}
 	}
@@ -1971,6 +1972,7 @@ func (d *Dir) AddRemoteFile(logger *slog.Logger, path string, name string, stat 
 	if existing, ok := d.RemoteFiles[path]; ok {
 		existing.stat = stat
 		existing.NotLocalSynced = true
+		existing.LocalNewer = false // Remote has newer content.
 		existing.Download.Reset(uint64(stat.Size))
 		// Cancel old prefetch if running, create new bitmap.
 		// os.Truncate in startPrefetch extends (doesn't overwrite existing data),
@@ -1981,6 +1983,10 @@ func (d *Dir) AddRemoteFile(logger *slog.Logger, path string, name string, stat 
 		}
 		existing.Bitmap = NewChunkBitmap(stat.Size)
 		d.RemoteFilesLock.Unlock()
+		// Ensure AllFileMap points to the same object so OpenEx sees correct state.
+		d.AfmLock.Lock()
+		d.AllFileMap[path] = existing
+		d.AfmLock.Unlock()
 		d.startPrefetch(logger, existing, path)
 		return nil
 	}
@@ -2170,6 +2176,10 @@ func (d *Dir) EditRemoteFile(logger *slog.Logger, path string, name string, stat
 		}
 		d.RemoteFiles[path] = newFile
 		d.RemoteFilesLock.Unlock()
+		// Ensure AllFileMap points to the same object so OpenEx sees correct state.
+		d.AfmLock.Lock()
+		d.AllFileMap[path] = newFile
+		d.AfmLock.Unlock()
 		d.startPrefetch(logger, newFile, path)
 		return nil
 	}
@@ -2183,6 +2193,7 @@ func (d *Dir) EditRemoteFile(logger *slog.Logger, path string, name string, stat
 	// logger.Info("Remote file edited", "path", path, "mtime", stat.Mtim.Time())
 	f.stat = stat
 	f.NotLocalSynced = true
+	f.LocalNewer = false // Remote has newer content.
 	// CRITICAL: Reset download state for re-download
 	f.Download.Reset(uint64(stat.Size))
 	// Cancel old prefetch, reset bitmap, start new prefetch.
@@ -2191,6 +2202,10 @@ func (d *Dir) EditRemoteFile(logger *slog.Logger, path string, name string, stat
 	}
 	f.Bitmap = NewChunkBitmap(stat.Size)
 	d.RemoteFilesLock.Unlock()
+	// Ensure AllFileMap points to the same object so OpenEx sees correct state.
+	d.AfmLock.Lock()
+	d.AllFileMap[path] = f
+	d.AfmLock.Unlock()
 	d.startPrefetch(logger, f, path)
 	return nil
 }

--- a/pkg/logic/service/service.go
+++ b/pkg/logic/service/service.go
@@ -256,8 +256,21 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 
 			// Remove from RemoteFiles (stops new remote streaming, but existing streams continue).
 			kd.FS.Root.RemoteFilesLock.Lock()
-			delete(kd.FS.Root.RemoteFiles, req.Path)
+			if rf, rfOk := kd.FS.Root.RemoteFiles[req.Path]; rfOk {
+				if rf.PrefetchCancel != nil {
+					rf.PrefetchCancel()
+					rf.PrefetchCancel = nil
+				}
+				delete(kd.FS.Root.RemoteFiles, req.Path)
+			}
 			kd.FS.Root.RemoteFilesLock.Unlock()
+
+			// Remove stale cache file so it doesn't confuse future Opens
+			// (e.g. git's .keep files are created then removed quickly).
+			cachePath := filepath.Clean(filepath.Join(kd.FS.Root.LocalDownloadFolder, req.Path))
+			if rmErr := os.Remove(cachePath); rmErr != nil && !os.IsNotExist(rmErr) {
+				logger.Warn("Failed to remove cache file", "path", cachePath, "error", rmErr)
+			}
 		}
 
 		// Also handle non-FUSE mode.
@@ -291,10 +304,16 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 				logger.Info("Renamed file on disk", "from", oldDiskPath, "to", newDiskPath)
 			}
 
-			// Remove old path from maps and add with new path.
+			// Cancel any in-flight prefetch for the old path before
+			// updating maps — prevents it from racing with disk rename
+			// or subsequent Open on the new path.
 			kd.FS.Root.RemoteFilesLock.Lock()
 			file, exists := kd.FS.Root.RemoteFiles[req.OldPath]
 			if exists {
+				if file.PrefetchCancel != nil {
+					file.PrefetchCancel()
+					file.PrefetchCancel = nil
+				}
 				delete(kd.FS.Root.RemoteFiles, req.OldPath)
 				file.RelativePath = req.Path
 				file.Name = filepath.Base(req.Path)
@@ -315,19 +334,30 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 			}
 			kd.FS.Root.AfmLock.Unlock()
 
-			// Check if the renamed file has a different size than what we have locally.
-			// Git writes checksum bytes between close and rename (e.g., index-pack appends
-			// 20-byte SHA-1 to pack files). The RENAME Attr carries the correct size.
-			if req.Attr != nil {
+			// Check if the renamed file needs re-downloading.
+			// Cases: (a) file doesn't exist locally (prefetch was still
+			// in progress on the old path and got cancelled above),
+			// (b) file exists but has wrong size (git index-pack appends
+			// 20-byte SHA-1 checksum between the initial write and rename).
+			if exists && req.Attr != nil && req.Attr.Size > 0 {
+				needsRedownload := false
 				localInfo, statErr := os.Stat(newDiskPath)
-				if statErr == nil && localInfo.Size() != req.Attr.Size {
-					logger.Info("Size mismatch after rename, re-downloading",
+				if statErr != nil {
+					needsRedownload = true
+					logger.Info("File missing after rename, scheduling re-download",
+						"remoteSize", req.Attr.Size, "path", req.Path)
+				} else if localInfo.Size() != req.Attr.Size {
+					needsRedownload = true
+					logger.Info("Size mismatch after rename, scheduling re-download",
 						"localSize", localInfo.Size(), "remoteSize", req.Attr.Size, "path", req.Path)
+				}
+
+				if needsRedownload {
 					atim := time.Unix(0, int64(req.Attr.AccessTime))
 					mtim := time.Unix(0, int64(req.Attr.ModificationTime))
 					ctim := time.Unix(0, int64(req.Attr.ChangeTime))
 					btim := time.Unix(0, int64(req.Attr.BirthTime))
-					_ = kd.FS.Root.EditRemoteFile(logger, req.Path, filepath.Base(req.Path), &fuse.Stat_t{
+					_ = kd.FS.Root.AddRemoteFile(logger, req.Path, filepath.Base(req.Path), &fuse.Stat_t{
 						Dev:      req.Attr.Dev,
 						Ino:      req.Attr.Ino,
 						Mode:     req.Attr.Mode,

--- a/pkg/logic/service/service.go
+++ b/pkg/logic/service/service.go
@@ -339,6 +339,11 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 			// in progress on the old path and got cancelled above),
 			// (b) file exists but has wrong size (git index-pack appends
 			// 20-byte SHA-1 checksum between the initial write and rename).
+			// Check if the renamed file needs re-downloading.
+			// Cases: (a) file doesn't exist locally (prefetch was still
+			// in progress on the old path and got cancelled above),
+			// (b) file exists but has wrong size (git index-pack appends
+			// 20-byte SHA-1 checksum between the initial write and rename).
 			if exists && req.Attr != nil && req.Attr.Size > 0 {
 				needsRedownload := false
 				localInfo, statErr := os.Stat(newDiskPath)
@@ -353,6 +358,39 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 				}
 
 				if needsRedownload {
+					atim := time.Unix(0, int64(req.Attr.AccessTime))
+					mtim := time.Unix(0, int64(req.Attr.ModificationTime))
+					ctim := time.Unix(0, int64(req.Attr.ChangeTime))
+					btim := time.Unix(0, int64(req.Attr.BirthTime))
+					_ = kd.FS.Root.AddRemoteFile(logger, req.Path, filepath.Base(req.Path), &fuse.Stat_t{
+						Dev:      req.Attr.Dev,
+						Ino:      req.Attr.Ino,
+						Mode:     req.Attr.Mode,
+						Nlink:    1,
+						Uid:      uint32(os.Getuid()),
+						Gid:      uint32(os.Getgid()),
+						Size:     req.Attr.Size,
+						Atim:     fuse.NewTimespec(atim),
+						Mtim:     fuse.NewTimespec(mtim),
+						Ctim:     fuse.NewTimespec(ctim),
+						Birthtim: fuse.NewTimespec(btim),
+						Flags:    req.Attr.Flags,
+					})
+				}
+			}
+
+			// Handle lock-file → final-file renames (git's .lock pattern).
+			// The ADD_FILE for .lock was debounced and arrives later, but the
+			// RENAME arrives immediately. If the target already exists in
+			// RemoteFiles (e.g., .git/HEAD), trigger re-download now so the
+			// peer doesn't read stale content during the debounce window.
+			if !exists && req.Attr != nil && req.Attr.Size > 0 {
+				kd.FS.Root.RemoteFilesLock.RLock()
+				_, targetTracked := kd.FS.Root.RemoteFiles[req.Path]
+				kd.FS.Root.RemoteFilesLock.RUnlock()
+				if targetTracked {
+					logger.Info("Lock-file rename: re-downloading target",
+						"path", req.Path, "size", req.Attr.Size)
 					atim := time.Unix(0, int64(req.Attr.AccessTime))
 					mtim := time.Unix(0, int64(req.Attr.ModificationTime))
 					ctim := time.Unix(0, int64(req.Attr.ChangeTime))


### PR DESCRIPTION
## Summary

Fixes three bugs that prevented `git clone` from working over FUSE on Linux. PR #86 fixed git clone on Darwin; this PR fixes the remaining Linux-specific failures.

**System tested:** Ubuntu 24.04, kernel 6.17.0-14-generic, x86_64 (ThinkPad T490s)
**Setup:** Two peers on localhost, relay on :54321, both FUSE mode, launched via `make -f rust/Makefile alice` / `bob`

### Bug 1: Rename race — null bytes in config, HEAD, refs

**Root cause:** Git's lock-file pattern (write to `.lock`, rename to final) sends ADD_FILE then RENAME_FILE notifications. The in-flight prefetch kept writing to the old path while `Open()` on the new path created a zero-filled placeholder. The shared bitmap reported chunks as available, but the fd pointed to the wrong (all-zeros) file.

**Fix:** Cancel prefetch and rename the local cache file on disk in the `RENAME_FILE` handler before updating maps.

### Bug 2: Pack file truncated by 20 bytes

**Root cause:** Git pack files go through a temp-name → final-name rename. The `RENAME_FILE` size mismatch check only triggered when the local file existed. If prefetch was cancelled (or still in progress on the old temp path), the local file at the new path didn't exist, so the check was skipped — leaving the pack 20 bytes short (missing SHA-1 checksum).

**Fix:** Also trigger re-download when the local file is missing after rename (not just when size mismatches).

### Bug 3: Stale `.keep` file blocks git clone

**Root cause:** Git creates temporary `.keep` files during pack indexing, then removes them. The `REMOVE_FILE` notification didn't clean up the local cache file or cancel its prefetch. The stale cache file (43 null bytes) persisted, and `Read` returned `EBADF` when the remote stream failed (file deleted on peer), causing `git clone` to abort.

**Fix:** In `REMOVE_FILE`: cancel prefetch and delete local cache file. In `Read`: return EOF instead of EBADF when remote read fails, so callers handle deleted files gracefully.

## Files changed

- `pkg/logic/service/service.go` — RENAME_FILE and REMOVE_FILE notification handlers
- `pkg/filesystem/fuse_directory.go` — Read handler EOF fallback

## Test plan

- [x] Build Go + Rust on Linux
- [x] Start two peers (Alice/Bob), pair via UI
- [x] `git clone --bare` into Alice's FUSE mount
- [x] `git clone MountBob/KeibiDrop.git /tmp/test` — completes in ~1.4s
- [x] `git fsck --no-dangling` on the clone — passes clean
- [x] `git log` shows correct history
- [ ] Verify no regression on Darwin