### PR TITLE
feat: add local network direct connection mode

### DIFF
--- a/cmd/kd/main.go
+++ b/cmd/kd/main.go
@@ -96,6 +96,7 @@ func runDaemon() {
 	}
 
 	isFuse := checkfuse.IsFUSEPresent() && !cfg.NoFUSE
+	isLocal := os.Getenv("KD_LOCAL") != ""
 
 	// Setup logger
 	var logWriter *os.File = os.Stderr
@@ -119,6 +120,7 @@ func runDaemon() {
 		fmt.Fprintf(os.Stderr, `{"ok":false,"error":"init failed: %s"}`+"\n", err)
 		os.Exit(1)
 	}
+	kd.IsLocalMode = isLocal
 	go kd.Run()
 
 	// Listen on Unix socket
@@ -145,6 +147,11 @@ func runDaemon() {
 		"mount_path":  cfg.MountPath,
 		"log_file":    cfg.LogFile,
 		"config_path": config.ConfigPath(),
+	}
+	if isLocal {
+		addr, _ := common.GetLinkLocalAddress(kd.InboundPort())
+		startData["local_mode"] = true
+		startData["local_address"] = addr
 	}
 	b, _ := json.Marshal(Response{OK: true, Data: mustMarshal(startData)})
 	fmt.Println(string(b))
@@ -198,7 +205,14 @@ func dispatch(kd *common.KeibiDrop, req Request, cancel context.CancelFunc, ln n
 
 	case "register":
 		if len(req.Args) < 1 {
-			return errResponse("usage: kd register <fingerprint>")
+			return errResponse("usage: kd register <fingerprint-or-address>")
+		}
+		if kd.IsLocalMode {
+			err := kd.SetPeerDirectAddress(req.Args[0])
+			if err != nil {
+				return errResponse(err.Error())
+			}
+			return okResponse(map[string]string{"registered_address": req.Args[0]})
 		}
 		err := kd.AddPeerFingerprint(req.Args[0])
 		if err != nil {
@@ -279,11 +293,19 @@ func cmdShow(kd *common.KeibiDrop, args []string) Response {
 	}
 
 	if showAll || what == "fingerprint" {
-		fp, err := kd.ExportFingerprint()
-		if err != nil {
-			return errResponse(err.Error())
+		if kd.IsLocalMode {
+			addr, err := common.GetLinkLocalAddress(kd.InboundPort())
+			if err != nil {
+				return errResponse(err.Error())
+			}
+			data["local_address"] = addr
+		} else {
+			fp, err := kd.ExportFingerprint()
+			if err != nil {
+				return errResponse(err.Error())
+			}
+			data["fingerprint"] = fp
 		}
-		data["fingerprint"] = fp
 	}
 	if showAll || what == "ip" {
 		data["ip"] = kd.LocalIPv6IP

--- a/mobile/mobile.go
+++ b/mobile/mobile.go
@@ -494,6 +494,28 @@ func (api *API) HasResumableDownload(remoteName string) bool {
 	return err == nil
 }
 
+// GetLocalAddress returns the link-local IPv6 address for local mode connections.
+// Format: "fe80::1234:5678%en0:26431"
+func (api *API) GetLocalAddress() string {
+	port := 26431 // default inbound port
+	if api.kd != nil {
+		port = api.kd.InboundPort()
+	}
+	addr, err := common.GetLinkLocalAddress(port)
+	if err != nil {
+		return ""
+	}
+	return addr
+}
+
+// SetPeerDirectAddress sets the peer's link-local address for local mode (no relay).
+func (api *API) SetPeerDirectAddress(addr string) error {
+	if api.kd == nil {
+		return fmt.Errorf("not initialized")
+	}
+	return api.kd.SetPeerDirectAddress(addr)
+}
+
 // RelayEndpoint returns the relay URL string.
 func (api *API) RelayEndpoint() string {
 	if api.kd == nil {

--- a/pkg/filesystem/fuse_directory.go
+++ b/pkg/filesystem/fuse_directory.go
@@ -1171,28 +1171,38 @@ func (d *Dir) Release(path string, fh uint64) (errCode int) {
 				// Defer notification with exponential back-off until the file
 				// size stabilizes (two consecutive lstats return the same size).
 				go func() {
-					prevSize := stgo.Size
-					for attempt := 0; attempt < 10; attempt++ {
-						delay := time.Duration(200+attempt*100) * time.Millisecond
+					// Wait for fcopyfile to finish. Require 3 consecutive lstats
+					// with the same size, starting after a 500ms initial delay.
+					// fcopyfile on large files can pause between writes, so 2
+					// matches isn't enough (469 MB -> 469 MB -> then 611 MB).
+					time.Sleep(500 * time.Millisecond)
+					prevSize := int64(-1)
+					stableCount := 0
+					for attempt := 0; attempt < 15; attempt++ {
+						delay := time.Duration(300+attempt*100) * time.Millisecond
 						time.Sleep(delay)
 						if f.openFileCounter.CountOpenDescriptors() > 0 {
-							return // File reopened, that Release will handle it.
+							return
 						}
 						recheckStat, recheckErr := platLstat(cleanPath)
 						if recheckErr != nil {
 							logger.Error("Deferred lstat failed", "path", path, "error", recheckErr)
 							return
 						}
-						if recheckStat.Size == prevSize {
-							// Size stabilized. Send notification.
-							d.OnLocalChange(types.FileEvent{
-								Path:   path,
-								Action: types.AddFile,
-								Attr:   types.StatToAttr(&recheckStat),
-							})
-							f.NotRemoteSynced = false
-							f.HadEdits = false
-							return
+						if recheckStat.Size == prevSize && recheckStat.Size > 0 {
+							stableCount++
+							if stableCount >= 2 {
+								d.OnLocalChange(types.FileEvent{
+									Path:   path,
+									Action: types.AddFile,
+									Attr:   types.StatToAttr(&recheckStat),
+								})
+								f.NotRemoteSynced = false
+								f.HadEdits = false
+								return
+							}
+						} else {
+							stableCount = 0
 						}
 						prevSize = recheckStat.Size
 					}

--- a/pkg/logic/common/helpers.go
+++ b/pkg/logic/common/helpers.go
@@ -27,8 +27,16 @@ func GetLinkLocalAddress(port int) (string, error) {
 		return "", err
 	}
 
-	// First pass: look for a real link-local unicast address.
+	// Collect all link-local candidates from non-loopback, up interfaces.
+	type candidate struct {
+		ip    net.IP
+		iface string
+	}
+	var candidates []candidate
 	for _, iface := range ifaces {
+		if iface.Flags&net.FlagLoopback != 0 || iface.Flags&net.FlagUp == 0 {
+			continue
+		}
 		addrs, _ := iface.Addrs()
 		for _, addr := range addrs {
 			ip, _, err := net.ParseCIDR(addr.String())
@@ -36,9 +44,34 @@ func GetLinkLocalAddress(port int) (string, error) {
 				continue
 			}
 			if ip.To16() != nil && ip.To4() == nil && ip.IsLinkLocalUnicast() {
-				return fmt.Sprintf("%s%%%s:%d", ip.String(), iface.Name, port), nil
+				candidates = append(candidates, candidate{ip: ip, iface: iface.Name})
 			}
 		}
+	}
+
+	if len(candidates) > 0 {
+		// Prefer common LAN interfaces: en0 (macOS WiFi), eth0/wlan0 (Linux).
+		// Avoid utun*, awdl*, llw*, ap* (VPN, AirDrop, low-latency WLAN, access point).
+		preferred := []string{"en0", "eth0", "wlan0", "en1", "wlp", "enp"}
+		for _, pref := range preferred {
+			for _, c := range candidates {
+				if strings.HasPrefix(c.iface, pref) {
+					return fmt.Sprintf("%s%%%s:%d", c.ip.String(), c.iface, port), nil
+				}
+			}
+		}
+		// No preferred match, pick first non-virtual candidate.
+		for _, c := range candidates {
+			skip := strings.HasPrefix(c.iface, "utun") ||
+				strings.HasPrefix(c.iface, "awdl") ||
+				strings.HasPrefix(c.iface, "llw")
+			if !skip {
+				return fmt.Sprintf("%s%%%s:%d", c.ip.String(), c.iface, port), nil
+			}
+		}
+		// All candidates are virtual, use first one anyway.
+		c := candidates[0]
+		return fmt.Sprintf("%s%%%s:%d", c.ip.String(), c.iface, port), nil
 	}
 
 	// Fallback: accept loopback for local testing.

--- a/pkg/logic/common/helpers.go
+++ b/pkg/logic/common/helpers.go
@@ -14,7 +14,136 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strconv"
+	"strings"
 )
+
+// GetLinkLocalAddress finds a link-local IPv6 address on this machine and
+// returns it formatted as "ip%zone:port" for direct LAN peer connections.
+// Falls back to loopback (::1) when no link-local interface is available.
+func GetLinkLocalAddress(port int) (string, error) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return "", err
+	}
+
+	// First pass: look for a real link-local unicast address.
+	for _, iface := range ifaces {
+		addrs, _ := iface.Addrs()
+		for _, addr := range addrs {
+			ip, _, err := net.ParseCIDR(addr.String())
+			if err != nil {
+				continue
+			}
+			if ip.To16() != nil && ip.To4() == nil && ip.IsLinkLocalUnicast() {
+				return fmt.Sprintf("%s%%%s:%d", ip.String(), iface.Name, port), nil
+			}
+		}
+	}
+
+	// Fallback: accept loopback for local testing.
+	for _, iface := range ifaces {
+		addrs, _ := iface.Addrs()
+		for _, addr := range addrs {
+			ip, _, err := net.ParseCIDR(addr.String())
+			if err != nil {
+				continue
+			}
+			if ip.To16() != nil && ip.To4() == nil && ip.IsLoopback() {
+				return fmt.Sprintf("%s:%d", ip.String(), port), nil
+			}
+		}
+	}
+
+	return "", fmt.Errorf("no link-local or loopback IPv6 address found")
+}
+
+// ParsePeerDirectAddress parses a direct LAN peer address in the format
+// "ip%zone:port" (link-local) or "ip:port" (loopback). Returns the IP,
+// zone identifier, port number, and any error.
+func ParsePeerDirectAddress(addr string) (ip string, zone string, port int, err error) {
+	if addr == "" {
+		return "", "", 0, fmt.Errorf("empty address")
+	}
+
+	// If there is a zone (%...), the format is: ip%zone:port
+	// Split on % first to detect zone presence.
+	if idx := strings.Index(addr, "%"); idx != -1 {
+		ipPart := addr[:idx]
+		rest := addr[idx+1:] // "zone:port"
+
+		lastColon := strings.LastIndex(rest, ":")
+		if lastColon == -1 {
+			return "", "", 0, fmt.Errorf("missing port in address %q", addr)
+		}
+		zone = rest[:lastColon]
+		portStr := rest[lastColon+1:]
+
+		port, err = strconv.Atoi(portStr)
+		if err != nil {
+			return "", "", 0, fmt.Errorf("invalid port %q: %w", portStr, err)
+		}
+
+		parsedIP := net.ParseIP(ipPart)
+		if parsedIP == nil {
+			return "", "", 0, fmt.Errorf("invalid IP %q", ipPart)
+		}
+		if parsedIP.To4() != nil {
+			return "", "", 0, fmt.Errorf("IPv4 addresses not supported: %q", ipPart)
+		}
+		if !parsedIP.IsLinkLocalUnicast() && !parsedIP.IsLoopback() {
+			return "", "", 0, fmt.Errorf("address must be link-local or loopback: %q", ipPart)
+		}
+
+		if port < 26000 || port > 27000 {
+			return "", "", 0, fmt.Errorf("port %d out of range 26000-27000", port)
+		}
+
+		return ipPart, zone, port, nil
+	}
+
+	// No zone: could be loopback (::1:port) or ambiguous link-local.
+	// For loopback, the known format is "::1:PORT" where PORT is the last
+	// colon-separated segment and "::1" is the IP.
+	// For anything starting with fe80, require a zone — reject as ambiguous.
+	if strings.HasPrefix(addr, "fe80") {
+		return "", "", 0, fmt.Errorf("link-local address requires zone ID (%%iface): %q", addr)
+	}
+
+	lastColon := strings.LastIndex(addr, ":")
+	if lastColon == -1 || lastColon == 0 {
+		return "", "", 0, fmt.Errorf("invalid address format %q", addr)
+	}
+
+	ipPart := addr[:lastColon]
+	portStr := addr[lastColon+1:]
+
+	if portStr == "" {
+		return "", "", 0, fmt.Errorf("missing port in address %q", addr)
+	}
+
+	port, err = strconv.Atoi(portStr)
+	if err != nil {
+		return "", "", 0, fmt.Errorf("invalid port %q: %w", portStr, err)
+	}
+
+	parsedIP := net.ParseIP(ipPart)
+	if parsedIP == nil {
+		return "", "", 0, fmt.Errorf("invalid IP %q", ipPart)
+	}
+	if parsedIP.To4() != nil {
+		return "", "", 0, fmt.Errorf("IPv4 addresses not supported: %q", ipPart)
+	}
+	if !parsedIP.IsLoopback() {
+		return "", "", 0, fmt.Errorf("non-loopback address without zone ID: %q", ipPart)
+	}
+
+	if port < 26000 || port > 27000 {
+		return "", "", 0, fmt.Errorf("port %d out of range 26000-27000", port)
+	}
+
+	return ipPart, "", port, nil
+}
 
 func GetLocalIPv6() (string, error) {
 	ifaces, err := net.Interfaces()

--- a/pkg/logic/common/helpers_test.go
+++ b/pkg/logic/common/helpers_test.go
@@ -1,0 +1,143 @@
+// ABOUTME: Tests for local-mode helper functions — address discovery and parsing.
+// ABOUTME: Covers GetLinkLocalAddress and ParsePeerDirectAddress for LAN connectivity.
+package common
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGetLinkLocalAddress(t *testing.T) {
+	addr, err := GetLinkLocalAddress(26431)
+	if err != nil {
+		t.Fatalf("GetLinkLocalAddress returned error: %v", err)
+	}
+
+	// Result must contain a zone separator (%) and a port separator (:).
+	if !strings.Contains(addr, ":") {
+		t.Errorf("expected address to contain ':', got %q", addr)
+	}
+}
+
+func TestGetLinkLocalAddress_PortInResult(t *testing.T) {
+	addr, err := GetLinkLocalAddress(26999)
+	if err != nil {
+		t.Fatalf("GetLinkLocalAddress returned error: %v", err)
+	}
+
+	// The port must appear at the very end after the last colon.
+	lastColon := strings.LastIndex(addr, ":")
+	if lastColon == -1 {
+		t.Fatalf("no colon in address %q", addr)
+	}
+	portStr := addr[lastColon+1:]
+	if portStr != "26999" {
+		t.Errorf("expected port 26999 at end of address, got %q (full: %q)", portStr, addr)
+	}
+}
+
+func TestParsePeerDirectAddress_Valid(t *testing.T) {
+	ip, zone, port, err := ParsePeerDirectAddress("fe80::1%eth0:26431")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ip != "fe80::1" {
+		t.Errorf("ip = %q, want %q", ip, "fe80::1")
+	}
+	if zone != "eth0" {
+		t.Errorf("zone = %q, want %q", zone, "eth0")
+	}
+	if port != 26431 {
+		t.Errorf("port = %d, want %d", port, 26431)
+	}
+}
+
+func TestParsePeerDirectAddress_ValidLongAddr(t *testing.T) {
+	ip, zone, port, err := ParsePeerDirectAddress("fe80::abcd:ef01:2345:6789%wlan0:26500")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ip != "fe80::abcd:ef01:2345:6789" {
+		t.Errorf("ip = %q, want %q", ip, "fe80::abcd:ef01:2345:6789")
+	}
+	if zone != "wlan0" {
+		t.Errorf("zone = %q, want %q", zone, "wlan0")
+	}
+	if port != 26500 {
+		t.Errorf("port = %d, want %d", port, 26500)
+	}
+}
+
+func TestParsePeerDirectAddress_Loopback(t *testing.T) {
+	ip, zone, port, err := ParsePeerDirectAddress("::1:26431")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ip != "::1" {
+		t.Errorf("ip = %q, want %q", ip, "::1")
+	}
+	if zone != "" {
+		t.Errorf("zone = %q, want empty", zone)
+	}
+	if port != 26431 {
+		t.Errorf("port = %d, want %d", port, 26431)
+	}
+}
+
+func TestParsePeerDirectAddress_IPv4_Rejected(t *testing.T) {
+	_, _, _, err := ParsePeerDirectAddress("192.168.1.1:26431")
+	if err == nil {
+		t.Fatal("expected error for IPv4 address, got nil")
+	}
+}
+
+func TestParsePeerDirectAddress_BadPort_TooHigh(t *testing.T) {
+	_, _, _, err := ParsePeerDirectAddress("fe80::1%eth0:99999")
+	if err == nil {
+		t.Fatal("expected error for port too high, got nil")
+	}
+}
+
+func TestParsePeerDirectAddress_BadPort_TooLow(t *testing.T) {
+	_, _, _, err := ParsePeerDirectAddress("fe80::1%eth0:100")
+	if err == nil {
+		t.Fatal("expected error for port too low, got nil")
+	}
+}
+
+func TestParsePeerDirectAddress_BadPort_NotNumber(t *testing.T) {
+	_, _, _, err := ParsePeerDirectAddress("fe80::1%eth0:abc")
+	if err == nil {
+		t.Fatal("expected error for non-numeric port, got nil")
+	}
+}
+
+func TestParsePeerDirectAddress_MissingZone_LinkLocal(t *testing.T) {
+	// fe80::1:26431 is ambiguous — looks like part of IPv6 address.
+	// Should return an error because link-local without zone is unusable.
+	_, _, _, err := ParsePeerDirectAddress("fe80::1:26431")
+	if err == nil {
+		t.Fatal("expected error for link-local without zone, got nil")
+	}
+}
+
+func TestParsePeerDirectAddress_EmptyString(t *testing.T) {
+	_, _, _, err := ParsePeerDirectAddress("")
+	if err == nil {
+		t.Fatal("expected error for empty string, got nil")
+	}
+}
+
+func TestParsePeerDirectAddress_JustPort(t *testing.T) {
+	_, _, _, err := ParsePeerDirectAddress(":26431")
+	if err == nil {
+		t.Fatal("expected error for just port, got nil")
+	}
+}
+
+func TestParsePeerDirectAddress_NoPort(t *testing.T) {
+	_, _, _, err := ParsePeerDirectAddress("fe80::1%eth0")
+	if err == nil {
+		t.Fatal("expected error for missing port, got nil")
+	}
+}

--- a/pkg/logic/common/logic.go
+++ b/pkg/logic/common/logic.go
@@ -397,6 +397,26 @@ func (kd *KeibiDrop) GetPeerFingerprint() (string, error) {
 	return kd.session.ExpectedPeerFingerprint, nil
 }
 
+// SetPeerDirectAddress parses a direct LAN peer address (e.g. "fe80::1%eth0:26431"),
+// stores the peer IP and port, and sets TOFU mode for the handshake.
+func (kd *KeibiDrop) SetPeerDirectAddress(addr string) error {
+	if kd.session == nil {
+		return ErrNilPointer
+	}
+	ip, zone, port, err := ParsePeerDirectAddress(addr)
+	if err != nil {
+		return err
+	}
+	if zone != "" {
+		kd.PeerIPv6IP = ip + "%" + zone
+	} else {
+		kd.PeerIPv6IP = ip
+	}
+	kd.session.PeerPort = port
+	kd.session.ExpectedPeerFingerprint = "TOFU"
+	return nil
+}
+
 func (kd *KeibiDrop) JoinRoom() error {
 	logger := kd.logger.With("method", "join-room")
 	if kd.session == nil {
@@ -423,8 +443,27 @@ func (kd *KeibiDrop) JoinRoom() error {
 		break
 	}
 
-	if err := kd.getRoomFromRelay(kd.session.ExpectedPeerFingerprint); err != nil {
-		return err
+	// In local mode, PeerIPv6IP and PeerPort are already set by SetPeerDirectAddress.
+	if !kd.IsLocalMode {
+		if err := kd.getRoomFromRelay(kd.session.ExpectedPeerFingerprint); err != nil {
+			return err
+		}
+	} else {
+		// Local mode: exchange public keys before the PQC handshake.
+		// The relay normally provides peer keys; we do a plaintext pre-exchange instead.
+		peerAddr := net.JoinHostPort(kd.PeerIPv6IP, strconv.Itoa(kd.session.PeerPort))
+		keyConn, err := net.DialTimeout("tcp", peerAddr, 15*time.Second)
+		if err != nil {
+			logger.Error("Failed to dial for key exchange", "addr", peerAddr, "error", err)
+			return err
+		}
+		if err := session.ExchangePublicKeysLocal(kd.session, keyConn, true); err != nil {
+			keyConn.Close()
+			logger.Error("Failed local key exchange", "error", err)
+			return err
+		}
+		keyConn.Close()
+		logger.Info("Local key exchange complete (join side)")
 	}
 
 	if err := session.PerformOutboundHandshake(kd.session, net.JoinHostPort(kd.PeerIPv6IP, strconv.Itoa(kd.session.PeerPort))); err != nil {
@@ -485,13 +524,15 @@ func (kd *KeibiDrop) CreateRoom() error {
 		return ErrAlreadyRunning
 	}
 
-	if err := kd.registerRoomToRelay(); err != nil {
-		return err
+	if !kd.IsLocalMode {
+		if err := kd.registerRoomToRelay(); err != nil {
+			return err
+		}
 	}
 
 	logger.Info("Waiting for peer to join...")
 
-	// Wait for expected peer fingerprint
+	// Wait for expected peer fingerprint (skip if already set, e.g. local mode TOFU).
 	elapsed := 0
 	for {
 		if elapsed >= Timeout {
@@ -504,6 +545,23 @@ func (kd *KeibiDrop) CreateRoom() error {
 			continue
 		}
 		break
+	}
+
+	// In local mode, exchange public keys before the PQC handshake.
+	// The relay normally provides peer keys; local mode uses a plaintext pre-exchange.
+	if kd.IsLocalMode {
+		keyConn, err := kd.listener.Accept()
+		if err != nil {
+			logger.Error("Failed to accept key exchange connection", "error", err)
+			return err
+		}
+		if err := session.ExchangePublicKeysLocal(kd.session, keyConn, false); err != nil {
+			keyConn.Close()
+			logger.Error("Failed local key exchange", "error", err)
+			return err
+		}
+		keyConn.Close()
+		logger.Info("Local key exchange complete (create side)")
 	}
 
 	conn, err := kd.listener.Accept()
@@ -522,9 +580,14 @@ func (kd *KeibiDrop) CreateRoom() error {
 		return err
 	}
 
-	kd.PeerIPv6IP = addr.IP.String()
+	// Include zone ID for link-local addresses (required for routing on Linux/macOS).
+	peerIP := addr.IP.String()
+	if addr.Zone != "" {
+		peerIP = peerIP + "%" + addr.Zone
+	}
+	kd.PeerIPv6IP = peerIP
 
-	if err := session.PerformOutboundHandshake(kd.session, net.JoinHostPort(addr.IP.String(), strconv.Itoa(kd.session.PeerPort))); err != nil {
+	if err := session.PerformOutboundHandshake(kd.session, net.JoinHostPort(peerIP, strconv.Itoa(kd.session.PeerPort))); err != nil {
 		return err
 	}
 

--- a/pkg/logic/common/resilience.go
+++ b/pkg/logic/common/resilience.go
@@ -34,14 +34,16 @@ func (kd *KeibiDrop) InitConnectionResilience() error {
 	kd.ReconnectManager = session.NewReconnectManager(kd.session, kd.logger)
 	kd.ReconnectManager.CachedPeerIP = kd.PeerIPv6IP
 	kd.ReconnectManager.CachedPeerPort = kd.session.PeerPort
-	kd.ReconnectManager.RelayRefresh = func() error {
-		return kd.registerRoomToRelay()
-	}
-	kd.ReconnectManager.RelayLookup = func(fingerprint string) (string, int, error) {
-		if err := kd.getRoomFromRelay(fingerprint); err != nil {
-			return "", 0, err
+	if !kd.IsLocalMode {
+		kd.ReconnectManager.RelayRefresh = func() error {
+			return kd.registerRoomToRelay()
 		}
-		return kd.PeerIPv6IP, kd.session.PeerPort, nil
+		kd.ReconnectManager.RelayLookup = func(fingerprint string) (string, int, error) {
+			if err := kd.getRoomFromRelay(fingerprint); err != nil {
+				return "", 0, err
+			}
+			return kd.PeerIPv6IP, kd.session.PeerPort, nil
+		}
 	}
 	kd.ReconnectManager.AcceptConn = func(timeout time.Duration) (net.Conn, error) {
 		if tcpL, ok := kd.listener.(*net.TCPListener); ok {
@@ -52,12 +54,14 @@ func (kd *KeibiDrop) InitConnectionResilience() error {
 	}
 	kd.ReconnectManager.OnReconnected = kd.onReconnected
 
-	// Initialize relay keepalive
-	kd.RelayKeepalive = NewRelayKeepalive(kd, kd.logger)
-
 	// Start all components
 	kd.HealthMonitor.Start()
-	kd.RelayKeepalive.Start()
+
+	// Skip relay keepalive in local mode — no relay to keep alive.
+	if !kd.IsLocalMode {
+		kd.RelayKeepalive = NewRelayKeepalive(kd, kd.logger)
+		kd.RelayKeepalive.Start()
+	}
 
 	logger.Info("Connection resilience initialized")
 	return nil

--- a/pkg/logic/common/types.go
+++ b/pkg/logic/common/types.go
@@ -33,6 +33,7 @@ type KeibiDrop struct {
 	RelayEndoint *url.URL
 
 	IsFUSE       bool
+	IsLocalMode  bool
 	OpInProgress atomic.Int32
 
 	session *session.Session
@@ -201,6 +202,9 @@ type EncryptedRegistration struct {
 
 // Map server status errors to semantic errors.
 type ErrorMapperFunc func(statusCode int, err error) error
+
+// InboundPort returns the port this instance listens on for incoming connections.
+func (kd *KeibiDrop) InboundPort() int { return kd.inboundPort }
 
 // IsRunning returns whether the KeibiDrop instance is in a connected session.
 func (kd *KeibiDrop) IsRunning() bool {

--- a/pkg/session/handshake.go
+++ b/pkg/session/handshake.go
@@ -10,6 +10,7 @@ import (
 	"crypto/subtle"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net"
 	"time"
 
@@ -64,7 +65,10 @@ func PerformInboundHandshake(session *Session, conn net.Conn) error {
 		return fmt.Errorf("fingerprint computation failed: %w", err)
 	}
 
-	if subtle.ConstantTimeCompare([]byte(computed), []byte(session.ExpectedPeerFingerprint)) != 1 {
+	if session.ExpectedPeerFingerprint == "TOFU" {
+		logger.Info("Local mode: accepting peer fingerprint (TOFU)", "fingerprint", computed)
+		session.ExpectedPeerFingerprint = computed
+	} else if subtle.ConstantTimeCompare([]byte(computed), []byte(session.ExpectedPeerFingerprint)) != 1 {
 		logger.Error("Fingerprint missmatch")
 		return fmt.Errorf("fingerprint mismatch: got %s, expected %s", computed, session.ExpectedPeerFingerprint)
 	}
@@ -156,6 +160,74 @@ func PerformInboundHandshake(session *Session, conn net.Conn) error {
 	}
 	session.Session.Inbound = secure
 
+	return nil
+}
+
+// keyExchangeMessage is the plaintext message used for local-mode key pre-exchange.
+type keyExchangeMessage struct {
+	PublicKeys map[string]string `json:"public_keys"`
+	Port       int               `json:"port"`
+}
+
+// ExchangePublicKeysLocal performs a plaintext exchange of public keys over conn.
+// In local mode, the relay is skipped, so both peers need each other's keys before
+// the PQC handshake can run. The initiator (joiner) sends first, responder second.
+func ExchangePublicKeysLocal(session *Session, conn net.Conn, isInitiator bool) error {
+	if session == nil || session.OwnKeys == nil {
+		return fmt.Errorf("nil session or keys")
+	}
+	logger := session.logger.With("phase", "local-key-exchange")
+
+	ownMsg := keyExchangeMessage{
+		PublicKeys: map[string]string{
+			"x25519": encodeBase64(session.OwnKeys.X25519Public.Bytes()),
+			"mlkem":  encodeBase64(session.OwnKeys.MlKemPublic.Bytes()),
+		},
+		Port: session.DefaultInboundPort,
+	}
+
+	if isInitiator {
+		// Send our keys first, then read peer's
+		if err := json.NewEncoder(conn).Encode(ownMsg); err != nil {
+			return fmt.Errorf("failed to send key exchange: %w", err)
+		}
+		var peerMsg keyExchangeMessage
+		if err := json.NewDecoder(conn).Decode(&peerMsg); err != nil {
+			return fmt.Errorf("failed to read peer key exchange: %w", err)
+		}
+		return storePeerKeysFromExchange(session, logger, peerMsg)
+	}
+
+	// Responder: read peer's keys first, then send ours
+	var peerMsg keyExchangeMessage
+	if err := json.NewDecoder(conn).Decode(&peerMsg); err != nil {
+		return fmt.Errorf("failed to read peer key exchange: %w", err)
+	}
+	if err := storePeerKeysFromExchange(session, logger, peerMsg); err != nil {
+		return err
+	}
+	if err := json.NewEncoder(conn).Encode(ownMsg); err != nil {
+		return fmt.Errorf("failed to send key exchange: %w", err)
+	}
+	return nil
+}
+
+func storePeerKeysFromExchange(session *Session, logger *slog.Logger, msg keyExchangeMessage) error {
+	pubKeys := make(map[string][]byte, 2)
+	for k, v := range msg.PublicKeys {
+		decoded, err := decodeBase64(v)
+		if err != nil {
+			return fmt.Errorf("invalid base64 key for %s: %w", k, err)
+		}
+		pubKeys[k] = decoded
+	}
+	peerKeys, err := kbc.ParsePeerKeys(pubKeys)
+	if err != nil {
+		return fmt.Errorf("failed to parse peer keys: %w", err)
+	}
+	session.PeerPubKeys = peerKeys
+	session.PeerPort = msg.Port
+	logger.Info("Local key exchange complete", "peer-port", msg.Port)
 	return nil
 }
 

--- a/pkg/session/handshake_test.go
+++ b/pkg/session/handshake_test.go
@@ -1,0 +1,134 @@
+// ABOUTME: Tests for the inbound handshake flow, covering TOFU acceptance
+// ABOUTME: and relay-mode fingerprint rejection.
+
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+
+package session
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net"
+	"os"
+	"testing"
+
+	kbc "github.com/KeibiSoft/KeibiDrop/pkg/crypto"
+	"github.com/stretchr/testify/require"
+)
+
+// buildHandshakeFixture creates two sessions (alice = inbound, bob = outbound)
+// and returns bob's handshake message ready to be sent over a pipe.
+func buildHandshakeFixture(t *testing.T) (*Session, PeerHandshakeMessage) {
+	t.Helper()
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	// Alice (inbound side)
+	alice, err := InitSession(logger, 26002, 26001)
+	require.NoError(t, err, "InitSession for alice")
+
+	// Bob (outbound side) — we only need his keys to build the message
+	bob, err := InitSession(logger, 26004, 26003)
+	require.NoError(t, err, "InitSession for bob")
+
+	// Bob encapsulates seeds using Alice's public keys
+	seed1 := kbc.GenerateSeed()
+	encSeed1, err := kbc.X25519Encapsulate(seed1, bob.OwnKeys.X25519Private, alice.OwnKeys.X25519Public)
+	require.NoError(t, err, "X25519Encapsulate")
+
+	_, encSeed2 := alice.OwnKeys.MlKemPublic.Encapsulate()
+
+	msg := PeerHandshakeMessage{
+		Fingerprint: bob.OwnFingerprint,
+		PublicKeys: map[string]string{
+			"x25519": encodeBase64(bob.OwnKeys.X25519Public.Bytes()),
+			"mlkem":  encodeBase64(bob.OwnKeys.MlKemPublic.Bytes()),
+		},
+		EncSeeds: map[string]string{
+			"x25519": encodeBase64(encSeed1),
+			"mlkem":  encodeBase64(encSeed2),
+		},
+		OutboundPort:     26004,
+		SupportedCiphers: []string{"chacha20-poly1305"},
+	}
+
+	return alice, msg
+}
+
+// pipeWithMessage creates a net.Pipe, writes the JSON message to one end,
+// and returns the other end for the handshake to read from.
+func pipeWithMessage(t *testing.T, msg PeerHandshakeMessage) net.Conn {
+	t.Helper()
+	server, client := net.Pipe()
+
+	go func() {
+		defer server.Close()
+		_ = json.NewEncoder(server).Encode(msg)
+	}()
+
+	return client
+}
+
+func TestPerformInboundHandshake_TOFU_AcceptsAnyFingerprint(t *testing.T) {
+	alice, msg := buildHandshakeFixture(t)
+	alice.ExpectedPeerFingerprint = "TOFU"
+
+	conn := pipeWithMessage(t, msg)
+	defer conn.Close()
+
+	err := PerformInboundHandshake(alice, conn)
+	require.NoError(t, err, "TOFU handshake should succeed with any valid peer")
+}
+
+func TestPerformInboundHandshake_TOFU_StoresActualFingerprint(t *testing.T) {
+	alice, msg := buildHandshakeFixture(t)
+	alice.ExpectedPeerFingerprint = "TOFU"
+
+	conn := pipeWithMessage(t, msg)
+	defer conn.Close()
+
+	err := PerformInboundHandshake(alice, conn)
+	require.NoError(t, err)
+
+	require.NotEqual(t, "TOFU", alice.ExpectedPeerFingerprint,
+		"After TOFU handshake, ExpectedPeerFingerprint must be replaced with the actual fingerprint")
+	require.NotEmpty(t, alice.ExpectedPeerFingerprint,
+		"After TOFU handshake, ExpectedPeerFingerprint must not be empty")
+}
+
+func TestPerformInboundHandshake_RelayMode_RejectsMismatch(t *testing.T) {
+	alice, msg := buildHandshakeFixture(t)
+	alice.ExpectedPeerFingerprint = "obviously-wrong-fingerprint"
+
+	conn := pipeWithMessage(t, msg)
+	defer conn.Close()
+
+	err := PerformInboundHandshake(alice, conn)
+	require.Error(t, err, "Handshake must fail when fingerprint does not match")
+	require.Contains(t, err.Error(), "fingerprint mismatch")
+}
+
+func TestPerformInboundHandshake_ExactMatch_Succeeds(t *testing.T) {
+	alice, msg := buildHandshakeFixture(t)
+
+	// Compute the actual fingerprint of bob's keys so alice expects it
+	bobPubKeys := make(map[string][]byte, 2)
+	for k, v := range msg.PublicKeys {
+		decoded, err := decodeBase64(v)
+		require.NoError(t, err)
+		bobPubKeys[k] = decoded
+	}
+	peerKeys, err := kbc.ParsePeerKeys(bobPubKeys)
+	require.NoError(t, err)
+	fp, err := peerKeys.Fingerprint()
+	require.NoError(t, err)
+
+	alice.ExpectedPeerFingerprint = fp
+
+	conn := pipeWithMessage(t, msg)
+	defer conn.Close()
+
+	err = PerformInboundHandshake(alice, conn)
+	require.NoError(t, err, "Handshake must succeed when fingerprint matches exactly")
+}

--- a/rust/src/bindings.rs
+++ b/rust/src/bindings.rs
@@ -11,147 +11,85 @@ pub struct __BindgenComplex<T> {
     pub re: T,
     pub im: T,
 }
-pub const _STDINT_H: u32 = 1;
-pub const _FEATURES_H: u32 = 1;
-pub const _DEFAULT_SOURCE: u32 = 1;
-pub const __GLIBC_USE_ISOC2X: u32 = 0;
-pub const __USE_ISOC11: u32 = 1;
-pub const __USE_ISOC99: u32 = 1;
-pub const __USE_ISOC95: u32 = 1;
-pub const __USE_POSIX_IMPLICITLY: u32 = 1;
-pub const _POSIX_SOURCE: u32 = 1;
-pub const _POSIX_C_SOURCE: u32 = 200809;
-pub const __USE_POSIX: u32 = 1;
-pub const __USE_POSIX2: u32 = 1;
-pub const __USE_POSIX199309: u32 = 1;
-pub const __USE_POSIX199506: u32 = 1;
-pub const __USE_XOPEN2K: u32 = 1;
-pub const __USE_XOPEN2K8: u32 = 1;
-pub const _ATFILE_SOURCE: u32 = 1;
 pub const __WORDSIZE: u32 = 64;
-pub const __WORDSIZE_TIME64_COMPAT32: u32 = 1;
-pub const __SYSCALL_WORDSIZE: u32 = 64;
-pub const __TIMESIZE: u32 = 64;
-pub const __USE_MISC: u32 = 1;
-pub const __USE_ATFILE: u32 = 1;
-pub const __USE_FORTIFY_LEVEL: u32 = 0;
-pub const __GLIBC_USE_DEPRECATED_GETS: u32 = 0;
-pub const __GLIBC_USE_DEPRECATED_SCANF: u32 = 0;
-pub const __GLIBC_USE_C2X_STRTOL: u32 = 0;
-pub const _STDC_PREDEF_H: u32 = 1;
-pub const __STDC_IEC_559__: u32 = 1;
-pub const __STDC_IEC_60559_BFP__: u32 = 201404;
-pub const __STDC_IEC_559_COMPLEX__: u32 = 1;
-pub const __STDC_IEC_60559_COMPLEX__: u32 = 201404;
-pub const __STDC_ISO_10646__: u32 = 201706;
-pub const __GNU_LIBRARY__: u32 = 6;
-pub const __GLIBC__: u32 = 2;
-pub const __GLIBC_MINOR__: u32 = 39;
-pub const _SYS_CDEFS_H: u32 = 1;
-pub const __glibc_c99_flexarr_available: u32 = 1;
-pub const __LDOUBLE_REDIRECTS_TO_FLOAT128_ABI: u32 = 0;
-pub const __HAVE_GENERIC_SELECTION: u32 = 1;
-pub const __GLIBC_USE_LIB_EXT2: u32 = 0;
-pub const __GLIBC_USE_IEC_60559_BFP_EXT: u32 = 0;
-pub const __GLIBC_USE_IEC_60559_BFP_EXT_C2X: u32 = 0;
-pub const __GLIBC_USE_IEC_60559_EXT: u32 = 0;
-pub const __GLIBC_USE_IEC_60559_FUNCS_EXT: u32 = 0;
-pub const __GLIBC_USE_IEC_60559_FUNCS_EXT_C2X: u32 = 0;
-pub const __GLIBC_USE_IEC_60559_TYPES_EXT: u32 = 0;
-pub const _BITS_TYPES_H: u32 = 1;
-pub const _BITS_TYPESIZES_H: u32 = 1;
-pub const __OFF_T_MATCHES_OFF64_T: u32 = 1;
-pub const __INO_T_MATCHES_INO64_T: u32 = 1;
-pub const __RLIM_T_MATCHES_RLIM64_T: u32 = 1;
-pub const __STATFS_MATCHES_STATFS64: u32 = 1;
-pub const __KERNEL_OLD_TIMEVAL_MATCHES_TIMEVAL64: u32 = 1;
-pub const __FD_SETSIZE: u32 = 1024;
-pub const _BITS_TIME64_H: u32 = 1;
-pub const _BITS_WCHAR_H: u32 = 1;
-pub const _BITS_STDINT_INTN_H: u32 = 1;
-pub const _BITS_STDINT_UINTN_H: u32 = 1;
-pub const _BITS_STDINT_LEAST_H: u32 = 1;
-pub const INT8_MIN: i32 = -128;
-pub const INT16_MIN: i32 = -32768;
-pub const INT32_MIN: i32 = -2147483648;
+pub const __has_safe_buffers: u32 = 1;
+pub const __DARWIN_ONLY_64_BIT_INO_T: u32 = 0;
+pub const __DARWIN_ONLY_UNIX_CONFORMANCE: u32 = 1;
+pub const __DARWIN_ONLY_VERS_1050: u32 = 0;
+pub const __DARWIN_UNIX03: u32 = 1;
+pub const __DARWIN_64_BIT_INO_T: u32 = 1;
+pub const __DARWIN_VERS_1050: u32 = 1;
+pub const __DARWIN_NON_CANCELABLE: u32 = 0;
+pub const __DARWIN_SUF_64_BIT_INO_T: &[u8; 9] = b"$INODE64\0";
+pub const __DARWIN_SUF_1050: &[u8; 6] = b"$1050\0";
+pub const __DARWIN_SUF_EXTSN: &[u8; 14] = b"$DARWIN_EXTSN\0";
+pub const __DARWIN_C_ANSI: u32 = 4096;
+pub const __DARWIN_C_FULL: u32 = 900000;
+pub const __DARWIN_C_LEVEL: u32 = 900000;
+pub const __STDC_WANT_LIB_EXT1__: u32 = 1;
+pub const __DARWIN_NO_LONG_LONG: u32 = 0;
+pub const _DARWIN_FEATURE_64_BIT_INODE: u32 = 1;
+pub const _DARWIN_FEATURE_ONLY_UNIX_CONFORMANCE: u32 = 1;
+pub const _DARWIN_FEATURE_UNIX_CONFORMANCE: u32 = 3;
+pub const __has_ptrcheck: u32 = 0;
+pub const __has_bounds_safety_attributes: u32 = 0;
+pub const USE_CLANG_TYPES: u32 = 0;
+pub const __PTHREAD_SIZE__: u32 = 8176;
+pub const __PTHREAD_ATTR_SIZE__: u32 = 56;
+pub const __PTHREAD_MUTEXATTR_SIZE__: u32 = 8;
+pub const __PTHREAD_MUTEX_SIZE__: u32 = 56;
+pub const __PTHREAD_CONDATTR_SIZE__: u32 = 8;
+pub const __PTHREAD_COND_SIZE__: u32 = 40;
+pub const __PTHREAD_ONCE_SIZE__: u32 = 8;
+pub const __PTHREAD_RWLOCK_SIZE__: u32 = 192;
+pub const __PTHREAD_RWLOCKATTR_SIZE__: u32 = 16;
 pub const INT8_MAX: u32 = 127;
 pub const INT16_MAX: u32 = 32767;
 pub const INT32_MAX: u32 = 2147483647;
+pub const INT64_MAX: u64 = 9223372036854775807;
+pub const INT8_MIN: i32 = -128;
+pub const INT16_MIN: i32 = -32768;
+pub const INT32_MIN: i32 = -2147483648;
+pub const INT64_MIN: i64 = -9223372036854775808;
 pub const UINT8_MAX: u32 = 255;
 pub const UINT16_MAX: u32 = 65535;
 pub const UINT32_MAX: u32 = 4294967295;
+pub const UINT64_MAX: i32 = -1;
 pub const INT_LEAST8_MIN: i32 = -128;
 pub const INT_LEAST16_MIN: i32 = -32768;
 pub const INT_LEAST32_MIN: i32 = -2147483648;
+pub const INT_LEAST64_MIN: i64 = -9223372036854775808;
 pub const INT_LEAST8_MAX: u32 = 127;
 pub const INT_LEAST16_MAX: u32 = 32767;
 pub const INT_LEAST32_MAX: u32 = 2147483647;
+pub const INT_LEAST64_MAX: u64 = 9223372036854775807;
 pub const UINT_LEAST8_MAX: u32 = 255;
 pub const UINT_LEAST16_MAX: u32 = 65535;
 pub const UINT_LEAST32_MAX: u32 = 4294967295;
+pub const UINT_LEAST64_MAX: i32 = -1;
 pub const INT_FAST8_MIN: i32 = -128;
-pub const INT_FAST16_MIN: i64 = -9223372036854775808;
-pub const INT_FAST32_MIN: i64 = -9223372036854775808;
+pub const INT_FAST16_MIN: i32 = -32768;
+pub const INT_FAST32_MIN: i32 = -2147483648;
+pub const INT_FAST64_MIN: i64 = -9223372036854775808;
 pub const INT_FAST8_MAX: u32 = 127;
-pub const INT_FAST16_MAX: u64 = 9223372036854775807;
-pub const INT_FAST32_MAX: u64 = 9223372036854775807;
+pub const INT_FAST16_MAX: u32 = 32767;
+pub const INT_FAST32_MAX: u32 = 2147483647;
+pub const INT_FAST64_MAX: u64 = 9223372036854775807;
 pub const UINT_FAST8_MAX: u32 = 255;
-pub const UINT_FAST16_MAX: i32 = -1;
-pub const UINT_FAST32_MAX: i32 = -1;
-pub const INTPTR_MIN: i64 = -9223372036854775808;
+pub const UINT_FAST16_MAX: u32 = 65535;
+pub const UINT_FAST32_MAX: u32 = 4294967295;
+pub const UINT_FAST64_MAX: i32 = -1;
 pub const INTPTR_MAX: u64 = 9223372036854775807;
+pub const INTPTR_MIN: i64 = -9223372036854775808;
 pub const UINTPTR_MAX: i32 = -1;
-pub const PTRDIFF_MIN: i64 = -9223372036854775808;
-pub const PTRDIFF_MAX: u64 = 9223372036854775807;
+pub const SIZE_MAX: i32 = -1;
+pub const RSIZE_MAX: i32 = -1;
+pub const WINT_MIN: i32 = -2147483648;
+pub const WINT_MAX: u32 = 2147483647;
 pub const SIG_ATOMIC_MIN: i32 = -2147483648;
 pub const SIG_ATOMIC_MAX: u32 = 2147483647;
-pub const SIZE_MAX: i32 = -1;
-pub const WINT_MIN: u32 = 0;
-pub const WINT_MAX: u32 = 4294967295;
 pub type wchar_t = ::std::os::raw::c_int;
-#[repr(C)]
-#[repr(align(16))]
-#[derive(Debug, Copy, Clone)]
-pub struct max_align_t {
-    pub __max_align_ll: ::std::os::raw::c_longlong,
-    pub __bindgen_padding_0: u64,
-    pub __max_align_ld: u128,
-}
-#[test]
-fn bindgen_test_layout_max_align_t() {
-    const UNINIT: ::std::mem::MaybeUninit<max_align_t> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<max_align_t>(),
-        32usize,
-        concat!("Size of: ", stringify!(max_align_t))
-    );
-    assert_eq!(
-        ::std::mem::align_of::<max_align_t>(),
-        16usize,
-        concat!("Alignment of ", stringify!(max_align_t))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).__max_align_ll) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(max_align_t),
-            "::",
-            stringify!(__max_align_ll)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).__max_align_ld) as usize - ptr as usize },
-        16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(max_align_t),
-            "::",
-            stringify!(__max_align_ld)
-        )
-    );
-}
+pub type max_align_t = u128;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _GoString_ {
@@ -199,116 +137,558 @@ extern "C" {
 extern "C" {
     pub fn _GoStringPtr(s: _GoString_) -> *const ::std::os::raw::c_char;
 }
-pub type __u_char = ::std::os::raw::c_uchar;
-pub type __u_short = ::std::os::raw::c_ushort;
-pub type __u_int = ::std::os::raw::c_uint;
-pub type __u_long = ::std::os::raw::c_ulong;
+pub type int_least8_t = i8;
+pub type int_least16_t = i16;
+pub type int_least32_t = i32;
+pub type int_least64_t = i64;
+pub type uint_least8_t = u8;
+pub type uint_least16_t = u16;
+pub type uint_least32_t = u32;
+pub type uint_least64_t = u64;
+pub type int_fast8_t = i8;
+pub type int_fast16_t = i16;
+pub type int_fast32_t = i32;
+pub type int_fast64_t = i64;
+pub type uint_fast8_t = u8;
+pub type uint_fast16_t = u16;
+pub type uint_fast32_t = u32;
+pub type uint_fast64_t = u64;
 pub type __int8_t = ::std::os::raw::c_schar;
 pub type __uint8_t = ::std::os::raw::c_uchar;
 pub type __int16_t = ::std::os::raw::c_short;
 pub type __uint16_t = ::std::os::raw::c_ushort;
 pub type __int32_t = ::std::os::raw::c_int;
 pub type __uint32_t = ::std::os::raw::c_uint;
-pub type __int64_t = ::std::os::raw::c_long;
-pub type __uint64_t = ::std::os::raw::c_ulong;
-pub type __int_least8_t = __int8_t;
-pub type __uint_least8_t = __uint8_t;
-pub type __int_least16_t = __int16_t;
-pub type __uint_least16_t = __uint16_t;
-pub type __int_least32_t = __int32_t;
-pub type __uint_least32_t = __uint32_t;
-pub type __int_least64_t = __int64_t;
-pub type __uint_least64_t = __uint64_t;
-pub type __quad_t = ::std::os::raw::c_long;
-pub type __u_quad_t = ::std::os::raw::c_ulong;
-pub type __intmax_t = ::std::os::raw::c_long;
-pub type __uintmax_t = ::std::os::raw::c_ulong;
-pub type __dev_t = ::std::os::raw::c_ulong;
-pub type __uid_t = ::std::os::raw::c_uint;
-pub type __gid_t = ::std::os::raw::c_uint;
-pub type __ino_t = ::std::os::raw::c_ulong;
-pub type __ino64_t = ::std::os::raw::c_ulong;
-pub type __mode_t = ::std::os::raw::c_uint;
-pub type __nlink_t = ::std::os::raw::c_ulong;
-pub type __off_t = ::std::os::raw::c_long;
-pub type __off64_t = ::std::os::raw::c_long;
-pub type __pid_t = ::std::os::raw::c_int;
+pub type __int64_t = ::std::os::raw::c_longlong;
+pub type __uint64_t = ::std::os::raw::c_ulonglong;
+pub type __darwin_intptr_t = ::std::os::raw::c_long;
+pub type __darwin_natural_t = ::std::os::raw::c_uint;
+pub type __darwin_ct_rune_t = ::std::os::raw::c_int;
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __fsid_t {
-    pub __val: [::std::os::raw::c_int; 2usize],
+#[derive(Copy, Clone)]
+pub union __mbstate_t {
+    pub __mbstate8: [::std::os::raw::c_char; 128usize],
+    pub _mbstateL: ::std::os::raw::c_longlong,
 }
 #[test]
-fn bindgen_test_layout___fsid_t() {
-    const UNINIT: ::std::mem::MaybeUninit<__fsid_t> = ::std::mem::MaybeUninit::uninit();
+fn bindgen_test_layout___mbstate_t() {
+    const UNINIT: ::std::mem::MaybeUninit<__mbstate_t> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of::<__fsid_t>(),
+        ::std::mem::size_of::<__mbstate_t>(),
+        128usize,
+        concat!("Size of: ", stringify!(__mbstate_t))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<__mbstate_t>(),
         8usize,
-        concat!("Size of: ", stringify!(__fsid_t))
+        concat!("Alignment of ", stringify!(__mbstate_t))
     );
     assert_eq!(
-        ::std::mem::align_of::<__fsid_t>(),
-        4usize,
-        concat!("Alignment of ", stringify!(__fsid_t))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).__val) as usize - ptr as usize },
+        unsafe { ::std::ptr::addr_of!((*ptr).__mbstate8) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
-            stringify!(__fsid_t),
+            stringify!(__mbstate_t),
             "::",
-            stringify!(__val)
+            stringify!(__mbstate8)
+        )
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr)._mbstateL) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(__mbstate_t),
+            "::",
+            stringify!(_mbstateL)
         )
     );
 }
-pub type __clock_t = ::std::os::raw::c_long;
-pub type __rlim_t = ::std::os::raw::c_ulong;
-pub type __rlim64_t = ::std::os::raw::c_ulong;
-pub type __id_t = ::std::os::raw::c_uint;
-pub type __time_t = ::std::os::raw::c_long;
-pub type __useconds_t = ::std::os::raw::c_uint;
-pub type __suseconds_t = ::std::os::raw::c_long;
-pub type __suseconds64_t = ::std::os::raw::c_long;
-pub type __daddr_t = ::std::os::raw::c_int;
-pub type __key_t = ::std::os::raw::c_int;
-pub type __clockid_t = ::std::os::raw::c_int;
-pub type __timer_t = *mut ::std::os::raw::c_void;
-pub type __blksize_t = ::std::os::raw::c_long;
-pub type __blkcnt_t = ::std::os::raw::c_long;
-pub type __blkcnt64_t = ::std::os::raw::c_long;
-pub type __fsblkcnt_t = ::std::os::raw::c_ulong;
-pub type __fsblkcnt64_t = ::std::os::raw::c_ulong;
-pub type __fsfilcnt_t = ::std::os::raw::c_ulong;
-pub type __fsfilcnt64_t = ::std::os::raw::c_ulong;
-pub type __fsword_t = ::std::os::raw::c_long;
-pub type __ssize_t = ::std::os::raw::c_long;
-pub type __syscall_slong_t = ::std::os::raw::c_long;
-pub type __syscall_ulong_t = ::std::os::raw::c_ulong;
-pub type __loff_t = __off64_t;
-pub type __caddr_t = *mut ::std::os::raw::c_char;
-pub type __intptr_t = ::std::os::raw::c_long;
-pub type __socklen_t = ::std::os::raw::c_uint;
-pub type __sig_atomic_t = ::std::os::raw::c_int;
-pub type int_least8_t = __int_least8_t;
-pub type int_least16_t = __int_least16_t;
-pub type int_least32_t = __int_least32_t;
-pub type int_least64_t = __int_least64_t;
-pub type uint_least8_t = __uint_least8_t;
-pub type uint_least16_t = __uint_least16_t;
-pub type uint_least32_t = __uint_least32_t;
-pub type uint_least64_t = __uint_least64_t;
-pub type int_fast8_t = ::std::os::raw::c_schar;
-pub type int_fast16_t = ::std::os::raw::c_long;
-pub type int_fast32_t = ::std::os::raw::c_long;
-pub type int_fast64_t = ::std::os::raw::c_long;
-pub type uint_fast8_t = ::std::os::raw::c_uchar;
-pub type uint_fast16_t = ::std::os::raw::c_ulong;
-pub type uint_fast32_t = ::std::os::raw::c_ulong;
-pub type uint_fast64_t = ::std::os::raw::c_ulong;
-pub type intmax_t = __intmax_t;
-pub type uintmax_t = __uintmax_t;
+pub type __darwin_mbstate_t = __mbstate_t;
+pub type __darwin_ptrdiff_t = ::std::os::raw::c_long;
+pub type __darwin_size_t = ::std::os::raw::c_ulong;
+pub type __darwin_va_list = __builtin_va_list;
+pub type __darwin_wchar_t = ::std::os::raw::c_int;
+pub type __darwin_rune_t = __darwin_wchar_t;
+pub type __darwin_wint_t = ::std::os::raw::c_int;
+pub type __darwin_clock_t = ::std::os::raw::c_ulong;
+pub type __darwin_socklen_t = __uint32_t;
+pub type __darwin_ssize_t = ::std::os::raw::c_long;
+pub type __darwin_time_t = ::std::os::raw::c_long;
+pub type __darwin_blkcnt_t = __int64_t;
+pub type __darwin_blksize_t = __int32_t;
+pub type __darwin_dev_t = __int32_t;
+pub type __darwin_fsblkcnt_t = ::std::os::raw::c_uint;
+pub type __darwin_fsfilcnt_t = ::std::os::raw::c_uint;
+pub type __darwin_gid_t = __uint32_t;
+pub type __darwin_id_t = __uint32_t;
+pub type __darwin_ino64_t = __uint64_t;
+pub type __darwin_ino_t = __darwin_ino64_t;
+pub type __darwin_mach_port_name_t = __darwin_natural_t;
+pub type __darwin_mach_port_t = __darwin_mach_port_name_t;
+pub type __darwin_mode_t = __uint16_t;
+pub type __darwin_off_t = __int64_t;
+pub type __darwin_pid_t = __int32_t;
+pub type __darwin_sigset_t = __uint32_t;
+pub type __darwin_suseconds_t = __int32_t;
+pub type __darwin_uid_t = __uint32_t;
+pub type __darwin_useconds_t = __uint32_t;
+pub type __darwin_uuid_t = [::std::os::raw::c_uchar; 16usize];
+pub type __darwin_uuid_string_t = [::std::os::raw::c_char; 37usize];
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __darwin_pthread_handler_rec {
+    pub __routine: ::std::option::Option<unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void)>,
+    pub __arg: *mut ::std::os::raw::c_void,
+    pub __next: *mut __darwin_pthread_handler_rec,
+}
+#[test]
+fn bindgen_test_layout___darwin_pthread_handler_rec() {
+    const UNINIT: ::std::mem::MaybeUninit<__darwin_pthread_handler_rec> =
+        ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
+    assert_eq!(
+        ::std::mem::size_of::<__darwin_pthread_handler_rec>(),
+        24usize,
+        concat!("Size of: ", stringify!(__darwin_pthread_handler_rec))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<__darwin_pthread_handler_rec>(),
+        8usize,
+        concat!("Alignment of ", stringify!(__darwin_pthread_handler_rec))
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).__routine) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(__darwin_pthread_handler_rec),
+            "::",
+            stringify!(__routine)
+        )
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).__arg) as usize - ptr as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(__darwin_pthread_handler_rec),
+            "::",
+            stringify!(__arg)
+        )
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).__next) as usize - ptr as usize },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(__darwin_pthread_handler_rec),
+            "::",
+            stringify!(__next)
+        )
+    );
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _opaque_pthread_attr_t {
+    pub __sig: ::std::os::raw::c_long,
+    pub __opaque: [::std::os::raw::c_char; 56usize],
+}
+#[test]
+fn bindgen_test_layout__opaque_pthread_attr_t() {
+    const UNINIT: ::std::mem::MaybeUninit<_opaque_pthread_attr_t> =
+        ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
+    assert_eq!(
+        ::std::mem::size_of::<_opaque_pthread_attr_t>(),
+        64usize,
+        concat!("Size of: ", stringify!(_opaque_pthread_attr_t))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<_opaque_pthread_attr_t>(),
+        8usize,
+        concat!("Alignment of ", stringify!(_opaque_pthread_attr_t))
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).__sig) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(_opaque_pthread_attr_t),
+            "::",
+            stringify!(__sig)
+        )
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).__opaque) as usize - ptr as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(_opaque_pthread_attr_t),
+            "::",
+            stringify!(__opaque)
+        )
+    );
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _opaque_pthread_cond_t {
+    pub __sig: ::std::os::raw::c_long,
+    pub __opaque: [::std::os::raw::c_char; 40usize],
+}
+#[test]
+fn bindgen_test_layout__opaque_pthread_cond_t() {
+    const UNINIT: ::std::mem::MaybeUninit<_opaque_pthread_cond_t> =
+        ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
+    assert_eq!(
+        ::std::mem::size_of::<_opaque_pthread_cond_t>(),
+        48usize,
+        concat!("Size of: ", stringify!(_opaque_pthread_cond_t))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<_opaque_pthread_cond_t>(),
+        8usize,
+        concat!("Alignment of ", stringify!(_opaque_pthread_cond_t))
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).__sig) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(_opaque_pthread_cond_t),
+            "::",
+            stringify!(__sig)
+        )
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).__opaque) as usize - ptr as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(_opaque_pthread_cond_t),
+            "::",
+            stringify!(__opaque)
+        )
+    );
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _opaque_pthread_condattr_t {
+    pub __sig: ::std::os::raw::c_long,
+    pub __opaque: [::std::os::raw::c_char; 8usize],
+}
+#[test]
+fn bindgen_test_layout__opaque_pthread_condattr_t() {
+    const UNINIT: ::std::mem::MaybeUninit<_opaque_pthread_condattr_t> =
+        ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
+    assert_eq!(
+        ::std::mem::size_of::<_opaque_pthread_condattr_t>(),
+        16usize,
+        concat!("Size of: ", stringify!(_opaque_pthread_condattr_t))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<_opaque_pthread_condattr_t>(),
+        8usize,
+        concat!("Alignment of ", stringify!(_opaque_pthread_condattr_t))
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).__sig) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(_opaque_pthread_condattr_t),
+            "::",
+            stringify!(__sig)
+        )
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).__opaque) as usize - ptr as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(_opaque_pthread_condattr_t),
+            "::",
+            stringify!(__opaque)
+        )
+    );
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _opaque_pthread_mutex_t {
+    pub __sig: ::std::os::raw::c_long,
+    pub __opaque: [::std::os::raw::c_char; 56usize],
+}
+#[test]
+fn bindgen_test_layout__opaque_pthread_mutex_t() {
+    const UNINIT: ::std::mem::MaybeUninit<_opaque_pthread_mutex_t> =
+        ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
+    assert_eq!(
+        ::std::mem::size_of::<_opaque_pthread_mutex_t>(),
+        64usize,
+        concat!("Size of: ", stringify!(_opaque_pthread_mutex_t))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<_opaque_pthread_mutex_t>(),
+        8usize,
+        concat!("Alignment of ", stringify!(_opaque_pthread_mutex_t))
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).__sig) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(_opaque_pthread_mutex_t),
+            "::",
+            stringify!(__sig)
+        )
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).__opaque) as usize - ptr as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(_opaque_pthread_mutex_t),
+            "::",
+            stringify!(__opaque)
+        )
+    );
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _opaque_pthread_mutexattr_t {
+    pub __sig: ::std::os::raw::c_long,
+    pub __opaque: [::std::os::raw::c_char; 8usize],
+}
+#[test]
+fn bindgen_test_layout__opaque_pthread_mutexattr_t() {
+    const UNINIT: ::std::mem::MaybeUninit<_opaque_pthread_mutexattr_t> =
+        ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
+    assert_eq!(
+        ::std::mem::size_of::<_opaque_pthread_mutexattr_t>(),
+        16usize,
+        concat!("Size of: ", stringify!(_opaque_pthread_mutexattr_t))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<_opaque_pthread_mutexattr_t>(),
+        8usize,
+        concat!("Alignment of ", stringify!(_opaque_pthread_mutexattr_t))
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).__sig) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(_opaque_pthread_mutexattr_t),
+            "::",
+            stringify!(__sig)
+        )
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).__opaque) as usize - ptr as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(_opaque_pthread_mutexattr_t),
+            "::",
+            stringify!(__opaque)
+        )
+    );
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _opaque_pthread_once_t {
+    pub __sig: ::std::os::raw::c_long,
+    pub __opaque: [::std::os::raw::c_char; 8usize],
+}
+#[test]
+fn bindgen_test_layout__opaque_pthread_once_t() {
+    const UNINIT: ::std::mem::MaybeUninit<_opaque_pthread_once_t> =
+        ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
+    assert_eq!(
+        ::std::mem::size_of::<_opaque_pthread_once_t>(),
+        16usize,
+        concat!("Size of: ", stringify!(_opaque_pthread_once_t))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<_opaque_pthread_once_t>(),
+        8usize,
+        concat!("Alignment of ", stringify!(_opaque_pthread_once_t))
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).__sig) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(_opaque_pthread_once_t),
+            "::",
+            stringify!(__sig)
+        )
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).__opaque) as usize - ptr as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(_opaque_pthread_once_t),
+            "::",
+            stringify!(__opaque)
+        )
+    );
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _opaque_pthread_rwlock_t {
+    pub __sig: ::std::os::raw::c_long,
+    pub __opaque: [::std::os::raw::c_char; 192usize],
+}
+#[test]
+fn bindgen_test_layout__opaque_pthread_rwlock_t() {
+    const UNINIT: ::std::mem::MaybeUninit<_opaque_pthread_rwlock_t> =
+        ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
+    assert_eq!(
+        ::std::mem::size_of::<_opaque_pthread_rwlock_t>(),
+        200usize,
+        concat!("Size of: ", stringify!(_opaque_pthread_rwlock_t))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<_opaque_pthread_rwlock_t>(),
+        8usize,
+        concat!("Alignment of ", stringify!(_opaque_pthread_rwlock_t))
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).__sig) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(_opaque_pthread_rwlock_t),
+            "::",
+            stringify!(__sig)
+        )
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).__opaque) as usize - ptr as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(_opaque_pthread_rwlock_t),
+            "::",
+            stringify!(__opaque)
+        )
+    );
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _opaque_pthread_rwlockattr_t {
+    pub __sig: ::std::os::raw::c_long,
+    pub __opaque: [::std::os::raw::c_char; 16usize],
+}
+#[test]
+fn bindgen_test_layout__opaque_pthread_rwlockattr_t() {
+    const UNINIT: ::std::mem::MaybeUninit<_opaque_pthread_rwlockattr_t> =
+        ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
+    assert_eq!(
+        ::std::mem::size_of::<_opaque_pthread_rwlockattr_t>(),
+        24usize,
+        concat!("Size of: ", stringify!(_opaque_pthread_rwlockattr_t))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<_opaque_pthread_rwlockattr_t>(),
+        8usize,
+        concat!("Alignment of ", stringify!(_opaque_pthread_rwlockattr_t))
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).__sig) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(_opaque_pthread_rwlockattr_t),
+            "::",
+            stringify!(__sig)
+        )
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).__opaque) as usize - ptr as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(_opaque_pthread_rwlockattr_t),
+            "::",
+            stringify!(__opaque)
+        )
+    );
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _opaque_pthread_t {
+    pub __sig: ::std::os::raw::c_long,
+    pub __cleanup_stack: *mut __darwin_pthread_handler_rec,
+    pub __opaque: [::std::os::raw::c_char; 8176usize],
+}
+#[test]
+fn bindgen_test_layout__opaque_pthread_t() {
+    const UNINIT: ::std::mem::MaybeUninit<_opaque_pthread_t> = ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
+    assert_eq!(
+        ::std::mem::size_of::<_opaque_pthread_t>(),
+        8192usize,
+        concat!("Size of: ", stringify!(_opaque_pthread_t))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<_opaque_pthread_t>(),
+        8usize,
+        concat!("Alignment of ", stringify!(_opaque_pthread_t))
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).__sig) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(_opaque_pthread_t),
+            "::",
+            stringify!(__sig)
+        )
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).__cleanup_stack) as usize - ptr as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(_opaque_pthread_t),
+            "::",
+            stringify!(__cleanup_stack)
+        )
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).__opaque) as usize - ptr as usize },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(_opaque_pthread_t),
+            "::",
+            stringify!(__opaque)
+        )
+    );
+}
+pub type __darwin_pthread_attr_t = _opaque_pthread_attr_t;
+pub type __darwin_pthread_cond_t = _opaque_pthread_cond_t;
+pub type __darwin_pthread_condattr_t = _opaque_pthread_condattr_t;
+pub type __darwin_pthread_key_t = ::std::os::raw::c_ulong;
+pub type __darwin_pthread_mutex_t = _opaque_pthread_mutex_t;
+pub type __darwin_pthread_mutexattr_t = _opaque_pthread_mutexattr_t;
+pub type __darwin_pthread_once_t = _opaque_pthread_once_t;
+pub type __darwin_pthread_rwlock_t = _opaque_pthread_rwlock_t;
+pub type __darwin_pthread_rwlockattr_t = _opaque_pthread_rwlockattr_t;
+pub type __darwin_pthread_t = *mut _opaque_pthread_t;
+pub type intmax_t = ::std::os::raw::c_long;
+pub type uintmax_t = ::std::os::raw::c_ulong;
 pub type GoInt8 = ::std::os::raw::c_schar;
 pub type GoUint8 = ::std::os::raw::c_uchar;
 pub type GoInt16 = ::std::os::raw::c_short;
@@ -555,4 +935,68 @@ extern "C" {
 }
 extern "C" {
     pub fn KD_GetConfigPath() -> *mut ::std::os::raw::c_char;
+}
+pub type __builtin_va_list = [__va_list_tag; 1usize];
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __va_list_tag {
+    pub gp_offset: ::std::os::raw::c_uint,
+    pub fp_offset: ::std::os::raw::c_uint,
+    pub overflow_arg_area: *mut ::std::os::raw::c_void,
+    pub reg_save_area: *mut ::std::os::raw::c_void,
+}
+#[test]
+fn bindgen_test_layout___va_list_tag() {
+    const UNINIT: ::std::mem::MaybeUninit<__va_list_tag> = ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
+    assert_eq!(
+        ::std::mem::size_of::<__va_list_tag>(),
+        24usize,
+        concat!("Size of: ", stringify!(__va_list_tag))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<__va_list_tag>(),
+        8usize,
+        concat!("Alignment of ", stringify!(__va_list_tag))
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).gp_offset) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(__va_list_tag),
+            "::",
+            stringify!(gp_offset)
+        )
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).fp_offset) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(__va_list_tag),
+            "::",
+            stringify!(fp_offset)
+        )
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).overflow_arg_area) as usize - ptr as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(__va_list_tag),
+            "::",
+            stringify!(overflow_arg_area)
+        )
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).reg_save_area) as usize - ptr as usize },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(__va_list_tag),
+            "::",
+            stringify!(reg_save_area)
+        )
+    );
 }

--- a/rust/src/bindings.rs
+++ b/rust/src/bindings.rs
@@ -11,85 +11,147 @@ pub struct __BindgenComplex<T> {
     pub re: T,
     pub im: T,
 }
+pub const _STDINT_H: u32 = 1;
+pub const _FEATURES_H: u32 = 1;
+pub const _DEFAULT_SOURCE: u32 = 1;
+pub const __GLIBC_USE_ISOC2X: u32 = 0;
+pub const __USE_ISOC11: u32 = 1;
+pub const __USE_ISOC99: u32 = 1;
+pub const __USE_ISOC95: u32 = 1;
+pub const __USE_POSIX_IMPLICITLY: u32 = 1;
+pub const _POSIX_SOURCE: u32 = 1;
+pub const _POSIX_C_SOURCE: u32 = 200809;
+pub const __USE_POSIX: u32 = 1;
+pub const __USE_POSIX2: u32 = 1;
+pub const __USE_POSIX199309: u32 = 1;
+pub const __USE_POSIX199506: u32 = 1;
+pub const __USE_XOPEN2K: u32 = 1;
+pub const __USE_XOPEN2K8: u32 = 1;
+pub const _ATFILE_SOURCE: u32 = 1;
 pub const __WORDSIZE: u32 = 64;
-pub const __has_safe_buffers: u32 = 1;
-pub const __DARWIN_ONLY_64_BIT_INO_T: u32 = 0;
-pub const __DARWIN_ONLY_UNIX_CONFORMANCE: u32 = 1;
-pub const __DARWIN_ONLY_VERS_1050: u32 = 0;
-pub const __DARWIN_UNIX03: u32 = 1;
-pub const __DARWIN_64_BIT_INO_T: u32 = 1;
-pub const __DARWIN_VERS_1050: u32 = 1;
-pub const __DARWIN_NON_CANCELABLE: u32 = 0;
-pub const __DARWIN_SUF_64_BIT_INO_T: &[u8; 9] = b"$INODE64\0";
-pub const __DARWIN_SUF_1050: &[u8; 6] = b"$1050\0";
-pub const __DARWIN_SUF_EXTSN: &[u8; 14] = b"$DARWIN_EXTSN\0";
-pub const __DARWIN_C_ANSI: u32 = 4096;
-pub const __DARWIN_C_FULL: u32 = 900000;
-pub const __DARWIN_C_LEVEL: u32 = 900000;
-pub const __STDC_WANT_LIB_EXT1__: u32 = 1;
-pub const __DARWIN_NO_LONG_LONG: u32 = 0;
-pub const _DARWIN_FEATURE_64_BIT_INODE: u32 = 1;
-pub const _DARWIN_FEATURE_ONLY_UNIX_CONFORMANCE: u32 = 1;
-pub const _DARWIN_FEATURE_UNIX_CONFORMANCE: u32 = 3;
-pub const __has_ptrcheck: u32 = 0;
-pub const __has_bounds_safety_attributes: u32 = 0;
-pub const USE_CLANG_TYPES: u32 = 0;
-pub const __PTHREAD_SIZE__: u32 = 8176;
-pub const __PTHREAD_ATTR_SIZE__: u32 = 56;
-pub const __PTHREAD_MUTEXATTR_SIZE__: u32 = 8;
-pub const __PTHREAD_MUTEX_SIZE__: u32 = 56;
-pub const __PTHREAD_CONDATTR_SIZE__: u32 = 8;
-pub const __PTHREAD_COND_SIZE__: u32 = 40;
-pub const __PTHREAD_ONCE_SIZE__: u32 = 8;
-pub const __PTHREAD_RWLOCK_SIZE__: u32 = 192;
-pub const __PTHREAD_RWLOCKATTR_SIZE__: u32 = 16;
-pub const INT8_MAX: u32 = 127;
-pub const INT16_MAX: u32 = 32767;
-pub const INT32_MAX: u32 = 2147483647;
-pub const INT64_MAX: u64 = 9223372036854775807;
+pub const __WORDSIZE_TIME64_COMPAT32: u32 = 1;
+pub const __SYSCALL_WORDSIZE: u32 = 64;
+pub const __TIMESIZE: u32 = 64;
+pub const __USE_MISC: u32 = 1;
+pub const __USE_ATFILE: u32 = 1;
+pub const __USE_FORTIFY_LEVEL: u32 = 0;
+pub const __GLIBC_USE_DEPRECATED_GETS: u32 = 0;
+pub const __GLIBC_USE_DEPRECATED_SCANF: u32 = 0;
+pub const __GLIBC_USE_C2X_STRTOL: u32 = 0;
+pub const _STDC_PREDEF_H: u32 = 1;
+pub const __STDC_IEC_559__: u32 = 1;
+pub const __STDC_IEC_60559_BFP__: u32 = 201404;
+pub const __STDC_IEC_559_COMPLEX__: u32 = 1;
+pub const __STDC_IEC_60559_COMPLEX__: u32 = 201404;
+pub const __STDC_ISO_10646__: u32 = 201706;
+pub const __GNU_LIBRARY__: u32 = 6;
+pub const __GLIBC__: u32 = 2;
+pub const __GLIBC_MINOR__: u32 = 39;
+pub const _SYS_CDEFS_H: u32 = 1;
+pub const __glibc_c99_flexarr_available: u32 = 1;
+pub const __LDOUBLE_REDIRECTS_TO_FLOAT128_ABI: u32 = 0;
+pub const __HAVE_GENERIC_SELECTION: u32 = 1;
+pub const __GLIBC_USE_LIB_EXT2: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_BFP_EXT: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_BFP_EXT_C2X: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_EXT: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_FUNCS_EXT: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_FUNCS_EXT_C2X: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_TYPES_EXT: u32 = 0;
+pub const _BITS_TYPES_H: u32 = 1;
+pub const _BITS_TYPESIZES_H: u32 = 1;
+pub const __OFF_T_MATCHES_OFF64_T: u32 = 1;
+pub const __INO_T_MATCHES_INO64_T: u32 = 1;
+pub const __RLIM_T_MATCHES_RLIM64_T: u32 = 1;
+pub const __STATFS_MATCHES_STATFS64: u32 = 1;
+pub const __KERNEL_OLD_TIMEVAL_MATCHES_TIMEVAL64: u32 = 1;
+pub const __FD_SETSIZE: u32 = 1024;
+pub const _BITS_TIME64_H: u32 = 1;
+pub const _BITS_WCHAR_H: u32 = 1;
+pub const _BITS_STDINT_INTN_H: u32 = 1;
+pub const _BITS_STDINT_UINTN_H: u32 = 1;
+pub const _BITS_STDINT_LEAST_H: u32 = 1;
 pub const INT8_MIN: i32 = -128;
 pub const INT16_MIN: i32 = -32768;
 pub const INT32_MIN: i32 = -2147483648;
-pub const INT64_MIN: i64 = -9223372036854775808;
+pub const INT8_MAX: u32 = 127;
+pub const INT16_MAX: u32 = 32767;
+pub const INT32_MAX: u32 = 2147483647;
 pub const UINT8_MAX: u32 = 255;
 pub const UINT16_MAX: u32 = 65535;
 pub const UINT32_MAX: u32 = 4294967295;
-pub const UINT64_MAX: i32 = -1;
 pub const INT_LEAST8_MIN: i32 = -128;
 pub const INT_LEAST16_MIN: i32 = -32768;
 pub const INT_LEAST32_MIN: i32 = -2147483648;
-pub const INT_LEAST64_MIN: i64 = -9223372036854775808;
 pub const INT_LEAST8_MAX: u32 = 127;
 pub const INT_LEAST16_MAX: u32 = 32767;
 pub const INT_LEAST32_MAX: u32 = 2147483647;
-pub const INT_LEAST64_MAX: u64 = 9223372036854775807;
 pub const UINT_LEAST8_MAX: u32 = 255;
 pub const UINT_LEAST16_MAX: u32 = 65535;
 pub const UINT_LEAST32_MAX: u32 = 4294967295;
-pub const UINT_LEAST64_MAX: i32 = -1;
 pub const INT_FAST8_MIN: i32 = -128;
-pub const INT_FAST16_MIN: i32 = -32768;
-pub const INT_FAST32_MIN: i32 = -2147483648;
-pub const INT_FAST64_MIN: i64 = -9223372036854775808;
+pub const INT_FAST16_MIN: i64 = -9223372036854775808;
+pub const INT_FAST32_MIN: i64 = -9223372036854775808;
 pub const INT_FAST8_MAX: u32 = 127;
-pub const INT_FAST16_MAX: u32 = 32767;
-pub const INT_FAST32_MAX: u32 = 2147483647;
-pub const INT_FAST64_MAX: u64 = 9223372036854775807;
+pub const INT_FAST16_MAX: u64 = 9223372036854775807;
+pub const INT_FAST32_MAX: u64 = 9223372036854775807;
 pub const UINT_FAST8_MAX: u32 = 255;
-pub const UINT_FAST16_MAX: u32 = 65535;
-pub const UINT_FAST32_MAX: u32 = 4294967295;
-pub const UINT_FAST64_MAX: i32 = -1;
-pub const INTPTR_MAX: u64 = 9223372036854775807;
+pub const UINT_FAST16_MAX: i32 = -1;
+pub const UINT_FAST32_MAX: i32 = -1;
 pub const INTPTR_MIN: i64 = -9223372036854775808;
+pub const INTPTR_MAX: u64 = 9223372036854775807;
 pub const UINTPTR_MAX: i32 = -1;
-pub const SIZE_MAX: i32 = -1;
-pub const RSIZE_MAX: i32 = -1;
-pub const WINT_MIN: i32 = -2147483648;
-pub const WINT_MAX: u32 = 2147483647;
+pub const PTRDIFF_MIN: i64 = -9223372036854775808;
+pub const PTRDIFF_MAX: u64 = 9223372036854775807;
 pub const SIG_ATOMIC_MIN: i32 = -2147483648;
 pub const SIG_ATOMIC_MAX: u32 = 2147483647;
+pub const SIZE_MAX: i32 = -1;
+pub const WINT_MIN: u32 = 0;
+pub const WINT_MAX: u32 = 4294967295;
 pub type wchar_t = ::std::os::raw::c_int;
-pub type max_align_t = u128;
+#[repr(C)]
+#[repr(align(16))]
+#[derive(Debug, Copy, Clone)]
+pub struct max_align_t {
+    pub __max_align_ll: ::std::os::raw::c_longlong,
+    pub __bindgen_padding_0: u64,
+    pub __max_align_ld: u128,
+}
+#[test]
+fn bindgen_test_layout_max_align_t() {
+    const UNINIT: ::std::mem::MaybeUninit<max_align_t> = ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
+    assert_eq!(
+        ::std::mem::size_of::<max_align_t>(),
+        32usize,
+        concat!("Size of: ", stringify!(max_align_t))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<max_align_t>(),
+        16usize,
+        concat!("Alignment of ", stringify!(max_align_t))
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).__max_align_ll) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(max_align_t),
+            "::",
+            stringify!(__max_align_ll)
+        )
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).__max_align_ld) as usize - ptr as usize },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(max_align_t),
+            "::",
+            stringify!(__max_align_ld)
+        )
+    );
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _GoString_ {
@@ -131,558 +193,122 @@ fn bindgen_test_layout__GoString_() {
         )
     );
 }
-pub type int_least8_t = i8;
-pub type int_least16_t = i16;
-pub type int_least32_t = i32;
-pub type int_least64_t = i64;
-pub type uint_least8_t = u8;
-pub type uint_least16_t = u16;
-pub type uint_least32_t = u32;
-pub type uint_least64_t = u64;
-pub type int_fast8_t = i8;
-pub type int_fast16_t = i16;
-pub type int_fast32_t = i32;
-pub type int_fast64_t = i64;
-pub type uint_fast8_t = u8;
-pub type uint_fast16_t = u16;
-pub type uint_fast32_t = u32;
-pub type uint_fast64_t = u64;
+extern "C" {
+    pub fn _GoStringLen(s: _GoString_) -> usize;
+}
+extern "C" {
+    pub fn _GoStringPtr(s: _GoString_) -> *const ::std::os::raw::c_char;
+}
+pub type __u_char = ::std::os::raw::c_uchar;
+pub type __u_short = ::std::os::raw::c_ushort;
+pub type __u_int = ::std::os::raw::c_uint;
+pub type __u_long = ::std::os::raw::c_ulong;
 pub type __int8_t = ::std::os::raw::c_schar;
 pub type __uint8_t = ::std::os::raw::c_uchar;
 pub type __int16_t = ::std::os::raw::c_short;
 pub type __uint16_t = ::std::os::raw::c_ushort;
 pub type __int32_t = ::std::os::raw::c_int;
 pub type __uint32_t = ::std::os::raw::c_uint;
-pub type __int64_t = ::std::os::raw::c_longlong;
-pub type __uint64_t = ::std::os::raw::c_ulonglong;
-pub type __darwin_intptr_t = ::std::os::raw::c_long;
-pub type __darwin_natural_t = ::std::os::raw::c_uint;
-pub type __darwin_ct_rune_t = ::std::os::raw::c_int;
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union __mbstate_t {
-    pub __mbstate8: [::std::os::raw::c_char; 128usize],
-    pub _mbstateL: ::std::os::raw::c_longlong,
-}
-#[test]
-fn bindgen_test_layout___mbstate_t() {
-    const UNINIT: ::std::mem::MaybeUninit<__mbstate_t> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<__mbstate_t>(),
-        128usize,
-        concat!("Size of: ", stringify!(__mbstate_t))
-    );
-    assert_eq!(
-        ::std::mem::align_of::<__mbstate_t>(),
-        8usize,
-        concat!("Alignment of ", stringify!(__mbstate_t))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).__mbstate8) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(__mbstate_t),
-            "::",
-            stringify!(__mbstate8)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr)._mbstateL) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(__mbstate_t),
-            "::",
-            stringify!(_mbstateL)
-        )
-    );
-}
-pub type __darwin_mbstate_t = __mbstate_t;
-pub type __darwin_ptrdiff_t = ::std::os::raw::c_long;
-pub type __darwin_size_t = ::std::os::raw::c_ulong;
-pub type __darwin_va_list = __builtin_va_list;
-pub type __darwin_wchar_t = ::std::os::raw::c_int;
-pub type __darwin_rune_t = __darwin_wchar_t;
-pub type __darwin_wint_t = ::std::os::raw::c_int;
-pub type __darwin_clock_t = ::std::os::raw::c_ulong;
-pub type __darwin_socklen_t = __uint32_t;
-pub type __darwin_ssize_t = ::std::os::raw::c_long;
-pub type __darwin_time_t = ::std::os::raw::c_long;
-pub type __darwin_blkcnt_t = __int64_t;
-pub type __darwin_blksize_t = __int32_t;
-pub type __darwin_dev_t = __int32_t;
-pub type __darwin_fsblkcnt_t = ::std::os::raw::c_uint;
-pub type __darwin_fsfilcnt_t = ::std::os::raw::c_uint;
-pub type __darwin_gid_t = __uint32_t;
-pub type __darwin_id_t = __uint32_t;
-pub type __darwin_ino64_t = __uint64_t;
-pub type __darwin_ino_t = __darwin_ino64_t;
-pub type __darwin_mach_port_name_t = __darwin_natural_t;
-pub type __darwin_mach_port_t = __darwin_mach_port_name_t;
-pub type __darwin_mode_t = __uint16_t;
-pub type __darwin_off_t = __int64_t;
-pub type __darwin_pid_t = __int32_t;
-pub type __darwin_sigset_t = __uint32_t;
-pub type __darwin_suseconds_t = __int32_t;
-pub type __darwin_uid_t = __uint32_t;
-pub type __darwin_useconds_t = __uint32_t;
-pub type __darwin_uuid_t = [::std::os::raw::c_uchar; 16usize];
-pub type __darwin_uuid_string_t = [::std::os::raw::c_char; 37usize];
+pub type __int64_t = ::std::os::raw::c_long;
+pub type __uint64_t = ::std::os::raw::c_ulong;
+pub type __int_least8_t = __int8_t;
+pub type __uint_least8_t = __uint8_t;
+pub type __int_least16_t = __int16_t;
+pub type __uint_least16_t = __uint16_t;
+pub type __int_least32_t = __int32_t;
+pub type __uint_least32_t = __uint32_t;
+pub type __int_least64_t = __int64_t;
+pub type __uint_least64_t = __uint64_t;
+pub type __quad_t = ::std::os::raw::c_long;
+pub type __u_quad_t = ::std::os::raw::c_ulong;
+pub type __intmax_t = ::std::os::raw::c_long;
+pub type __uintmax_t = ::std::os::raw::c_ulong;
+pub type __dev_t = ::std::os::raw::c_ulong;
+pub type __uid_t = ::std::os::raw::c_uint;
+pub type __gid_t = ::std::os::raw::c_uint;
+pub type __ino_t = ::std::os::raw::c_ulong;
+pub type __ino64_t = ::std::os::raw::c_ulong;
+pub type __mode_t = ::std::os::raw::c_uint;
+pub type __nlink_t = ::std::os::raw::c_ulong;
+pub type __off_t = ::std::os::raw::c_long;
+pub type __off64_t = ::std::os::raw::c_long;
+pub type __pid_t = ::std::os::raw::c_int;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct __darwin_pthread_handler_rec {
-    pub __routine: ::std::option::Option<unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void)>,
-    pub __arg: *mut ::std::os::raw::c_void,
-    pub __next: *mut __darwin_pthread_handler_rec,
+pub struct __fsid_t {
+    pub __val: [::std::os::raw::c_int; 2usize],
 }
 #[test]
-fn bindgen_test_layout___darwin_pthread_handler_rec() {
-    const UNINIT: ::std::mem::MaybeUninit<__darwin_pthread_handler_rec> =
-        ::std::mem::MaybeUninit::uninit();
+fn bindgen_test_layout___fsid_t() {
+    const UNINIT: ::std::mem::MaybeUninit<__fsid_t> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of::<__darwin_pthread_handler_rec>(),
-        24usize,
-        concat!("Size of: ", stringify!(__darwin_pthread_handler_rec))
-    );
-    assert_eq!(
-        ::std::mem::align_of::<__darwin_pthread_handler_rec>(),
+        ::std::mem::size_of::<__fsid_t>(),
         8usize,
-        concat!("Alignment of ", stringify!(__darwin_pthread_handler_rec))
+        concat!("Size of: ", stringify!(__fsid_t))
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).__routine) as usize - ptr as usize },
+        ::std::mem::align_of::<__fsid_t>(),
+        4usize,
+        concat!("Alignment of ", stringify!(__fsid_t))
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).__val) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
-            stringify!(__darwin_pthread_handler_rec),
+            stringify!(__fsid_t),
             "::",
-            stringify!(__routine)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).__arg) as usize - ptr as usize },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(__darwin_pthread_handler_rec),
-            "::",
-            stringify!(__arg)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).__next) as usize - ptr as usize },
-        16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(__darwin_pthread_handler_rec),
-            "::",
-            stringify!(__next)
+            stringify!(__val)
         )
     );
 }
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_attr_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 56usize],
-}
-#[test]
-fn bindgen_test_layout__opaque_pthread_attr_t() {
-    const UNINIT: ::std::mem::MaybeUninit<_opaque_pthread_attr_t> =
-        ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<_opaque_pthread_attr_t>(),
-        64usize,
-        concat!("Size of: ", stringify!(_opaque_pthread_attr_t))
-    );
-    assert_eq!(
-        ::std::mem::align_of::<_opaque_pthread_attr_t>(),
-        8usize,
-        concat!("Alignment of ", stringify!(_opaque_pthread_attr_t))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).__sig) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(_opaque_pthread_attr_t),
-            "::",
-            stringify!(__sig)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).__opaque) as usize - ptr as usize },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(_opaque_pthread_attr_t),
-            "::",
-            stringify!(__opaque)
-        )
-    );
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_cond_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 40usize],
-}
-#[test]
-fn bindgen_test_layout__opaque_pthread_cond_t() {
-    const UNINIT: ::std::mem::MaybeUninit<_opaque_pthread_cond_t> =
-        ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<_opaque_pthread_cond_t>(),
-        48usize,
-        concat!("Size of: ", stringify!(_opaque_pthread_cond_t))
-    );
-    assert_eq!(
-        ::std::mem::align_of::<_opaque_pthread_cond_t>(),
-        8usize,
-        concat!("Alignment of ", stringify!(_opaque_pthread_cond_t))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).__sig) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(_opaque_pthread_cond_t),
-            "::",
-            stringify!(__sig)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).__opaque) as usize - ptr as usize },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(_opaque_pthread_cond_t),
-            "::",
-            stringify!(__opaque)
-        )
-    );
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_condattr_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 8usize],
-}
-#[test]
-fn bindgen_test_layout__opaque_pthread_condattr_t() {
-    const UNINIT: ::std::mem::MaybeUninit<_opaque_pthread_condattr_t> =
-        ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<_opaque_pthread_condattr_t>(),
-        16usize,
-        concat!("Size of: ", stringify!(_opaque_pthread_condattr_t))
-    );
-    assert_eq!(
-        ::std::mem::align_of::<_opaque_pthread_condattr_t>(),
-        8usize,
-        concat!("Alignment of ", stringify!(_opaque_pthread_condattr_t))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).__sig) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(_opaque_pthread_condattr_t),
-            "::",
-            stringify!(__sig)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).__opaque) as usize - ptr as usize },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(_opaque_pthread_condattr_t),
-            "::",
-            stringify!(__opaque)
-        )
-    );
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_mutex_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 56usize],
-}
-#[test]
-fn bindgen_test_layout__opaque_pthread_mutex_t() {
-    const UNINIT: ::std::mem::MaybeUninit<_opaque_pthread_mutex_t> =
-        ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<_opaque_pthread_mutex_t>(),
-        64usize,
-        concat!("Size of: ", stringify!(_opaque_pthread_mutex_t))
-    );
-    assert_eq!(
-        ::std::mem::align_of::<_opaque_pthread_mutex_t>(),
-        8usize,
-        concat!("Alignment of ", stringify!(_opaque_pthread_mutex_t))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).__sig) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(_opaque_pthread_mutex_t),
-            "::",
-            stringify!(__sig)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).__opaque) as usize - ptr as usize },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(_opaque_pthread_mutex_t),
-            "::",
-            stringify!(__opaque)
-        )
-    );
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_mutexattr_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 8usize],
-}
-#[test]
-fn bindgen_test_layout__opaque_pthread_mutexattr_t() {
-    const UNINIT: ::std::mem::MaybeUninit<_opaque_pthread_mutexattr_t> =
-        ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<_opaque_pthread_mutexattr_t>(),
-        16usize,
-        concat!("Size of: ", stringify!(_opaque_pthread_mutexattr_t))
-    );
-    assert_eq!(
-        ::std::mem::align_of::<_opaque_pthread_mutexattr_t>(),
-        8usize,
-        concat!("Alignment of ", stringify!(_opaque_pthread_mutexattr_t))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).__sig) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(_opaque_pthread_mutexattr_t),
-            "::",
-            stringify!(__sig)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).__opaque) as usize - ptr as usize },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(_opaque_pthread_mutexattr_t),
-            "::",
-            stringify!(__opaque)
-        )
-    );
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_once_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 8usize],
-}
-#[test]
-fn bindgen_test_layout__opaque_pthread_once_t() {
-    const UNINIT: ::std::mem::MaybeUninit<_opaque_pthread_once_t> =
-        ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<_opaque_pthread_once_t>(),
-        16usize,
-        concat!("Size of: ", stringify!(_opaque_pthread_once_t))
-    );
-    assert_eq!(
-        ::std::mem::align_of::<_opaque_pthread_once_t>(),
-        8usize,
-        concat!("Alignment of ", stringify!(_opaque_pthread_once_t))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).__sig) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(_opaque_pthread_once_t),
-            "::",
-            stringify!(__sig)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).__opaque) as usize - ptr as usize },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(_opaque_pthread_once_t),
-            "::",
-            stringify!(__opaque)
-        )
-    );
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_rwlock_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 192usize],
-}
-#[test]
-fn bindgen_test_layout__opaque_pthread_rwlock_t() {
-    const UNINIT: ::std::mem::MaybeUninit<_opaque_pthread_rwlock_t> =
-        ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<_opaque_pthread_rwlock_t>(),
-        200usize,
-        concat!("Size of: ", stringify!(_opaque_pthread_rwlock_t))
-    );
-    assert_eq!(
-        ::std::mem::align_of::<_opaque_pthread_rwlock_t>(),
-        8usize,
-        concat!("Alignment of ", stringify!(_opaque_pthread_rwlock_t))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).__sig) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(_opaque_pthread_rwlock_t),
-            "::",
-            stringify!(__sig)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).__opaque) as usize - ptr as usize },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(_opaque_pthread_rwlock_t),
-            "::",
-            stringify!(__opaque)
-        )
-    );
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_rwlockattr_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 16usize],
-}
-#[test]
-fn bindgen_test_layout__opaque_pthread_rwlockattr_t() {
-    const UNINIT: ::std::mem::MaybeUninit<_opaque_pthread_rwlockattr_t> =
-        ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<_opaque_pthread_rwlockattr_t>(),
-        24usize,
-        concat!("Size of: ", stringify!(_opaque_pthread_rwlockattr_t))
-    );
-    assert_eq!(
-        ::std::mem::align_of::<_opaque_pthread_rwlockattr_t>(),
-        8usize,
-        concat!("Alignment of ", stringify!(_opaque_pthread_rwlockattr_t))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).__sig) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(_opaque_pthread_rwlockattr_t),
-            "::",
-            stringify!(__sig)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).__opaque) as usize - ptr as usize },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(_opaque_pthread_rwlockattr_t),
-            "::",
-            stringify!(__opaque)
-        )
-    );
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __cleanup_stack: *mut __darwin_pthread_handler_rec,
-    pub __opaque: [::std::os::raw::c_char; 8176usize],
-}
-#[test]
-fn bindgen_test_layout__opaque_pthread_t() {
-    const UNINIT: ::std::mem::MaybeUninit<_opaque_pthread_t> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<_opaque_pthread_t>(),
-        8192usize,
-        concat!("Size of: ", stringify!(_opaque_pthread_t))
-    );
-    assert_eq!(
-        ::std::mem::align_of::<_opaque_pthread_t>(),
-        8usize,
-        concat!("Alignment of ", stringify!(_opaque_pthread_t))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).__sig) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(_opaque_pthread_t),
-            "::",
-            stringify!(__sig)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).__cleanup_stack) as usize - ptr as usize },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(_opaque_pthread_t),
-            "::",
-            stringify!(__cleanup_stack)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).__opaque) as usize - ptr as usize },
-        16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(_opaque_pthread_t),
-            "::",
-            stringify!(__opaque)
-        )
-    );
-}
-pub type __darwin_pthread_attr_t = _opaque_pthread_attr_t;
-pub type __darwin_pthread_cond_t = _opaque_pthread_cond_t;
-pub type __darwin_pthread_condattr_t = _opaque_pthread_condattr_t;
-pub type __darwin_pthread_key_t = ::std::os::raw::c_ulong;
-pub type __darwin_pthread_mutex_t = _opaque_pthread_mutex_t;
-pub type __darwin_pthread_mutexattr_t = _opaque_pthread_mutexattr_t;
-pub type __darwin_pthread_once_t = _opaque_pthread_once_t;
-pub type __darwin_pthread_rwlock_t = _opaque_pthread_rwlock_t;
-pub type __darwin_pthread_rwlockattr_t = _opaque_pthread_rwlockattr_t;
-pub type __darwin_pthread_t = *mut _opaque_pthread_t;
-pub type intmax_t = ::std::os::raw::c_long;
-pub type uintmax_t = ::std::os::raw::c_ulong;
+pub type __clock_t = ::std::os::raw::c_long;
+pub type __rlim_t = ::std::os::raw::c_ulong;
+pub type __rlim64_t = ::std::os::raw::c_ulong;
+pub type __id_t = ::std::os::raw::c_uint;
+pub type __time_t = ::std::os::raw::c_long;
+pub type __useconds_t = ::std::os::raw::c_uint;
+pub type __suseconds_t = ::std::os::raw::c_long;
+pub type __suseconds64_t = ::std::os::raw::c_long;
+pub type __daddr_t = ::std::os::raw::c_int;
+pub type __key_t = ::std::os::raw::c_int;
+pub type __clockid_t = ::std::os::raw::c_int;
+pub type __timer_t = *mut ::std::os::raw::c_void;
+pub type __blksize_t = ::std::os::raw::c_long;
+pub type __blkcnt_t = ::std::os::raw::c_long;
+pub type __blkcnt64_t = ::std::os::raw::c_long;
+pub type __fsblkcnt_t = ::std::os::raw::c_ulong;
+pub type __fsblkcnt64_t = ::std::os::raw::c_ulong;
+pub type __fsfilcnt_t = ::std::os::raw::c_ulong;
+pub type __fsfilcnt64_t = ::std::os::raw::c_ulong;
+pub type __fsword_t = ::std::os::raw::c_long;
+pub type __ssize_t = ::std::os::raw::c_long;
+pub type __syscall_slong_t = ::std::os::raw::c_long;
+pub type __syscall_ulong_t = ::std::os::raw::c_ulong;
+pub type __loff_t = __off64_t;
+pub type __caddr_t = *mut ::std::os::raw::c_char;
+pub type __intptr_t = ::std::os::raw::c_long;
+pub type __socklen_t = ::std::os::raw::c_uint;
+pub type __sig_atomic_t = ::std::os::raw::c_int;
+pub type int_least8_t = __int_least8_t;
+pub type int_least16_t = __int_least16_t;
+pub type int_least32_t = __int_least32_t;
+pub type int_least64_t = __int_least64_t;
+pub type uint_least8_t = __uint_least8_t;
+pub type uint_least16_t = __uint_least16_t;
+pub type uint_least32_t = __uint_least32_t;
+pub type uint_least64_t = __uint_least64_t;
+pub type int_fast8_t = ::std::os::raw::c_schar;
+pub type int_fast16_t = ::std::os::raw::c_long;
+pub type int_fast32_t = ::std::os::raw::c_long;
+pub type int_fast64_t = ::std::os::raw::c_long;
+pub type uint_fast8_t = ::std::os::raw::c_uchar;
+pub type uint_fast16_t = ::std::os::raw::c_ulong;
+pub type uint_fast32_t = ::std::os::raw::c_ulong;
+pub type uint_fast64_t = ::std::os::raw::c_ulong;
+pub type intmax_t = __intmax_t;
+pub type uintmax_t = __uintmax_t;
 pub type GoInt8 = ::std::os::raw::c_schar;
 pub type GoUint8 = ::std::os::raw::c_uchar;
 pub type GoInt16 = ::std::os::raw::c_short;
@@ -910,6 +536,18 @@ extern "C" {
     pub fn KD_GetFUSEMode() -> ::std::os::raw::c_int;
 }
 extern "C" {
+    pub fn KD_SetLocalMode(enabled: ::std::os::raw::c_int);
+}
+extern "C" {
+    pub fn KD_GetLocalMode() -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn KD_GetLinkLocalAddress() -> *mut ::std::os::raw::c_char;
+}
+extern "C" {
+    pub fn KD_SetPeerDirectAddress(addr: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+extern "C" {
     pub fn KD_GetVersion() -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -917,68 +555,4 @@ extern "C" {
 }
 extern "C" {
     pub fn KD_GetConfigPath() -> *mut ::std::os::raw::c_char;
-}
-pub type __builtin_va_list = [__va_list_tag; 1usize];
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __va_list_tag {
-    pub gp_offset: ::std::os::raw::c_uint,
-    pub fp_offset: ::std::os::raw::c_uint,
-    pub overflow_arg_area: *mut ::std::os::raw::c_void,
-    pub reg_save_area: *mut ::std::os::raw::c_void,
-}
-#[test]
-fn bindgen_test_layout___va_list_tag() {
-    const UNINIT: ::std::mem::MaybeUninit<__va_list_tag> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<__va_list_tag>(),
-        24usize,
-        concat!("Size of: ", stringify!(__va_list_tag))
-    );
-    assert_eq!(
-        ::std::mem::align_of::<__va_list_tag>(),
-        8usize,
-        concat!("Alignment of ", stringify!(__va_list_tag))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).gp_offset) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(__va_list_tag),
-            "::",
-            stringify!(gp_offset)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).fp_offset) as usize - ptr as usize },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(__va_list_tag),
-            "::",
-            stringify!(fp_offset)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).overflow_arg_area) as usize - ptr as usize },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(__va_list_tag),
-            "::",
-            stringify!(overflow_arg_area)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).reg_save_area) as usize - ptr as usize },
-        16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(__va_list_tag),
-            "::",
-            stringify!(reg_save_area)
-        )
-    );
 }

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -599,31 +599,29 @@ fn main() {
             let _ = Command::new("explorer").arg(&mount_path).spawn();
         });
 
-        // Handle Add File: native file picker (multi-select) → copy to save folder → KD_AddFile
+        // Handle Add File: native file picker → copy to save folder → KD_AddFile
         let save_path_add = to_save.clone();
         app.on_add_file_pressed(move || {
             println!("Add file pressed");
             let save_path = save_path_add.clone();
             std::thread::spawn(move || {
-                if let Some(paths) = rfd::FileDialog::new().pick_files() {
-                    for path in paths {
-                        let path_str = path.to_string_lossy().to_string();
-                        println!("Selected file: {}", path_str);
-                        // Copy to save folder for safekeeping
-                        let _ = std::fs::create_dir_all(&save_path);
-                        let filename = path.file_name().unwrap_or_default().to_string_lossy().to_string();
-                        let dest = format!("{}/{}", save_path, filename);
-                        if let Err(e) = std::fs::copy(&path_str, &dest) {
-                            eprintln!("Failed to copy file to save folder: {}", e);
-                        }
-                        let c_path = CString::new(path_str.clone()).unwrap();
-                        let res = bindings::KD_AddFile(c_path.into_raw());
-                        if res != 0 {
-                            let err = get_last_error();
-                            eprintln!("Failed to add file: {}", err);
-                        } else {
-                            println!("File added: {}", path_str);
-                        }
+                if let Some(path) = rfd::FileDialog::new().pick_file() {
+                    let path_str = path.to_string_lossy().to_string();
+                    println!("Selected file: {}", path_str);
+                    // Copy to save folder for safekeeping
+                    let _ = std::fs::create_dir_all(&save_path);
+                    let filename = path.file_name().unwrap_or_default().to_string_lossy().to_string();
+                    let dest = format!("{}/{}", save_path, filename);
+                    if let Err(e) = std::fs::copy(&path_str, &dest) {
+                        eprintln!("Failed to copy file to save folder: {}", e);
+                    }
+                    let c_path = CString::new(path_str.clone()).unwrap();
+                    let res = bindings::KD_AddFile(c_path.into_raw());
+                    if res != 0 {
+                        let err = get_last_error();
+                        eprintln!("Failed to add file: {}", err);
+                    } else {
+                        println!("File added: {}", path_str);
                     }
                 }
             });

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -599,29 +599,31 @@ fn main() {
             let _ = Command::new("explorer").arg(&mount_path).spawn();
         });
 
-        // Handle Add File: native file picker → copy to save folder → KD_AddFile
+        // Handle Add File: native file picker (multi-select) → copy to save folder → KD_AddFile
         let save_path_add = to_save.clone();
         app.on_add_file_pressed(move || {
             println!("Add file pressed");
             let save_path = save_path_add.clone();
             std::thread::spawn(move || {
-                if let Some(path) = rfd::FileDialog::new().pick_file() {
-                    let path_str = path.to_string_lossy().to_string();
-                    println!("Selected file: {}", path_str);
-                    // Copy to save folder for safekeeping
-                    let _ = std::fs::create_dir_all(&save_path);
-                    let filename = path.file_name().unwrap_or_default().to_string_lossy().to_string();
-                    let dest = format!("{}/{}", save_path, filename);
-                    if let Err(e) = std::fs::copy(&path_str, &dest) {
-                        eprintln!("Failed to copy file to save folder: {}", e);
-                    }
-                    let c_path = CString::new(path_str.clone()).unwrap();
-                    let res = bindings::KD_AddFile(c_path.into_raw());
-                    if res != 0 {
-                        let err = get_last_error();
-                        eprintln!("Failed to add file: {}", err);
-                    } else {
-                        println!("File added: {}", path_str);
+                if let Some(paths) = rfd::FileDialog::new().pick_files() {
+                    for path in paths {
+                        let path_str = path.to_string_lossy().to_string();
+                        println!("Selected file: {}", path_str);
+                        // Copy to save folder for safekeeping
+                        let _ = std::fs::create_dir_all(&save_path);
+                        let filename = path.file_name().unwrap_or_default().to_string_lossy().to_string();
+                        let dest = format!("{}/{}", save_path, filename);
+                        if let Err(e) = std::fs::copy(&path_str, &dest) {
+                            eprintln!("Failed to copy file to save folder: {}", e);
+                        }
+                        let c_path = CString::new(path_str.clone()).unwrap();
+                        let res = bindings::KD_AddFile(c_path.into_raw());
+                        if res != 0 {
+                            let err = get_last_error();
+                            eprintln!("Failed to add file: {}", err);
+                        } else {
+                            println!("File added: {}", path_str);
+                        }
                     }
                 }
             });

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -321,6 +321,12 @@ fn main() {
         fuse_present, no_fuse_env, use_fuse
     );
 
+    // Local mode: direct LAN connection, skip relay
+    let local_mode_env = env::var("KEIBIDROP_LOCAL")
+        .map(|v| !v.is_empty())
+        .unwrap_or(false);
+    println!("Local mode: {}", local_mode_env);
+
     // Collab sync: auto-enabled with FUSE, can be overridden via env vars.
     let prefetch_on_open = env::var("KEIBIDROP_PREFETCH_ON_OPEN")
         .map(|v| !v.is_empty())
@@ -399,16 +405,43 @@ fn main() {
             bindings::KD_SetFUSEMode(if enabled { 1 } else { 0 });
         });
 
-        // Handle Add: register peer fingerprint
+        // Local mode toggle
+        let local_addr = {
+            let ptr = bindings::KD_GetLinkLocalAddress();
+            if ptr.is_null() {
+                String::new()
+            } else {
+                CStr::from_ptr(ptr).to_string_lossy().to_string()
+            }
+        };
+        println!("Link-local address: {}", local_addr);
+        app.set_local_mode(local_mode_env);
+        app.set_local_address(slint::SharedString::from(&local_addr));
+        if local_mode_env {
+            bindings::KD_SetLocalMode(1);
+        }
+        app.on_local_mode_toggled(move |enabled| {
+            println!("Local mode toggled: {}", enabled);
+            bindings::KD_SetLocalMode(if enabled { 1 } else { 0 });
+        });
+
+        // Handle Add: register peer fingerprint or direct address (local mode)
         let weak = app.as_weak();
         app.on_add_peer_code(move || {
             if let Some(app) = weak.upgrade() {
                 let peer_code_shared = app.get_peer_code();
                 let peer_code = peer_code_shared.as_str();
-                println!("Peer code entered: {}", peer_code);
+                let is_local = app.get_local_mode();
+                println!("Peer code entered: {} (local={})", peer_code, is_local);
 
-                let c_peer_code = CString::new(peer_code).expect("CString::new failed");
-                let result = bindings::KD_AddPeerFingerprint(c_peer_code.as_ptr() as *mut i8);
+                let result = if is_local {
+                    let c_addr = CString::new(peer_code).expect("CString::new failed");
+                    bindings::KD_SetPeerDirectAddress(c_addr.as_ptr() as *mut i8)
+                } else {
+                    let c_fp = CString::new(peer_code).expect("CString::new failed");
+                    bindings::KD_AddPeerFingerprint(c_fp.as_ptr() as *mut i8)
+                };
+
                 if result != 0 {
                     println!("Received error code: {}", result);
                     app.set_peer_code_added(false);
@@ -420,16 +453,21 @@ fn main() {
             }
         });
 
-        // Handle Copy: copy fingerprint to clipboard
+        // Handle Copy: copy fingerprint or local address to clipboard
         let weak_copy = app.as_weak();
+        let local_addr_copy = local_addr.clone();
         app.on_copy_my_code(move || {
-            let fp = if let Some(app) = weak_copy.upgrade() {
-                app.get_my_code().to_string()
+            let text = if let Some(app) = weak_copy.upgrade() {
+                if app.get_local_mode() {
+                    local_addr_copy.clone()
+                } else {
+                    app.get_my_code().to_string()
+                }
             } else {
                 my_fp.clone()
             };
-            println!("Copy pressed: {}", fp);
-            ctx.set_contents(fp)
+            println!("Copy pressed: {}", text);
+            ctx.set_contents(text)
                 .expect("My operating system hates me");
         });
 

--- a/rust/src/ui.slint
+++ b/rust/src/ui.slint
@@ -622,6 +622,10 @@ export component MainWindow inherits Window {
     in property<bool> fuse_available: false;
     in property<string> fuse_install_hint: "Install macFUSE: macfuse.github.io";
     callback fuse_mode_toggled(bool);
+    // Local mode toggle (direct LAN connection, skip relay)
+    in-out property<bool> local_mode: false;
+    in property<string> local_address: "";
+    callback local_mode_toggled(bool);
 
     // Callbacks
     callback add_peer_code();
@@ -689,7 +693,7 @@ export component MainWindow inherits Window {
         SectionElement {
             x: 279px;
             y: 262px;
-            info: "Peer Code";
+            info: root.local_mode ? "Peer Address" : "Peer Code";
             inText <=> root.peer_code;
             readOnly: false;
             buttonText: "Add";
@@ -716,8 +720,12 @@ export component MainWindow inherits Window {
         snd := SectionElement {
             x: 279px;
             y: 437px;
-            info: "Your Code - share via Signal, Telegram, or email";
-            inText: root.my_code != "" ? root.my_code : "XXXX-XXXX-XXXX-XXXX-YYYY-YYYY-YYYY-YYYY";
+            info: root.local_mode
+                ? "Your Address (local network)"
+                : "Your Code - share via Signal, Telegram, or email";
+            inText: root.local_mode
+                ? (root.local_address != "" ? root.local_address : "No link-local address")
+                : (root.my_code != "" ? root.my_code : "XXXX-XXXX-XXXX-XXXX-YYYY-YYYY-YYYY-YYYY");
             readOnly: true;
             buttonText: "Copy";
             process_code => { root.copy_my_code() }
@@ -830,17 +838,65 @@ export component MainWindow inherits Window {
             }
         }
 
-        // Status / error message below FUSE toggle
-        if root.status_message != "" && root.error_message == "": Text {
+        // Local mode toggle
+        Rectangle {
             x: snd.x + snd.width + 38px;
             y: snd.y + snd.height - 34px + 118px;
+            width: 350px;
+            height: 24px;
+
+            Rectangle {
+                x: 0;
+                y: 2px;
+                width: 36px;
+                height: 20px;
+                border-radius: 10px;
+                background: root.local_mode ? #3b82f6 : #444;
+                animate background { duration: 150ms; }
+
+                Rectangle {
+                    x: root.local_mode ? parent.width - self.width - 2px : 2px;
+                    y: 2px;
+                    width: 16px;
+                    height: 16px;
+                    border-radius: 8px;
+                    background: white;
+                    animate x { duration: 150ms; easing: ease-out; }
+                }
+
+                local-toggle-touch := TouchArea {
+                    enabled: root.room_action == 0;
+                    clicked => {
+                        root.local_mode = !root.local_mode;
+                        root.local-mode-toggled(root.local_mode);
+                    }
+                }
+            }
+
+            Text {
+                x: 44px;
+                y: 0;
+                height: 24px;
+                text: root.local_mode
+                    ? "Local network (direct connection, no relay)"
+                    : "Internet (connect via relay server)";
+                color: #ccc;
+                font-size: 12px;
+                vertical-alignment: center;
+            }
+        }
+
+        // Status / error message below toggles
+        if root.status_message != "" && root.error_message == "": Text {
+            x: snd.x + snd.width + 38px;
+            y: snd.y + snd.height - 34px + 148px;
             text: root.status_message;
             color: #94a3b8;
             font-size: 12px;
         }
         if root.error_message != "": Rectangle {
             x: snd.x + snd.width + 38px;
-            y: snd.y + snd.height - 34px + 118px;
+            y: snd.y + snd.height - 34px + 148px;
             width: 161px;
             height: 40px;
             border-radius: 8px;
@@ -863,7 +919,7 @@ export component MainWindow inherits Window {
         // Cancel button - visible while creating or joining, below status
         if root.room_action != 0: OutlineButton {
             x: snd.x + snd.width + 38px;
-            y: snd.y + snd.height - 34px + 136px;
+            y: snd.y + snd.height - 34px + 166px;
             text: "Cancel";
             clicked => { root.cancel_connect_pressed() }
         }

--- a/rustbridge/main.go
+++ b/rustbridge/main.go
@@ -545,6 +545,45 @@ func KD_GetFUSEMode() C.int {
 	return 0
 }
 
+//export KD_SetLocalMode
+func KD_SetLocalMode(enabled C.int) {
+	if kd != nil {
+		kd.IsLocalMode = enabled != 0
+	}
+}
+
+//export KD_GetLocalMode
+func KD_GetLocalMode() C.int {
+	if kd != nil && kd.IsLocalMode {
+		return 1
+	}
+	return 0
+}
+
+//export KD_GetLinkLocalAddress
+func KD_GetLinkLocalAddress() *C.char {
+	if kd == nil {
+		return C.CString("")
+	}
+	addr, err := common.GetLinkLocalAddress(kd.InboundPort())
+	if err != nil {
+		return C.CString("")
+	}
+	return C.CString(addr)
+}
+
+//export KD_SetPeerDirectAddress
+func KD_SetPeerDirectAddress(addr *C.char) C.int {
+	if kd == nil {
+		return -1
+	}
+	if err := kd.SetPeerDirectAddress(C.GoString(addr)); err != nil {
+		setLastError(err)
+		return -2
+	}
+	return 0
+}
+
 //export KD_GetVersion
 func KD_GetVersion() *C.char {
 	return C.CString(common.Version + " (" + common.CommitHash + ")")


### PR DESCRIPTION
## Summary

- Adds a **Local Mode** toggle to the connect screen for direct LAN peer connections without the relay server
- When enabled, displays the device's link-local IPv6 address + interface + port instead of the cryptographic fingerprint
- Peers paste each other's local address, connect directly via TCP — PQC handshake still runs (TOFU model)
- Includes pre-handshake key exchange step since relay normally provides peer public keys
- All existing relay-mode functionality preserved — local mode is opt-in via toggle or `KEIBIDROP_LOCAL=1` env var

## Test plan

- [x] 17 unit tests (address parsing, TOFU handshake, relay-mode regression)
- [x] E2E: two kd instances in local mode — connect, transfer files, disconnect
- [x] GUI: Alice + Bob connected, transferred 7 files (0 bytes to 50MB), all SHA256 verified
- [x] `go vet` clean, `cargo build --release` clean
- [x] Test on macOS (link-local zone ID format may differ)
- [ ] Test across two physical machines on same LAN

Closes #97