### PR TITLE
fix(pr116): unblock CI and address review feedback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,10 @@ jobs:
       - name: Install FUSE dev headers
         run: sudo apt-get install -y libfuse-dev libfuse3-dev
 
+      - name: Enable user_allow_other for FUSE mounts
+        run: |
+          sudo sh -c 'echo user_allow_other >> /etc/fuse.conf'
+
       - name: Run tests
         run: go test -v -count=1 -timeout 180s -skip 'BlockSizeSweep|WorkerCountSweep|PullFileProfile|BaselineComparison|FUSEReadOverhead|FUSEWriteThroughput|TransferThroughputNetem|MeasureLatency|OpenCloseLatency|ChunkLatency|PullFileThroughput|EncryptedGRPC|TransferThroughput|SecureConnThroughput' ./tests/...
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,3 @@
-version: "2"
-
 run:
   timeout: 3m
   tests: true
@@ -10,14 +8,11 @@ linters:
     - staticcheck
     - unused
     - errcheck
+    - gofmt
     - gocritic
     - revive
     - ineffassign
     - gosec
-
-formatters:
-  enable:
-    - gofmt
 
 linters-settings:
   revive:

--- a/pkg/filesystem/fuse_directory.go
+++ b/pkg/filesystem/fuse_directory.go
@@ -142,7 +142,15 @@ func (d *Dir) Chown(path string, uid uint32, gid uint32) (errCode int) {
 	if gid == ^uint32(0) {
 		chownGid = -1
 	}
-	_ = platChown(cleanPath, chownUid, chownGid)
+	if err := platChown(cleanPath, chownUid, chownGid); err != nil {
+		// EPERM: caller isn't root / lacks CAP_CHOWN — expected for non-privileged flows.
+		// ENOENT: file vanished between lookup and chown — race, not our bug.
+		// ENOSYS: platform has no chown (Windows) — in-memory update below still applies.
+		if !errors.Is(err, syscall.EPERM) && !errors.Is(err, syscall.ENOENT) && !errors.Is(err, syscall.ENOSYS) {
+			d.logger.Warn("Chown: disk chown failed, in-memory stat will diverge",
+				"path", cleanPath, "uid", chownUid, "gid", chownGid, "error", err)
+		}
+	}
 
 	now := winfuse.NewTimespec(time.Now())
 	applyOwner := func(st *winfuse.Stat_t) {

--- a/pkg/filesystem/plat_windows.go
+++ b/pkg/filesystem/plat_windows.go
@@ -79,6 +79,9 @@ func platChmod(path string, mode uint32) error {
 	return os.Chmod(path, os.FileMode(mode&0o777))
 }
 
+// platChown is a no-op on Windows: NTFS has no POSIX uid/gid mapping, so chown
+// is only tracked in the in-memory stat. A caller observing the mount via FUSE
+// will see the requested uid/gid; other Windows tooling will not.
 func platChown(path string, uid int, gid int) error {
 	return nil
 }

--- a/tests/integration_fuse_fuse_test.go
+++ b/tests/integration_fuse_fuse_test.go
@@ -398,7 +398,7 @@ func TestFUSEtoFUSE(t *testing.T) {
 // mount must show directory names at the correct hierarchy level — never raw
 // file basenames from deeper levels (phantoms).
 func TestFUSEtoFUSE_ReaddirNoPhantoms(t *testing.T) {
-	t.Skip("Flaky: timing-dependent readdir race")
+	t.Skip("Flaky: timing-dependent readdir race — tracked in #117")
 	skipIfNoFUSE(t)
 
 	binary := getTestPeerBinary(t)


### PR DESCRIPTION
Follow-up commits for #116. Stacked on top of `testing` so your authorship on the core FD-reuse fix stays intact — merge these into your branch and PR #116 will re-run CI green.

## Why the CI checks on #116 are red

**Lint** — failed at `golangci-lint config verify`:
> jsonschema: "" does not validate with "/additionalProperties": additional properties 'version', 'formatters' not allowed

Commit `a26bb89 Fix lint` moved the config to v2 schema, but the pinned linter version (`v1.64.8`) and action (`@v6`) only understand v1. This PR reverts just the schema bits of that commit (`version: "2"` + top-level `formatters:`), keeping all the real fixes (`errcheck` exclusions for UDPConn, and the lint fixes in `cmd/cli` + `pkg/discovery`). Reproduced locally with the same v1.64.8 binary that CI runs.

**Tests** — all six FUSE failures share one error:
> fusermount: option allow_other only allowed if 'user_allow_other' is set in /etc/fuse.conf

`specifics_linux.go` now passes `allow_other` to fusermount (necessary for the PostgreSQL cross-user access this PR targets), but the GitHub Actions runner doesn't have `user_allow_other` in `/etc/fuse.conf`. Added a step to the test job that enables it before running tests.

## Review nits also addressed

- **Chown error handling** (`pkg/filesystem/fuse_directory.go`): the `_ = platChown(...)` was discarding every error. Now logs at warn when the disk chown fails with anything other than EPERM (unprivileged caller), ENOENT (file vanished) or ENOSYS (platform no-op). In-memory update still applies regardless, so behavior is unchanged — just no more silent IO failures.
- **Windows `platChown` docstring** (`pkg/filesystem/plat_windows.go`): documented as a deliberate no-op — NTFS has no POSIX uid/gid mapping, so chown only affects the FUSE-visible stat.
- **`TestFUSEtoFUSE_ReaddirNoPhantoms` skip** now references tracking issue #117 so it's not silently forgotten.

## Not addressed (deferred to you)

- PR scope split — your call.
- Dual-sync corruption bug — needs your repro and domain knowledge; please open a separate issue.
- `Info` → `Debug` log-level conversion instead of `// commenting out` — style preference.
- `platDiskModeIsAuthoritative` doc polish — nice-to-have.

## Verified locally

- `go build ./...` clean
- `go vet ./...` — only the pre-existing streamCancel/lostcancel warnings (same on `origin/main`)
- `pkg/filesystem` race tests: 5x full suite + 10x `TestHandleReuseRace` / `TestHandleIDsAreUnique` — all pass
- `golangci-lint config verify` passes with the restored config
- `golangci-lint run --new-from-rev=origin/testing ./...` — zero new lint issues introduced
- `.github/workflows/ci.yml` YAML syntax valid

## Test plan

- [ ] Merge this into `testing`
- [ ] PR #116 CI re-runs — expect lint green, tests green (or revealing only pre-existing failures unrelated to this PR)
- [ ] If any new issues surface, we push follow-up commits here