### PR TITLE
fix: v0.1.0 bug fixes — kd show all, FUSE mount error reporting

### DIFF
--- a/cmd/kd/main.go
+++ b/cmd/kd/main.go
@@ -305,11 +305,16 @@ func dispatch(kd *common.KeibiDrop, req Request, cancel context.CancelFunc, ln n
 	}
 }
 
+// isShowAll reports whether `kd show <args>` should show every field.
+// Both `kd show` (no args) and `kd show all` qualify.
+func isShowAll(args []string) bool {
+	return len(args) == 0 || (len(args) == 1 && args[0] == "all")
+}
+
 func cmdShow(kd *common.KeibiDrop, args []string) Response {
 	data := map[string]string{}
 
-	// If no args, show everything
-	showAll := len(args) == 0
+	showAll := isShowAll(args)
 
 	what := ""
 	if len(args) > 0 {

--- a/cmd/kd/main_test.go
+++ b/cmd/kd/main_test.go
@@ -1,0 +1,28 @@
+// ABOUTME: Tests for kd CLI argument parsing helpers.
+// ABOUTME: Currently covers isShowAll — see cmdShow for the call site.
+package main
+
+import "testing"
+
+func TestIsShowAll(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{"no args", nil, true},
+		{"empty slice", []string{}, true},
+		{"explicit all", []string{"all"}, true},
+		{"single field", []string{"fingerprint"}, false},
+		{"compound peer ip", []string{"peer", "ip"}, false},
+		{"all with extra", []string{"all", "extra"}, false},
+		{"capitalised", []string{"All"}, false}, // case-sensitive on purpose
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isShowAll(tc.args); got != tc.want {
+				t.Fatalf("isShowAll(%v) = %v, want %v", tc.args, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/filesystem/api.go
+++ b/pkg/filesystem/api.go
@@ -9,6 +9,7 @@
 package filesystem
 
 import (
+	"fmt"
 	"log/slog"
 	"path/filepath"
 	"runtime"
@@ -39,7 +40,10 @@ func NewFS(logger *slog.Logger) *FS {
 	}
 }
 
-func (fs *FS) Mount(mountPoint string, isSecond bool, downloadPath string) {
+// Mount blocks for the lifetime of the FUSE session. It returns an error
+// immediately if the mount point is invalid or host.Mount() refuses to come
+// up; on success it returns nil only after a clean unmount.
+func (fs *FS) Mount(mountPoint string, isSecond bool, downloadPath string) error {
 	fs.logger.Warn("FUSE Mount starting",
 		"mountPoint", mountPoint,
 		"downloadPath", downloadPath,
@@ -58,7 +62,7 @@ func (fs *FS) Mount(mountPoint string, isSecond bool, downloadPath string) {
 	}
 	if cleanMountPoint == "" || cleanMountPoint == "." {
 		fs.logger.Warn("FUSE Mount failed - invalid mount point", "mountPoint", mountPoint)
-		return
+		return fmt.Errorf("invalid mount point %q", mountPoint)
 	}
 
 	root := &Dir{
@@ -115,9 +119,10 @@ func (fs *FS) Mount(mountPoint string, isSecond bool, downloadPath string) {
 	ok := fs.host.Mount(cleanMountPoint, opts)
 	if !ok {
 		fs.logger.Error("FUSE Mount failed", "mountPoint", cleanMountPoint)
-		return
+		return fmt.Errorf("FUSE mount failed for %s: ensure user_allow_other is set in /etc/fuse.conf, or run with KD_NO_FUSE=1", cleanMountPoint)
 	}
 	fs.logger.Warn("FUSE Mount completed", "mountPoint", cleanMountPoint)
+	return nil
 }
 
 func (fs *FS) Unmount() {

--- a/pkg/filesystem/api_mount_test.go
+++ b/pkg/filesystem/api_mount_test.go
@@ -1,0 +1,42 @@
+// ABOUTME: Tests for FS.Mount error handling — verifies invalid mount points return error.
+// ABOUTME: The host.Mount failure branch is covered by integration tests, not here.
+
+//go:build !android
+
+package filesystem
+
+import (
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func newTestFS() *FS {
+	return NewFS(slog.New(slog.NewTextHandler(io.Discard, nil)))
+}
+
+func TestMount_EmptyMountPoint_ReturnsError(t *testing.T) {
+	err := newTestFS().Mount("", false, "/tmp/x")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid mount point") {
+		t.Fatalf("expected 'invalid mount point' error, got: %v", err)
+	}
+}
+
+func TestMount_DotMountPoint_ReturnsError(t *testing.T) {
+	err := newTestFS().Mount(".", false, "/tmp/x")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestMount_TrailingSlashCleansToDot_ReturnsError(t *testing.T) {
+	// filepath.Clean("./") == "."
+	err := newTestFS().Mount("./", false, "/tmp/x")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}

--- a/pkg/filesystem/fs_android.go
+++ b/pkg/filesystem/fs_android.go
@@ -31,8 +31,8 @@ func NewFS(_ *slog.Logger) *FS {
 	return &FS{}
 }
 
-// Mount is a no-op on Android.
-func (fs *FS) Mount(_ string, _ bool, _ string) {}
+// Mount is a no-op on Android. The error return matches the desktop signature.
+func (fs *FS) Mount(_ string, _ bool, _ string) error { return nil }
 
 // Unmount is a no-op on Android.
 func (fs *FS) Unmount() {}

--- a/pkg/logic/common/logic.go
+++ b/pkg/logic/common/logic.go
@@ -1035,8 +1035,10 @@ func (kd *KeibiDrop) MountFilesystem(toMount string, toSave string, isSecond boo
 	fs := filesystem.NewFS(logger)
 	kd.KDSvc.FS = fs
 
-	fs.Mount(filepath.Clean(toMount), isSecond, filepath.Clean(toSave))
-
+	if err := fs.Mount(filepath.Clean(toMount), isSecond, filepath.Clean(toSave)); err != nil {
+		logger.Error("Filesystem mount failed", "error", err)
+		return err
+	}
 	return nil
 }
 

--- a/pkg/logic/common/types.go
+++ b/pkg/logic/common/types.go
@@ -405,8 +405,11 @@ func (kd *KeibiDrop) Run() {
 				if kd.FS != nil && kd.KDSvc != nil {
 					logger.Info("Mounting filesystem", "mount", kd.ToMount, "save", kd.ToSave)
 					kd.KDSvc.FS = kd.FS
-					kd.FS.Mount(filepath.Clean(kd.ToMount), false, filepath.Clean(kd.ToSave))
-					logger.Info("Filesystem mounted successfully")
+					if err := kd.FS.Mount(filepath.Clean(kd.ToMount), false, filepath.Clean(kd.ToSave)); err != nil {
+						logger.Error("Filesystem mount failed", "error", err)
+					} else {
+						logger.Info("Filesystem mount session ended")
+					}
 				} else {
 					logger.Warn("No FS to mount")
 				}


### PR DESCRIPTION
## Summary

Two bugs found during end-to-end testing of the v0.1.0 release `.deb`:

- `kd show all` errored with `unknown show target: all` despite the help text advertising it as a valid argument
- When `host.Mount()` failed (e.g. missing `user_allow_other` in `/etc/fuse.conf`), the daemon logged "Filesystem mounted successfully" anyway and continued in a half-broken state where `kd add` notified the peer but `kd pull` failed with `no such file or directory`

## Changes

- **Bug 1:** `cmdShow()` now treats `kd show all` and `kd show` (no args) equivalently via an `isShowAll()` helper. Adds the first test file in `cmd/kd/`.
- **Bug 2:** `FS.Mount()` returns `error`. Failures are wrapped with an actionable hint (enable `user_allow_other`, or use `KD_NO_FUSE=1`). `Run()` and `MountFilesystem()` log truthfully based on the result. No false success log on failure.

## Test plan

- `go test ./pkg/filesystem/... ./cmd/kd/... -count=1` — new unit tests cover `isShowAll` and `Mount()` invalid-mount-point branches
- Manual: `kd show all` returns the same payload as `kd show` (no args)
- Manual: trigger a FUSE failure (comment out `user_allow_other` in `/etc/fuse.conf`) and verify log shows `Filesystem mount failed error="..."` instead of a false success