### PR TITLE
Add aes-gcm if hardware support AES-NI

### DIFF
--- a/pkg/crypto/asymmetric.go
+++ b/pkg/crypto/asymmetric.go
@@ -130,6 +130,12 @@ func DeriveChaCha20Key(sharedSecrets ...[]byte) ([]byte, error) {
 	return deriveKeyInternal(sha512.New, "KeibiDrop-ChaCha20-Poly1305-SEK", KeySize, sharedSecrets...)
 }
 
+// DeriveAES256Key derives a 32-byte symmetric key for AES-256-GCM.
+// Uses a different HKDF label for domain separation from ChaCha20 keys.
+func DeriveAES256Key(sharedSecrets ...[]byte) ([]byte, error) {
+	return deriveKeyInternal(sha512.New, "KeibiDrop-AES-256-GCM-SEK", KeySize, sharedSecrets...)
+}
+
 func Fingerprint(pub []byte) string {
 	sum := sha512.Sum512(pub)
 	return base64.RawURLEncoding.EncodeToString(sum[:])

--- a/pkg/crypto/cipher.go
+++ b/pkg/crypto/cipher.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package crypto
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"fmt"
+	"runtime"
+
+	"golang.org/x/crypto/chacha20poly1305"
+	"golang.org/x/sys/cpu"
+)
+
+// CipherSuite identifies an AEAD cipher for the encrypted connection.
+type CipherSuite string
+
+const (
+	CipherChaCha20 CipherSuite = "chacha20-poly1305"
+	CipherAES256   CipherSuite = "aes-256-gcm"
+)
+
+// HasHardwareAES returns true if the CPU has hardware AES acceleration.
+// On x86 this is AES-NI; on ARM64 this is the ARMv8 AES extension.
+func HasHardwareAES() bool {
+	switch runtime.GOARCH {
+	case "amd64":
+		return cpu.X86.HasAES
+	case "arm64":
+		return cpu.ARM64.HasAES
+	default:
+		return false
+	}
+}
+
+// SupportedCiphers returns the cipher suites this peer supports,
+// ordered by preference (best first).
+func SupportedCiphers() []CipherSuite {
+	if HasHardwareAES() {
+		return []CipherSuite{CipherAES256, CipherChaCha20}
+	}
+	return []CipherSuite{CipherChaCha20}
+}
+
+// NegotiateCipher picks the best cipher both peers support.
+// Returns the first cipher from `local` that also appears in `remote`.
+// Falls back to ChaCha20 if no intersection (should never happen).
+func NegotiateCipher(local, remote []CipherSuite) CipherSuite {
+	remoteSet := make(map[CipherSuite]bool, len(remote))
+	for _, c := range remote {
+		remoteSet[c] = true
+	}
+	for _, c := range local {
+		if remoteSet[c] {
+			return c
+		}
+	}
+	return CipherChaCha20 // safe fallback
+}
+
+// NewAEAD creates an AEAD cipher for the given suite and key.
+// Both AES-256-GCM and ChaCha20-Poly1305 use 32-byte keys, 12-byte nonces,
+// and 16-byte auth tags — the wire format is identical.
+func NewAEAD(suite CipherSuite, key []byte) (cipher.AEAD, error) {
+	switch suite {
+	case CipherAES256:
+		block, err := aes.NewCipher(key)
+		if err != nil {
+			return nil, fmt.Errorf("aes.NewCipher: %w", err)
+		}
+		return cipher.NewGCM(block)
+	case CipherChaCha20:
+		return chacha20poly1305.New(key)
+	default:
+		return nil, fmt.Errorf("unknown cipher suite: %s", suite)
+	}
+}
+
+// DeriveKey derives a symmetric key using the appropriate HKDF label for the cipher suite.
+// Domain separation ensures the same input secrets produce different keys for different ciphers.
+func DeriveKey(suite CipherSuite, sharedSecrets ...[]byte) ([]byte, error) {
+	switch suite {
+	case CipherAES256:
+		return DeriveAES256Key(sharedSecrets...)
+	case CipherChaCha20:
+		return DeriveChaCha20Key(sharedSecrets...)
+	default:
+		return nil, fmt.Errorf("unknown cipher suite: %s", suite)
+	}
+}

--- a/pkg/session/handshake.go
+++ b/pkg/session/handshake.go
@@ -20,10 +20,11 @@ import (
 
 // PeerHandshakeMessage defines the JSON payload sent during handshake.
 type PeerHandshakeMessage struct {
-	Fingerprint  string            `json:"fingerprint"`
-	PublicKeys   map[string]string `json:"public_keys"` // base64 encoded
-	EncSeeds     map[string]string `json:"enc_seeds"`   // optional for key encapsulation
-	OutboundPort int               `json:"port"`
+	Fingerprint      string            `json:"fingerprint"`
+	PublicKeys       map[string]string `json:"public_keys"`        // base64 encoded
+	EncSeeds         map[string]string `json:"enc_seeds"`          // optional for key encapsulation
+	OutboundPort     int               `json:"port"`
+	SupportedCiphers []string          `json:"supported_ciphers"` // cipher negotiation
 }
 
 // PerformInboundHandshake handles the first plaintext connection from Bob to Alice.
@@ -110,7 +111,22 @@ func PerformInboundHandshake(session *Session, conn net.Conn) error {
 		return err
 	}
 
-	inboundKey, err := kbc.DeriveChaCha20Key(seed1, seed2)
+	// Negotiate cipher suite: pick best cipher both peers support.
+	peerCiphers := make([]kbc.CipherSuite, len(msg.SupportedCiphers))
+	for i, c := range msg.SupportedCiphers {
+		peerCiphers[i] = kbc.CipherSuite(c)
+	}
+	if len(peerCiphers) == 0 {
+		peerCiphers = []kbc.CipherSuite{kbc.CipherChaCha20}
+	}
+	suite := kbc.NegotiateCipher(kbc.SupportedCiphers(), peerCiphers)
+	// Only update if not already set (outbound may have run first with local preference).
+	if session.CipherSuite == "" {
+		session.CipherSuite = suite
+	}
+	logger.Info("Cipher negotiated", "suite", suite, "peer-offered", msg.SupportedCiphers, "hardware-aes", kbc.HasHardwareAES())
+
+	inboundKey, err := kbc.DeriveKey(suite, seed1, seed2)
 	if err != nil {
 		logger.Error("Failed to derive inbound key", "error", err)
 		return err
@@ -131,7 +147,7 @@ func PerformInboundHandshake(session *Session, conn net.Conn) error {
 	*/
 
 	// Upgrade to SecureConn
-	secure := NewSecureConn(conn, session.SEKInbound)
+	secure := NewSecureConn(conn, session.SEKInbound, suite)
 	if session.Session == nil {
 		session.Session = &SessionSockets{}
 	}
@@ -157,7 +173,15 @@ func PerformOutboundHandshake(session *Session, remoteAddr string) error {
 
 	seed2, encSeed2MLKEM := session.PeerPubKeys.MlKemPublic.Encapsulate()
 
-	outboundKey, err := kbc.DeriveChaCha20Key(seed1, seed2)
+	// Determine cipher suite. If inbound already negotiated, use that.
+	// Otherwise use local preference (outbound runs before inbound in create-room flow).
+	suite := session.CipherSuite
+	if suite == "" {
+		suite = kbc.SupportedCiphers()[0] // local preference
+		session.CipherSuite = suite
+	}
+
+	outboundKey, err := kbc.DeriveKey(suite, seed1, seed2)
 	if err != nil {
 		logger.Error("Failed to derive outbound key", "error", err)
 		return err
@@ -181,11 +205,19 @@ func PerformOutboundHandshake(session *Session, remoteAddr string) error {
 		"x25519": encodeBase64(encSeed1X25519),
 	}
 
+	// Advertise our supported ciphers to the peer.
+	supported := kbc.SupportedCiphers()
+	supportedStr := make([]string, len(supported))
+	for i, c := range supported {
+		supportedStr[i] = string(c)
+	}
+
 	msg := PeerHandshakeMessage{
-		Fingerprint:  session.ExpectedPeerFingerprint,
-		PublicKeys:   pubKeys,
-		EncSeeds:     encSeeds,
-		OutboundPort: session.DefaultInboundPort,
+		Fingerprint:      session.ExpectedPeerFingerprint,
+		PublicKeys:       pubKeys,
+		EncSeeds:         encSeeds,
+		OutboundPort:     session.DefaultInboundPort,
+		SupportedCiphers: supportedStr,
 	}
 
 	if err := json.NewEncoder(conn).Encode(msg); err != nil {
@@ -209,7 +241,7 @@ func PerformOutboundHandshake(session *Session, remoteAddr string) error {
 	logger.Info("Peer confirmed handshake upgrading to encrypted connection")
 
 	// Upgrade to SecureConn
-	secure := NewSecureConn(conn, session.SEKOutbound)
+	secure := NewSecureConn(conn, session.SEKOutbound, suite)
 	if session.Session == nil {
 		session.Session = &SessionSockets{}
 	}
@@ -266,7 +298,11 @@ func FinalizeInboundSession(session *Session, conn net.Conn, encSeeds map[string
 	}
 
 	// === Step 3: Derive KEK ===
-	sek, err := kbc.DeriveChaCha20Key(seed1, sharedKEM)
+	suite := session.CipherSuite
+	if suite == "" {
+		suite = kbc.CipherChaCha20
+	}
+	sek, err := kbc.DeriveKey(suite, seed1, sharedKEM)
 	if err != nil {
 		logger.Error("Failed to derive SEK", "error", err)
 		return fmt.Errorf("SEK derivation failed: %w", err)
@@ -274,7 +310,7 @@ func FinalizeInboundSession(session *Session, conn net.Conn, encSeeds map[string
 	session.SEKInbound = sek
 
 	// === Step 4: Upgrade connection to SecureConn ===
-	secure := NewSecureConn(conn, sek)
+	secure := NewSecureConn(conn, sek, suite)
 	if session.Session == nil {
 		session.Session = &SessionSockets{}
 	}

--- a/pkg/session/rekey.go
+++ b/pkg/session/rekey.go
@@ -15,7 +15,7 @@ import (
 
 // CreateRekeyRequest generates a RekeyRequest with new encapsulated seeds.
 // Returns the request, the derived new key (for outbound), and any error.
-func CreateRekeyRequest(ownKeys *kbc.OwnKeys, peerKeys *kbc.PeerKeys, epoch uint64) (*bindings.RekeyRequest, []byte, error) {
+func CreateRekeyRequest(ownKeys *kbc.OwnKeys, peerKeys *kbc.PeerKeys, epoch uint64, suite kbc.CipherSuite) (*bindings.RekeyRequest, []byte, error) {
 	if ownKeys == nil {
 		return nil, nil, fmt.Errorf("own keys is nil")
 	}
@@ -39,8 +39,8 @@ func CreateRekeyRequest(ownKeys *kbc.OwnKeys, peerKeys *kbc.PeerKeys, epoch uint
 	// Encapsulate with ML-KEM.
 	seed2, encSeed2 := peerKeys.MlKemPublic.Encapsulate()
 
-	// Derive the new key from both seeds.
-	newKey, err := kbc.DeriveChaCha20Key(seed1, seed2)
+	// Derive the new key from both seeds using the negotiated cipher suite.
+	newKey, err := kbc.DeriveKey(suite, seed1, seed2)
 	if err != nil {
 		return nil, nil, fmt.Errorf("key derivation failed: %w", err)
 	}
@@ -58,7 +58,7 @@ func CreateRekeyRequest(ownKeys *kbc.OwnKeys, peerKeys *kbc.PeerKeys, epoch uint
 
 // ProcessRekeyRequest handles an incoming RekeyRequest.
 // Returns a RekeyResponse, the derived new inbound key, and any error.
-func ProcessRekeyRequest(req *bindings.RekeyRequest, ownKeys *kbc.OwnKeys, peerKeys *kbc.PeerKeys) (*bindings.RekeyResponse, []byte, error) {
+func ProcessRekeyRequest(req *bindings.RekeyRequest, ownKeys *kbc.OwnKeys, peerKeys *kbc.PeerKeys, suite kbc.CipherSuite) (*bindings.RekeyResponse, []byte, error) {
 	if ownKeys == nil {
 		return nil, nil, fmt.Errorf("own keys is nil")
 	}
@@ -94,13 +94,13 @@ func ProcessRekeyRequest(req *bindings.RekeyRequest, ownKeys *kbc.OwnKeys, peerK
 	}
 
 	// Derive the new inbound key.
-	newInboundKey, err := kbc.DeriveChaCha20Key(seed1, seed2)
+	newInboundKey, err := kbc.DeriveKey(suite, seed1, seed2)
 	if err != nil {
 		return nil, nil, fmt.Errorf("inbound key derivation failed: %w", err)
 	}
 
 	// Create our response with new seeds for the peer's inbound direction.
-	respReq, _, err := CreateRekeyRequest(ownKeys, peerKeys, req.Epoch)
+	respReq, _, err := CreateRekeyRequest(ownKeys, peerKeys, req.Epoch, suite)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create response seeds: %w", err)
 	}
@@ -115,7 +115,7 @@ func ProcessRekeyRequest(req *bindings.RekeyRequest, ownKeys *kbc.OwnKeys, peerK
 
 // ProcessRekeyResponse handles an incoming RekeyResponse.
 // Returns the derived new outbound key (peer's response seeds).
-func ProcessRekeyResponse(resp *bindings.RekeyResponse, ownKeys *kbc.OwnKeys, peerKeys *kbc.PeerKeys) ([]byte, error) {
+func ProcessRekeyResponse(resp *bindings.RekeyResponse, ownKeys *kbc.OwnKeys, peerKeys *kbc.PeerKeys, suite kbc.CipherSuite) ([]byte, error) {
 	if ownKeys == nil {
 		return nil, fmt.Errorf("own keys is nil")
 	}
@@ -151,7 +151,7 @@ func ProcessRekeyResponse(resp *bindings.RekeyResponse, ownKeys *kbc.OwnKeys, pe
 	}
 
 	// Derive the new key for receiving from peer.
-	newKey, err := kbc.DeriveChaCha20Key(seed1, seed2)
+	newKey, err := kbc.DeriveKey(suite, seed1, seed2)
 	if err != nil {
 		return nil, fmt.Errorf("key derivation failed: %w", err)
 	}

--- a/pkg/session/secureconn.go
+++ b/pkg/session/secureconn.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	kbc "github.com/KeibiSoft/KeibiDrop/pkg/crypto"
-	"golang.org/x/crypto/chacha20poly1305"
 )
 
 const lengthHeaderSize = 4 // uint32 prefix
@@ -43,10 +42,10 @@ type SecureWriter struct {
 	nonce *kbc.NonceGenerator
 }
 
-func NewSecureWriter(w io.Writer, kek []byte) *SecureWriter {
-	aead, err := chacha20poly1305.New(kek)
+func NewSecureWriter(w io.Writer, kek []byte, suite kbc.CipherSuite) *SecureWriter {
+	aead, err := kbc.NewAEAD(suite, kek)
 	if err != nil {
-		panic("secureconn: invalid key size: " + err.Error())
+		panic("secureconn: invalid key: " + err.Error())
 	}
 	return &SecureWriter{
 		w:     w,
@@ -56,10 +55,10 @@ func NewSecureWriter(w io.Writer, kek []byte) *SecureWriter {
 }
 
 // NewSecureWriterWithPrefix creates a writer with a custom nonce prefix.
-func NewSecureWriterWithPrefix(w io.Writer, kek []byte, prefix uint32) *SecureWriter {
-	aead, err := chacha20poly1305.New(kek)
+func NewSecureWriterWithPrefix(w io.Writer, kek []byte, suite kbc.CipherSuite, prefix uint32) *SecureWriter {
+	aead, err := kbc.NewAEAD(suite, kek)
 	if err != nil {
-		panic("secureconn: invalid key size: " + err.Error())
+		panic("secureconn: invalid key: " + err.Error())
 	}
 	return &SecureWriter{
 		w:     w,
@@ -96,10 +95,10 @@ type SecureReader struct {
 	head [lengthHeaderSize]byte
 }
 
-func NewSecureReader(r io.Reader, kek []byte) *SecureReader {
-	aead, err := chacha20poly1305.New(kek)
+func NewSecureReader(r io.Reader, kek []byte, suite kbc.CipherSuite) *SecureReader {
+	aead, err := kbc.NewAEAD(suite, kek)
 	if err != nil {
-		panic("secureconn: invalid key size: " + err.Error())
+		panic("secureconn: invalid key: " + err.Error())
 	}
 	return &SecureReader{r: r, aead: aead}
 }
@@ -132,9 +131,10 @@ func (s *SecureReader) Read() ([]byte, error) {
 
 // SecureConn wraps a net.Conn with separate inbound/outbound encryption.
 type SecureConn struct {
-	conn net.Conn
-	r    *SecureReader
-	w    *SecureWriter
+	conn  net.Conn
+	suite kbc.CipherSuite
+	r     *SecureReader
+	w     *SecureWriter
 
 	readBuf *bytes.Buffer
 	done    bool
@@ -149,11 +149,12 @@ type SecureConn struct {
 	keyMu        sync.RWMutex // protects key updates
 }
 
-func NewSecureConn(conn net.Conn, kek []byte) *SecureConn {
+func NewSecureConn(conn net.Conn, kek []byte, suite kbc.CipherSuite) *SecureConn {
 	return &SecureConn{
 		conn:    conn,
-		r:       NewSecureReader(conn, kek),
-		w:       NewSecureWriter(conn, kek),
+		suite:   suite,
+		r:       NewSecureReader(conn, kek, suite),
+		w:       NewSecureWriter(conn, kek, suite),
 		readBuf: bytes.NewBuffer(nil),
 		closed:  make(chan struct{}),
 	}
@@ -264,13 +265,13 @@ func (s *SecureConn) ShouldRekey() bool {
 		s.msgsSent.Load() >= RekeyMsgsThreshold
 }
 
-// UpdateKey atomically updates the encryption key.
+// UpdateKey atomically updates the encryption key (reuses negotiated cipher suite).
 func (s *SecureConn) UpdateKey(newKek []byte) {
 	s.keyMu.Lock()
 	defer s.keyMu.Unlock()
 
-	s.r = NewSecureReader(s.conn, newKek)
-	s.w = NewSecureWriter(s.conn, newKek)
+	s.r = NewSecureReader(s.conn, newKek, s.suite)
+	s.w = NewSecureWriter(s.conn, newKek, s.suite)
 	s.ResetStats()
 	s.currentEpoch.Add(1)
 }

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -43,6 +43,9 @@ type Session struct {
 	SEKInbound  []byte
 	SEKOutbound []byte
 
+	// Negotiated cipher suite for this session.
+	CipherSuite kbc.CipherSuite
+
 	// Peer-to-peer TCP connections.
 	Session  *SessionSockets
 	PeerPort int
@@ -119,10 +122,10 @@ type SessionSockets struct {
 	Outbound *SecureConn // Alice -> Bob
 }
 
-func NewSessionSockets(connIn, connOut net.Conn, sekIn, sekOut []byte) *SessionSockets {
+func NewSessionSockets(connIn, connOut net.Conn, sekIn, sekOut []byte, suite kbc.CipherSuite) *SessionSockets {
 	return &SessionSockets{
-		Inbound:  NewSecureConn(connIn, sekIn),
-		Outbound: NewSecureConn(connOut, sekOut),
+		Inbound:  NewSecureConn(connIn, sekIn, suite),
+		Outbound: NewSecureConn(connOut, sekOut, suite),
 	}
 }
 
@@ -199,7 +202,7 @@ func (s *Session) HandleRekeyRequest(req *bindings.RekeyRequest) (*bindings.Reke
 		return nil, fmt.Errorf("session keys not initialized")
 	}
 
-	resp, newInboundKey, err := ProcessRekeyRequest(req, s.OwnKeys, s.PeerPubKeys)
+	resp, newInboundKey, err := ProcessRekeyRequest(req, s.OwnKeys, s.PeerPubKeys, s.CipherSuite)
 	if err != nil {
 		return nil, fmt.Errorf("process rekey request: %w", err)
 	}
@@ -232,7 +235,7 @@ func (s *Session) HandleRekeyResponse(resp *bindings.RekeyResponse) error {
 	}
 
 	// Process peer's seeds for our inbound direction.
-	newInboundKey, err := ProcessRekeyResponse(resp, s.OwnKeys, s.PeerPubKeys)
+	newInboundKey, err := ProcessRekeyResponse(resp, s.OwnKeys, s.PeerPubKeys, s.CipherSuite)
 	if err != nil {
 		return fmt.Errorf("process rekey response: %w", err)
 	}

--- a/tests/cipher_test.go
+++ b/tests/cipher_test.go
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package tests
+
+import (
+	"bytes"
+	"crypto/rand"
+	"net"
+	"testing"
+
+	"github.com/KeibiSoft/KeibiDrop/pkg/crypto"
+	"github.com/KeibiSoft/KeibiDrop/pkg/session"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCipherNegotiation(t *testing.T) {
+	t.Run("HasHardwareAES", func(t *testing.T) {
+		has := crypto.HasHardwareAES()
+		t.Logf("Hardware AES: %v", has)
+		// On this machine (Intel i7 with AES-NI), should be true
+		supported := crypto.SupportedCiphers()
+		t.Logf("Supported ciphers: %v", supported)
+		if has {
+			require.Equal(t, crypto.CipherAES256, supported[0], "AES-256-GCM should be preferred on AES-NI hardware")
+		} else {
+			require.Equal(t, crypto.CipherChaCha20, supported[0], "ChaCha20 should be preferred without AES-NI")
+		}
+	})
+
+	t.Run("NegotiateBothAES", func(t *testing.T) {
+		local := []crypto.CipherSuite{crypto.CipherAES256, crypto.CipherChaCha20}
+		remote := []crypto.CipherSuite{crypto.CipherAES256, crypto.CipherChaCha20}
+		result := crypto.NegotiateCipher(local, remote)
+		require.Equal(t, crypto.CipherAES256, result)
+	})
+
+	t.Run("NegotiateFallbackChaCha", func(t *testing.T) {
+		local := []crypto.CipherSuite{crypto.CipherAES256, crypto.CipherChaCha20}
+		remote := []crypto.CipherSuite{crypto.CipherChaCha20} // no AES support
+		result := crypto.NegotiateCipher(local, remote)
+		require.Equal(t, crypto.CipherChaCha20, result)
+	})
+
+	t.Run("NegotiateChaChaOnly", func(t *testing.T) {
+		local := []crypto.CipherSuite{crypto.CipherChaCha20}
+		remote := []crypto.CipherSuite{crypto.CipherChaCha20}
+		result := crypto.NegotiateCipher(local, remote)
+		require.Equal(t, crypto.CipherChaCha20, result)
+	})
+}
+
+func TestSecureConnBothCiphers(t *testing.T) {
+	suites := []crypto.CipherSuite{crypto.CipherChaCha20, crypto.CipherAES256}
+
+	for _, suite := range suites {
+		t.Run(string(suite), func(t *testing.T) {
+			require := require.New(t)
+
+			// Generate a random 32-byte key.
+			key := make([]byte, 32)
+			_, err := rand.Read(key)
+			require.NoError(err)
+
+			// Create a pipe to simulate a network connection.
+			serverConn, clientConn := net.Pipe()
+			defer serverConn.Close()
+			defer clientConn.Close()
+
+			server := session.NewSecureConn(serverConn, key, suite)
+			client := session.NewSecureConn(clientConn, key, suite)
+
+			// Test: client writes, server reads.
+			testData := []byte("Hello from encrypted connection using " + string(suite))
+
+			go func() {
+				_, err := client.Write(testData)
+				if err != nil {
+					t.Errorf("client write: %v", err)
+				}
+			}()
+
+			buf := make([]byte, 1024)
+			n, err := server.Read(buf)
+			require.NoError(err)
+			require.Equal(testData, buf[:n])
+
+			// Test: large message (1MB).
+			bigData := make([]byte, 1024*1024)
+			_, err = rand.Read(bigData)
+			require.NoError(err)
+
+			go func() {
+				_, err := client.Write(bigData)
+				if err != nil {
+					t.Errorf("client write big: %v", err)
+				}
+			}()
+
+			received := make([]byte, 0, len(bigData))
+			for len(received) < len(bigData) {
+				n, err := server.Read(buf)
+				require.NoError(err)
+				received = append(received, buf[:n]...)
+			}
+			require.True(bytes.Equal(bigData, received), "large message mismatch")
+		})
+	}
+}
+
+func TestKeyDerivationDomainSeparation(t *testing.T) {
+	require := require.New(t)
+
+	// Same input secrets, different cipher suites → different keys.
+	secret := make([]byte, 32)
+	_, err := rand.Read(secret)
+	require.NoError(err)
+
+	chachaKey, err := crypto.DeriveKey(crypto.CipherChaCha20, secret)
+	require.NoError(err)
+
+	aesKey, err := crypto.DeriveKey(crypto.CipherAES256, secret)
+	require.NoError(err)
+
+	require.False(bytes.Equal(chachaKey, aesKey), "different cipher suites must produce different keys (domain separation)")
+	require.Len(chachaKey, 32)
+	require.Len(aesKey, 32)
+}

--- a/tests/rekey_test.go
+++ b/tests/rekey_test.go
@@ -77,7 +77,7 @@ func TestRekeyRequest_KeyDerivation(t *testing.T) {
 		aliceOwn, alicePeer, bobOwn, bobPeer := generateTestKeyPairs(t)
 
 		// Alice creates a rekey request.
-		req, aliceNewKey, err := session.CreateRekeyRequest(aliceOwn, alicePeer, 1)
+		req, aliceNewKey, err := session.CreateRekeyRequest(aliceOwn, alicePeer, 1, crypto.CipherChaCha20)
 		if err != nil {
 			t.Errorf("CreateRekeyRequest failed: %v", err)
 			done <- false
@@ -91,7 +91,7 @@ func TestRekeyRequest_KeyDerivation(t *testing.T) {
 		}
 
 		// Bob processes the request.
-		resp, bobNewKey, err := session.ProcessRekeyRequest(req, bobOwn, bobPeer)
+		resp, bobNewKey, err := session.ProcessRekeyRequest(req, bobOwn, bobPeer, crypto.CipherChaCha20)
 		if err != nil {
 			t.Errorf("ProcessRekeyRequest failed: %v", err)
 			done <- false
@@ -134,7 +134,7 @@ func TestRekeyResponse_KeyDerivation(t *testing.T) {
 		aliceOwn, alicePeer, bobOwn, bobPeer := generateTestKeyPairs(t)
 
 		// Alice initiates rekey.
-		req, _, err := session.CreateRekeyRequest(aliceOwn, alicePeer, 1)
+		req, _, err := session.CreateRekeyRequest(aliceOwn, alicePeer, 1, crypto.CipherChaCha20)
 		if err != nil {
 			t.Errorf("CreateRekeyRequest failed: %v", err)
 			done <- false
@@ -142,7 +142,7 @@ func TestRekeyResponse_KeyDerivation(t *testing.T) {
 		}
 
 		// Bob processes request and creates response.
-		resp, _, err := session.ProcessRekeyRequest(req, bobOwn, bobPeer)
+		resp, _, err := session.ProcessRekeyRequest(req, bobOwn, bobPeer, crypto.CipherChaCha20)
 		if err != nil {
 			t.Errorf("ProcessRekeyRequest failed: %v", err)
 			done <- false
@@ -150,7 +150,7 @@ func TestRekeyResponse_KeyDerivation(t *testing.T) {
 		}
 
 		// Alice processes Bob's response.
-		newKey, err := session.ProcessRekeyResponse(resp, aliceOwn, alicePeer)
+		newKey, err := session.ProcessRekeyResponse(resp, aliceOwn, alicePeer, crypto.CipherChaCha20)
 		if err != nil {
 			t.Errorf("ProcessRekeyResponse failed: %v", err)
 			done <- false
@@ -194,7 +194,7 @@ func TestRekeyRequest_MissingSeeds(t *testing.T) {
 			Epoch: 1,
 		}
 
-		_, _, err := session.ProcessRekeyRequest(badReq, bobOwn, bobPeer)
+		_, _, err := session.ProcessRekeyRequest(badReq, bobOwn, bobPeer, crypto.CipherChaCha20)
 		if err == nil {
 			t.Error("Expected error for missing x25519 seed")
 			done <- false
@@ -226,7 +226,7 @@ func TestRekeyEpochIncreases(t *testing.T) {
 		var prevEpoch uint64
 		for i := 1; i <= 5; i++ {
 			epoch := uint64(i)
-			req, _, err := session.CreateRekeyRequest(aliceOwn, alicePeer, epoch)
+			req, _, err := session.CreateRekeyRequest(aliceOwn, alicePeer, epoch, crypto.CipherChaCha20)
 			if err != nil {
 				t.Errorf("CreateRekeyRequest failed at epoch %d: %v", epoch, err)
 				done <- false
@@ -269,7 +269,7 @@ func TestMultipleRekeys(t *testing.T) {
 			epoch := uint64(i)
 
 			// Alice initiates.
-			req, aliceKey, err := session.CreateRekeyRequest(aliceOwn, alicePeer, epoch)
+			req, aliceKey, err := session.CreateRekeyRequest(aliceOwn, alicePeer, epoch, crypto.CipherChaCha20)
 			if err != nil {
 				t.Errorf("Rekey %d CreateRekeyRequest failed: %v", i, err)
 				done <- false
@@ -277,7 +277,7 @@ func TestMultipleRekeys(t *testing.T) {
 			}
 
 			// Bob processes.
-			resp, bobKey, err := session.ProcessRekeyRequest(req, bobOwn, bobPeer)
+			resp, bobKey, err := session.ProcessRekeyRequest(req, bobOwn, bobPeer, crypto.CipherChaCha20)
 			if err != nil {
 				t.Errorf("Rekey %d ProcessRekeyRequest failed: %v", i, err)
 				done <- false
@@ -333,12 +333,12 @@ func TestCompromisedKeyLimitedExposure(t *testing.T) {
 		aliceOwn, alicePeer, bobOwn, bobPeer := generateTestKeyPairs(t)
 
 		// Generate key for epoch 1.
-		req1, key1, _ := session.CreateRekeyRequest(aliceOwn, alicePeer, 1)
-		_, bobKey1, _ := session.ProcessRekeyRequest(req1, bobOwn, bobPeer)
+		req1, key1, _ := session.CreateRekeyRequest(aliceOwn, alicePeer, 1, crypto.CipherChaCha20)
+		_, bobKey1, _ := session.ProcessRekeyRequest(req1, bobOwn, bobPeer, crypto.CipherChaCha20)
 
 		// Generate key for epoch 2.
-		req2, key2, _ := session.CreateRekeyRequest(aliceOwn, alicePeer, 2)
-		_, bobKey2, _ := session.ProcessRekeyRequest(req2, bobOwn, bobPeer)
+		req2, key2, _ := session.CreateRekeyRequest(aliceOwn, alicePeer, 2, crypto.CipherChaCha20)
+		_, bobKey2, _ := session.ProcessRekeyRequest(req2, bobOwn, bobPeer, crypto.CipherChaCha20)
 
 		// Verify keys match within each epoch.
 		if !bytes.Equal(key1, bobKey1) {
@@ -397,7 +397,7 @@ func TestRekeyRequest_NilKeys(t *testing.T) {
 
 	go func() {
 		// Test with nil OwnKeys.
-		_, _, err := session.CreateRekeyRequest(nil, &crypto.PeerKeys{}, 1)
+		_, _, err := session.CreateRekeyRequest(nil, &crypto.PeerKeys{}, 1, crypto.CipherChaCha20)
 		if err == nil {
 			t.Error("Expected error for nil OwnKeys")
 			done <- false
@@ -406,7 +406,7 @@ func TestRekeyRequest_NilKeys(t *testing.T) {
 
 		// Test with nil PeerKeys.
 		aliceOwn, _, _, _ := generateTestKeyPairs(t)
-		_, _, err = session.CreateRekeyRequest(aliceOwn, nil, 1)
+		_, _, err = session.CreateRekeyRequest(aliceOwn, nil, 1, crypto.CipherChaCha20)
 		if err == nil {
 			t.Error("Expected error for nil PeerKeys")
 			done <- false


### PR DESCRIPTION
| Metric | ChaCha20 (before) | AES-256-GCM (after) | Change |
|--------|-------------------|---------------------|--------|
| Encrypted gRPC (1GB) | 442 MB/s | **490 MB/s** | **+11%** |
| FUSE E2E (1GB) | 233 MB/s | **233 MB/s** | same |
| gRPC baseline (100MB) | 367 MB/s | **503 MB/s** | **+37%** |
