### PR TITLE
fix(grpc): grace-delay DISCONNECT teardown to stop goroutine leak

### DIFF
--- a/pkg/logic/common/disconnect_grace_test.go
+++ b/pkg/logic/common/disconnect_grace_test.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// ABOUTME: Regression test for issue #122 — verifies handleNotifyDisconnect
+// ABOUTME: waits the grace window before cancelling, so the in-flight
+// ABOUTME: DISCONNECT RPC response flushes before grpcServer.Stop().
+
+package common
+
+import (
+	"context"
+	"log/slog"
+	"net/url"
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestHandleNotifyDisconnectHonorsGraceDelay verifies that the post-DISCONNECT
+// teardown waits grpcDisconnectGraceDelay before invoking cancelContext. Issue
+// #122: cancelling earlier races the in-flight DISCONNECT RPC response write
+// and either crashes the gRPC server or leaks Serve()/ClientConn goroutines.
+func TestHandleNotifyDisconnectHonorsGraceDelay(t *testing.T) {
+	origDelay := grpcDisconnectGraceDelay
+	grpcDisconnectGraceDelay = 50 * time.Millisecond
+	t.Cleanup(func() { grpcDisconnectGraceDelay = origDelay })
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	relayURL, _ := url.Parse("https://localhost:9999")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	kd, err := NewKeibiDropWithIP(ctx, logger, false, relayURL, 26720, 26721, "", t.TempDir(), false, false, "::1")
+	if err != nil {
+		t.Fatalf("NewKeibiDropWithIP failed: %v", err)
+	}
+
+	var cancelAt atomic.Int64
+	kd.Cancel = func() { cancelAt.Store(time.Now().UnixNano()) }
+
+	start := time.Now()
+	kd.handleNotifyDisconnect()
+
+	got := cancelAt.Load()
+	if got == 0 {
+		t.Fatal("Cancel was never invoked by handleNotifyDisconnect")
+	}
+
+	elapsed := time.Unix(0, got).Sub(start)
+	if elapsed < grpcDisconnectGraceDelay {
+		t.Fatalf("Cancel fired too early: %v < grace %v (in-flight RPC response would race teardown)",
+			elapsed, grpcDisconnectGraceDelay)
+	}
+}

--- a/pkg/logic/common/types.go
+++ b/pkg/logic/common/types.go
@@ -320,8 +320,17 @@ func (kd *KeibiDrop) Run() {
 				kd.FS.Unmount()
 				kd.FS = nil
 			}
-			kd.grpcServer = nil
-			kd.grpcClientConn = nil
+			// Safe to Stop()/Close() here: handleNotifyDisconnect waits
+			// grpcDisconnectGraceDelay before cancelling the context, so the
+			// in-flight DISCONNECT RPC response has flushed. See #122.
+			if kd.grpcServer != nil {
+				kd.grpcServer.Stop()
+				kd.grpcServer = nil
+			}
+			if kd.grpcClientConn != nil {
+				kd.grpcClientConn.Close()
+				kd.grpcClientConn = nil
+			}
 			kd.KDClient = nil
 			kd.KDSvc = nil
 			kd.session = nil

--- a/pkg/logic/common/utils.go
+++ b/pkg/logic/common/utils.go
@@ -549,7 +549,31 @@ func (kd *KeibiDrop) connectGRPCClientWithRetry(timeout time.Duration) error {
 	}
 }
 
+// grpcDisconnectGraceDelay is the wait between a peer's Notify(DISCONNECT)
+// arriving and our own context cancellation. The DISCONNECT handler returns
+// a response on the same gRPC server we then tear down; without this wait
+// the teardown races the response write and either crashes the server (the
+// original bug) or, post-#121, leaks the Serve() and ClientConn maintenance
+// goroutines once Stop()/Close() are restored on the cleanup path. See #122.
 //
+// Declared as var (not const) so tests can shrink it.
+var grpcDisconnectGraceDelay = 250 * time.Millisecond
+
+// handleNotifyDisconnect runs the post-DISCONNECT teardown: unmount FUSE
+// first (so Run()'s Start handler can return), then sleep the grace window
+// to let the in-flight DISCONNECT RPC response flush before we cancel the
+// context (which the Run() ctx.Done branch uses to call grpcServer.Stop()
+// and grpcClientConn.Close()).
+//
+// MUST be invoked in a goroutine separate from the gRPC handler — the
+// handler is still writing the response when this runs.
+func (kd *KeibiDrop) handleNotifyDisconnect() {
+	if kd.FS != nil {
+		kd.FS.Unmount()
+	}
+	time.Sleep(grpcDisconnectGraceDelay)
+	kd.cancelContext()
+}
 
 func (kd *KeibiDrop) startGRPCServer() error {
 	kd.session.GRPCListener = kd.session.Session.Inbound
@@ -567,15 +591,7 @@ func (kd *KeibiDrop) startGRPCServer() error {
 		Logger:      kd.logger.With("component", "keibidrop-server"),
 		SyncTracker: kd.SyncTracker,
 		OnEvent:     kd.OnEvent,
-		OnDisconnect: func() {
-			// Unmount first to unblock Mount() in Run()'s Start handler.
-			// Mount() blocks the select loop, so ctx.Done() can't fire
-			// until Mount() returns (which only happens on Unmount).
-			if kd.FS != nil {
-				kd.FS.Unmount()
-			}
-			kd.cancelContext()
-		},
+		OnDisconnect: kd.handleNotifyDisconnect,
 	}
 
 	kd.KDSvc = svc

--- a/pkg/logic/common/utils.go
+++ b/pkg/logic/common/utils.go
@@ -587,10 +587,10 @@ func (kd *KeibiDrop) startGRPCServer() error {
 	ln := NewSingleConnListener(kd.session.Session.Inbound)
 
 	svc := &service.KeibidropServiceImpl{
-		Session:     kd.session,
-		Logger:      kd.logger.With("component", "keibidrop-server"),
-		SyncTracker: kd.SyncTracker,
-		OnEvent:     kd.OnEvent,
+		Session:      kd.session,
+		Logger:       kd.logger.With("component", "keibidrop-server"),
+		SyncTracker:  kd.SyncTracker,
+		OnEvent:      kd.OnEvent,
 		OnDisconnect: kd.handleNotifyDisconnect,
 	}
 


### PR DESCRIPTION
Closes #122.

## Summary
- Adds a 250ms grace window between a peer's `Notify(DISCONNECT)` arriving and our own `cancelContext()`, so the in-flight DISCONNECT RPC response finishes flushing before the gRPC server is torn down.
- Restores `grpcServer.Stop()` / `grpcClientConn.Close()` in `Run()`'s `ctx.Done` cleanup branch (PR #121 had to drop them to fix the crash; this brings them back safely).
- Eliminates the per-disconnect leak of the `Serve()` goroutine (parked in `singleConnListener.Accept` on `<-l.done`) plus ~5 `grpc-go` `ClientConn` maintenance goroutines.

## What changed
- **`pkg/logic/common/utils.go`** — new `grpcDisconnectGraceDelay` package-level var (250ms, declared as `var` so tests can shrink it) and a new `kd.handleNotifyDisconnect()` method that runs Unmount → grace sleep → cancelContext. The inline `OnDisconnect` closure in `startGRPCServer` becomes a method-value reference.
- **`pkg/logic/common/types.go`** — `Run()`'s `case <-kd.ctx.Done():` branch now calls `grpcServer.Stop()` / `grpcClientConn.Close()` again, with a comment explaining that the grace delay in `handleNotifyDisconnect` makes this safe.
- **`pkg/logic/common/disconnect_grace_test.go`** (new) — `TestHandleNotifyDisconnectHonorsGraceDelay` overrides the grace var to 50ms, stubs `kd.Cancel`, and asserts the cancel fires no earlier than the grace window. Acts as a regression guard on the timing contract.

## Why this approach
- The DISCONNECT handler at `pkg/logic/service/service.go:75-77` already dispatches `OnDisconnect` in a goroutine. Adding a `time.Sleep` inside `handleNotifyDisconnect` is the cheapest way to ensure ordering without restructuring the handler chain or introducing channels/`time.AfterFunc`.
- 250ms is ~10–25× a typical local-loop RPC response time, comfortably below user-perceptible latency on the Disconnect → main-screen transition, and gives plenty of buffer for relay/network jitter.
- Declaring the constant as `var` (not `const`) lets the regression test run in 50ms while production code keeps the 250ms default — same code path, no test-only hooks.

## Test plan
- [x] `go test -timeout 60s ./pkg/logic/common/... -skip TestParsePeerDirectAddress_IPv4_Rejected` — passes (the skipped test is a pre-existing failure unrelated to this PR, also failing on `main`).
- [x] `go build ./...` — clean.
- [x] `go vet ./pkg/logic/common/...` — clean.
- [x] Rebuilt c-archive (`go build -buildmode=c-archive -o libkeibidrop.a ./rustbridge`) and `cargo build --release`.
- [x] **Manual end-to-end:** alice + bob over LAN/relay (loopback), connected, peer A clicked Disconnect — both peers transitioned cleanly to the main screen, no crash, no panics or `gRPC server exited with error` lines in either log, both processes still alive afterwards.