### PR TITLE
fix(ui): bump dim text to #aaa for Wayland readability

### DIFF
--- a/rust/src/ui.slint
+++ b/rust/src/ui.slint
@@ -129,7 +129,7 @@ component DataRectangle inherits Rectangle {
         y: 120px;
         width: parent.width - 86px;
         text: root.helperText;
-        color: #6A6A6A;
+        color: #aaa;
         font-size: 12px;
         wrap: word-wrap;
     }
@@ -859,7 +859,7 @@ export component MainWindow inherits Window {
             x: 357px;
             y: 390px;
             text: "Paste the code your peer sent you";
-            color: #555;
+            color: #aaa;
             font-size: 12px;
         }
 
@@ -897,7 +897,7 @@ export component MainWindow inherits Window {
             y: 497px;
             width: 200px;
             text: "Both peers press Connect.";
-            color: #555;
+            color: #aaa;
             font-size: 11px;
         }
 
@@ -959,7 +959,7 @@ export component MainWindow inherits Window {
 
                 fuse-hint-text := Text {
                     text: root.fuse_install_hint;
-                    color: fuse-hint-touch.has-hover ? #888 : #555;
+                    color: fuse-hint-touch.has-hover ? #ccc : #aaa;
                     font-size: 11px;
                 }
                 fuse-hint-touch := TouchArea {
@@ -1003,11 +1003,11 @@ export component MainWindow inherits Window {
 
             if !root.local_mode && root.room_action == 0: Text {
                 x: 44px;
-                y: 28px;
+                y: 24px;
                 width: 210px;
                 text: "Same WiFi? Toggle to find your peer automatically.";
-                color: #444;
-                font-size: 10px;
+                color: #aaa;
+                font-size: 12px;
                 wrap: word-wrap;
             }
         }
@@ -1065,7 +1065,7 @@ export component MainWindow inherits Window {
             x: 868px;
             y: 656px;
             text: "Searching for devices...";
-            color: #666;
+            color: #aaa;
             font-size: 12px;
         }
 
@@ -1340,7 +1340,7 @@ export component MainWindow inherits Window {
 
             Text {
                 text: "Files stream on access. Open videos, documents, or code without waiting for the full download.";
-                color: #666;
+                color: #aaa;
                 font-size: 12px;
                 horizontal-alignment: center;
             }
@@ -1457,7 +1457,7 @@ export component MainWindow inherits Window {
             x: 20px;
             y: parent.height - 28px;
             text: "keibidrop.com";
-            color: #555;
+            color: #aaa;
             font-size: 11px;
         }
     }
@@ -1489,7 +1489,7 @@ export component MainWindow inherits Window {
         x: parent.width - self.width - 16px;
         y: parent.height - self.height - 12px;
         text: root.version_text;
-        color: #666666;
+        color: #aaa;
         font-size: 11px;
         font-family: "Inter";
     }


### PR DESCRIPTION
Closes #123.

## Summary
- Bumps low-contrast hint text from #444–#666 to #aaa across the dark theme so it stays readable on Ubuntu/Wayland 1080p 1.0×.
- "Same WiFi?" helper: color #444 → #aaa, font-size 10px → 12px (matching the rest of the hint-text family), and y: 28px → 24px ("up a couple of pixels" per the original PR #121 review comment).
- FUSE install hint preserves its hover-state contrast: hover branch shifts from #888 → #ccc to keep parity with the new dimmer baseline.

## Locations changed (rust/src/ui.slint)

| Line | Element | Before | After |
|---|---|---|---|
| 132  | helperText (e.g., "Send this code to your peer…")     | #6A6A6A     | #aaa |
| 862  | "Paste the code your peer sent you"                   | #555        | #aaa |
| 900  | "Both peers press Connect."                           | #555        | #aaa |
| 962  | FUSE install hint (ternary)                           | #888 / #555 | #ccc / #aaa |
| 1009 | "Same WiFi? Toggle to find your peer automatically."  | #444, 10px, y:28px | #aaa, 12px, y:24px |
| 1068 | "Searching for devices..."                            | #666        | #aaa |
| 1343 | "Files stream on access…"                             | #666        | #aaa |
| 1460 | "keibidrop.com"                                       | #555        | #aaa |
| 1492 | App version (bottom-right)                            | #666666     | #aaa |

## Test plan
- [x] cargo build --release succeeds
- [x] Visual confirmation on Ubuntu/Wayland 1080p 1.0× — all 9 elements legible, no layout reflow
- [ ] Sanity on a non-Wayland/macOS setup (welcome from reviewers)