### PR TITLE
fix(session): update handshake tests for length-prefix framing

### DIFF
--- a/pkg/session/handshake_test.go
+++ b/pkg/session/handshake_test.go
@@ -7,6 +7,7 @@
 package session
 
 import (
+	"encoding/binary"
 	"encoding/json"
 	"log/slog"
 	"net"
@@ -56,15 +57,23 @@ func buildHandshakeFixture(t *testing.T) (*Session, PeerHandshakeMessage) {
 	return alice, msg
 }
 
-// pipeWithMessage creates a net.Pipe, writes the JSON message to one end,
-// and returns the other end for the handshake to read from.
+// pipeWithMessage creates a net.Pipe, writes the length-prefixed JSON message
+// to one end, and returns the other end for the handshake to read from.
+// Format matches PerformInboundHandshake: 4-byte big-endian length + JSON body.
 func pipeWithMessage(t *testing.T, msg PeerHandshakeMessage) net.Conn {
 	t.Helper()
 	server, client := net.Pipe()
 
 	go func() {
 		defer server.Close()
-		_ = json.NewEncoder(server).Encode(msg)
+		payload, err := json.Marshal(msg)
+		if err != nil {
+			return
+		}
+		var lenBuf [4]byte
+		binary.BigEndian.PutUint32(lenBuf[:], uint32(len(payload)))
+		_, _ = server.Write(lenBuf[:])
+		_, _ = server.Write(payload)
 	}()
 
 	return client


### PR DESCRIPTION
## Summary

- PR #105 changed `PerformInboundHandshake` from `json.Decoder.Decode()` to a 4-byte big-endian length prefix + `io.ReadFull` framing (to prevent `json.Decoder` buffering ahead into the `SecureConn` stream)
- `handshake_test.go` was never updated — `pipeWithMessage` still used `json.NewEncoder().Encode()` (bare JSON, no length prefix)
- The first 4 bytes of `{"fi...` were read as `uint32 = 2,065,852,009`, hitting the 64 KiB sanity limit → `handshake message too large: 2065852009 bytes`

## Fix

Update `pipeWithMessage` to match the production framing: `json.Marshal` → write 4-byte big-endian length → write payload.

## Test plan

- [ ] `go test -v -count=1 -run TestPerformInboundHandshake ./pkg/session/` — all 4 tests pass