### PR TITLE
Fix bridge connection mis-pairing

### DIFF
--- a/mobile/mobile.go
+++ b/mobile/mobile.go
@@ -591,6 +591,17 @@ func (api *API) SetPeerDirectAddress(addr string) error {
 	return api.kd.SetPeerDirectAddress(addr)
 }
 
+// SetBridgeAddr sets a TCP bridge relay address for NAT traversal fallback.
+// When set, if direct P2P fails, both peers connect through the bridge server
+// instead. Call before CreateRoomAsync or JoinRoomAsync.
+func (api *API) SetBridgeAddr(addr string) error {
+	if api.kd == nil {
+		return fmt.Errorf("not initialized")
+	}
+	api.kd.BridgeAddr = addr
+	return nil
+}
+
 // RelayEndpoint returns the relay URL string.
 func (api *API) RelayEndpoint() string {
 	if api.kd == nil {

--- a/pkg/logic/common/bridge.go
+++ b/pkg/logic/common/bridge.go
@@ -21,8 +21,12 @@ func bridgeRoomToken(ownFingerprint, peerFingerprint string) [32]byte {
 }
 
 // dialBridge connects to the bridge relay and sends the room token.
-// The bridge pairs connections with matching tokens.
-func (kd *KeibiDrop) dialBridge(logger *slog.Logger) (net.Conn, error) {
+// connIdx (0 or 1) distinguishes the two connection pairs so they cannot
+// mis-pair when one side's connections arrive before the other's.
+// Both peers use the same connIdx for the same logical connection:
+//   CreateRoom: inConn=0, outConn=1
+//   JoinRoom:   outConn=0, inConn=1
+func (kd *KeibiDrop) dialBridge(logger *slog.Logger, connIdx uint8) (net.Conn, error) {
 	conn, err := session.DialWithStableAddr("tcp", kd.BridgeAddr, 15*time.Second, logger)
 	if err != nil {
 		return nil, fmt.Errorf("dial bridge: %w", err)
@@ -31,6 +35,7 @@ func (kd *KeibiDrop) dialBridge(logger *slog.Logger) (net.Conn, error) {
 	ownFP := kd.session.OwnFingerprint
 	peerFP := kd.session.ExpectedPeerFingerprint
 	token := bridgeRoomToken(ownFP, peerFP)
+	token[31] ^= connIdx // Distinct token per connection pair to prevent mis-pairing.
 
 	conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
 	if _, err := conn.Write(token[:]); err != nil {

--- a/pkg/logic/common/helpers.go
+++ b/pkg/logic/common/helpers.go
@@ -1,3 +1,6 @@
+// ABOUTME: Cross-platform utility helpers: fingerprint validation, address parsing,
+// ABOUTME: and HTTP JSON request helpers used across all platforms.
+
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (c) 2025 KeibiSoft S.R.L.
 // This Source Code Form is subject to the terms of the Mozilla Public
@@ -17,79 +20,6 @@ import (
 	"strconv"
 	"strings"
 )
-
-// GetLinkLocalAddress finds a link-local IPv6 address on this machine and
-// returns it formatted as "ip%zone:port" for direct LAN peer connections.
-// Falls back to loopback (::1) when no link-local interface is available.
-func GetLinkLocalAddress(port int) (string, error) {
-	ifaces, err := net.Interfaces()
-	if err != nil {
-		return "", err
-	}
-
-	// Collect all link-local candidates from non-loopback, up interfaces.
-	type candidate struct {
-		ip    net.IP
-		iface string
-	}
-	var candidates []candidate
-	for _, iface := range ifaces {
-		if iface.Flags&net.FlagLoopback != 0 || iface.Flags&net.FlagUp == 0 {
-			continue
-		}
-		addrs, _ := iface.Addrs()
-		for _, addr := range addrs {
-			ip, _, err := net.ParseCIDR(addr.String())
-			if err != nil {
-				continue
-			}
-			if ip.To16() != nil && ip.To4() == nil && ip.IsLinkLocalUnicast() {
-				candidates = append(candidates, candidate{ip: ip, iface: iface.Name})
-			}
-		}
-	}
-
-	if len(candidates) > 0 {
-		// Prefer common LAN interfaces: en0 (macOS WiFi), eth0/wlan0 (Linux).
-		// Avoid utun*, awdl*, llw*, ap* (VPN, AirDrop, low-latency WLAN, access point).
-		preferred := []string{"en0", "eth0", "wlan0", "en1", "wlp", "enp"}
-		for _, pref := range preferred {
-			for _, c := range candidates {
-				if strings.HasPrefix(c.iface, pref) {
-					return fmt.Sprintf("%s%%%s:%d", c.ip.String(), c.iface, port), nil
-				}
-			}
-		}
-		// No preferred match, pick first non-virtual candidate.
-		for _, c := range candidates {
-			skip := strings.HasPrefix(c.iface, "utun") ||
-				strings.HasPrefix(c.iface, "awdl") ||
-				strings.HasPrefix(c.iface, "llw")
-			if !skip {
-				return fmt.Sprintf("%s%%%s:%d", c.ip.String(), c.iface, port), nil
-			}
-		}
-		// All candidates are virtual, use first one anyway.
-		c := candidates[0]
-		return fmt.Sprintf("%s%%%s:%d", c.ip.String(), c.iface, port), nil
-	}
-
-	// Fallback: accept loopback for local testing.
-	for _, iface := range ifaces {
-		addrs, _ := iface.Addrs()
-		for _, addr := range addrs {
-			ip, _, err := net.ParseCIDR(addr.String())
-			if err != nil {
-				continue
-			}
-			if ip.To16() != nil && ip.To4() == nil && ip.IsLoopback() {
-				return fmt.Sprintf("%s:%d", ip.String(), port), nil
-			}
-		}
-	}
-
-	return "", fmt.Errorf("no link-local or loopback IPv6 address found")
-}
 
 // ParsePeerDirectAddress parses a direct LAN peer address in the format
 // "ip%zone:port" (link-local) or "ip:port" (loopback). Returns the IP,
@@ -176,97 +106,6 @@ func ParsePeerDirectAddress(addr string) (ip string, zone string, port int, err 
 	}
 
 	return ipPart, "", port, nil
-}
-
-func GetLocalIPv6() (string, error) {
-	ifaces, err := net.Interfaces()
-	if err != nil {
-		return "", err
-	}
-
-	for _, iface := range ifaces {
-		addrs, _ := iface.Addrs()
-		for _, addr := range addrs {
-			ip, _, err := net.ParseCIDR(addr.String())
-			if err != nil {
-				continue
-			}
-			if ip.To16() != nil && ip.To4() == nil {
-				// allow loopback + ULA + link-local
-				return ip.String(), nil
-			}
-		}
-	}
-	return "", fmt.Errorf("no IPv6 address found")
-}
-
-// GetGlobalIPv6 returns a stable (non-temporary) global IPv6 address.
-// On macOS/Linux, privacy extensions (RFC 4941) generate temporary addresses
-// that rotate periodically. Connections bound to a temporary address break
-// when the OS deprecates it. This function prefers stable addresses by
-// collecting all candidates and picking the best one.
-func GetGlobalIPv6() (string, error) {
-	interfaces, err := net.Interfaces()
-	if err != nil {
-		return "", err
-	}
-
-	// Preferred interfaces for LAN (same order as GetLinkLocalAddress).
-	preferred := []string{"en0", "eth0", "wlan0", "en1", "wlp", "enp"}
-
-	type candidate struct {
-		ip    string
-		iface string
-	}
-	var candidates []candidate
-
-	for _, iface := range interfaces {
-		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
-			continue
-		}
-		// Skip virtual/VPN interfaces.
-		if strings.HasPrefix(iface.Name, "utun") ||
-			strings.HasPrefix(iface.Name, "awdl") ||
-			strings.HasPrefix(iface.Name, "llw") ||
-			strings.HasPrefix(iface.Name, "docker") ||
-			strings.HasPrefix(iface.Name, "br-") ||
-			strings.HasPrefix(iface.Name, "veth") {
-			continue
-		}
-
-		addrs, err := iface.Addrs()
-		if err != nil {
-			continue
-		}
-		for _, addr := range addrs {
-			ip, _, err := net.ParseCIDR(addr.String())
-			if err != nil {
-				continue
-			}
-			if ip.To16() != nil && ip.To4() == nil && !ip.IsLoopback() && !ip.IsLinkLocalUnicast() {
-				candidates = append(candidates, candidate{ip: ip.String(), iface: iface.Name})
-			}
-		}
-	}
-
-	if len(candidates) == 0 {
-		// Fallback to any local IPv6 for testing.
-		return GetLocalIPv6()
-	}
-
-	// Prefer candidates on preferred interfaces (en0, eth0, etc.).
-	// The first address on a preferred interface is typically the stable one;
-	// temporary addresses are appended after the stable/secured address.
-	for _, pref := range preferred {
-		for _, c := range candidates {
-			if strings.HasPrefix(c.iface, pref) {
-				return c.ip, nil
-			}
-		}
-	}
-
-	// No preferred interface match, return first candidate.
-	return candidates[0].ip, nil
 }
 
 func ValidateFingerprint(fp string) error {

--- a/pkg/logic/common/helpers_android.go
+++ b/pkg/logic/common/helpers_android.go
@@ -1,0 +1,135 @@
+// ABOUTME: Android-specific network helpers that avoid net.Interfaces() which triggers
+// ABOUTME: SELinux-denied netlink_route_socket bind operations on Android (b/155595000)
+
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//go:build android
+
+package common
+
+import (
+	"bufio"
+	"encoding/hex"
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// inet6Entry holds a parsed line from /proc/net/if_inet6.
+type inet6Entry struct {
+	ip    net.IP
+	iface string
+	scope int
+}
+
+// parseIfInet6 reads /proc/net/if_inet6 to discover IPv6 addresses without
+// using net.Interfaces() (which requires netlink, blocked by SELinux on Android).
+func parseIfInet6() ([]inet6Entry, error) {
+	f, err := os.Open("/proc/net/if_inet6")
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var results []inet6Entry
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		// Format: address device_number prefix_len scope flags interface_name
+		// Example: fec000000000000050540000fe123456 0f 40 40 20 eth0
+		fields := strings.Fields(scanner.Text())
+		if len(fields) < 6 {
+			continue
+		}
+		addrHex := fields[0]
+		scopeHex := fields[3]
+		ifName := fields[5]
+
+		if len(addrHex) != 32 {
+			continue
+		}
+
+		addrBytes, err := hex.DecodeString(addrHex)
+		if err != nil {
+			continue
+		}
+
+		ip := net.IP(addrBytes)
+		scope, _ := strconv.ParseInt(scopeHex, 16, 32)
+		results = append(results, inet6Entry{ip: ip, iface: ifName, scope: int(scope)})
+	}
+	return results, nil
+}
+
+// GetLinkLocalAddress returns a link-local IPv6 address for direct LAN
+// connections. On Android, we parse /proc/net/if_inet6 instead of using
+// net.Interfaces().
+func GetLinkLocalAddress(port int) (string, error) {
+	entries, err := parseIfInet6()
+	if err != nil {
+		return net.JoinHostPort("::1", strconv.Itoa(port)), nil
+	}
+
+	for _, e := range entries {
+		if e.ip.IsLinkLocalUnicast() && e.iface != "lo" && e.iface != "dummy0" {
+			return fmt.Sprintf("%s%%%s:%d", e.ip.String(), e.iface, port), nil
+		}
+	}
+	return net.JoinHostPort("::1", strconv.Itoa(port)), nil
+}
+
+// GetGlobalIPv6 returns a global-scope IPv6 address. On Android, we first
+// try a UDP dial probe, then fall back to parsing /proc/net/if_inet6.
+func GetGlobalIPv6() (string, error) {
+	// Try dial probe first (works when IPv6 connectivity exists).
+	conn, err := net.Dial("udp6", "[2001:4860:4860::8888]:80")
+	if err == nil {
+		defer conn.Close()
+		host, _, err := net.SplitHostPort(conn.LocalAddr().String())
+		if err == nil && host != "::1" {
+			return host, nil
+		}
+	}
+
+	// Fall back to /proc/net/if_inet6 for any non-loopback, non-link-local address.
+	entries, err := parseIfInet6()
+	if err != nil {
+		return "::1", nil
+	}
+
+	// Prefer global scope, then site-local, then link-local.
+	for _, e := range entries {
+		if e.ip.IsGlobalUnicast() && !e.ip.IsLinkLocalUnicast() && e.iface != "lo" {
+			return e.ip.String(), nil
+		}
+	}
+	// Accept site-local (fec0::/10) addresses (common in emulators).
+	for _, e := range entries {
+		if !e.ip.IsLoopback() && !e.ip.IsLinkLocalUnicast() && e.iface != "lo" {
+			return e.ip.String(), nil
+		}
+	}
+	// Accept any non-loopback.
+	for _, e := range entries {
+		if !e.ip.IsLoopback() && e.iface != "lo" && e.iface != "dummy0" {
+			return e.ip.String(), nil
+		}
+	}
+	return "::1", nil
+}
+
+// GetLocalIPv6 returns any available local IPv6 address. On Android, we
+// use /proc/net/if_inet6 to avoid netlink.
+func GetLocalIPv6() (string, error) {
+	ip, err := GetGlobalIPv6()
+	if err != nil {
+		return "", fmt.Errorf("no IPv6 address found")
+	}
+	return ip, nil
+}

--- a/pkg/logic/common/helpers_netlink.go
+++ b/pkg/logic/common/helpers_netlink.go
@@ -1,0 +1,140 @@
+// ABOUTME: Network interface helpers using net.Interfaces() (netlink-based).
+// ABOUTME: Excluded on Android where SELinux blocks netlink_route_socket bind.
+
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//go:build !android
+
+package common
+
+import (
+	"fmt"
+	"net"
+	"strings"
+)
+
+// GetLinkLocalAddress finds a link-local IPv6 address on this machine and
+// returns it formatted as "ip%zone:port" for direct LAN peer connections.
+// Falls back to loopback (::1) when no link-local interface is available.
+func GetLinkLocalAddress(port int) (string, error) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return "", err
+	}
+
+	// Collect all link-local candidates from non-loopback, up interfaces.
+	type candidate struct {
+		ip    net.IP
+		iface string
+	}
+	var candidates []candidate
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagLoopback != 0 || iface.Flags&net.FlagUp == 0 {
+			continue
+		}
+		addrs, _ := iface.Addrs()
+		for _, addr := range addrs {
+			ip, _, err := net.ParseCIDR(addr.String())
+			if err != nil {
+				continue
+			}
+			if ip.To16() != nil && ip.To4() == nil && ip.IsLinkLocalUnicast() {
+				candidates = append(candidates, candidate{ip: ip, iface: iface.Name})
+			}
+		}
+	}
+
+	if len(candidates) > 0 {
+		// Prefer common LAN interfaces: en0 (macOS WiFi), eth0/wlan0 (Linux).
+		// Avoid utun*, awdl*, llw*, ap* (VPN, AirDrop, low-latency WLAN, access point).
+		preferred := []string{"en0", "eth0", "wlan0", "en1", "wlp", "enp"}
+		for _, pref := range preferred {
+			for _, c := range candidates {
+				if strings.HasPrefix(c.iface, pref) {
+					return fmt.Sprintf("%s%%%s:%d", c.ip.String(), c.iface, port), nil
+				}
+			}
+		}
+		// No preferred match, pick first non-virtual candidate.
+		for _, c := range candidates {
+			skip := strings.HasPrefix(c.iface, "utun") ||
+				strings.HasPrefix(c.iface, "awdl") ||
+				strings.HasPrefix(c.iface, "llw")
+			if !skip {
+				return fmt.Sprintf("%s%%%s:%d", c.ip.String(), c.iface, port), nil
+			}
+		}
+		// All candidates are virtual, use first one anyway.
+		c := candidates[0]
+		return fmt.Sprintf("%s%%%s:%d", c.ip.String(), c.iface, port), nil
+	}
+
+	// Fallback: accept loopback for local testing.
+	for _, iface := range ifaces {
+		addrs, _ := iface.Addrs()
+		for _, addr := range addrs {
+			ip, _, err := net.ParseCIDR(addr.String())
+			if err != nil {
+				continue
+			}
+			if ip.To16() != nil && ip.To4() == nil && ip.IsLoopback() {
+				return fmt.Sprintf("%s:%d", ip.String(), port), nil
+			}
+		}
+	}
+
+	return "", fmt.Errorf("no link-local or loopback IPv6 address found")
+}
+
+// GetLocalIPv6 returns any local IPv6 address (including loopback, link-local, ULA).
+func GetLocalIPv6() (string, error) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return "", err
+	}
+
+	for _, iface := range ifaces {
+		addrs, _ := iface.Addrs()
+		for _, addr := range addrs {
+			ip, _, err := net.ParseCIDR(addr.String())
+			if err != nil {
+				continue
+			}
+			if ip.To16() != nil && ip.To4() == nil {
+				// allow loopback + ULA + link-local
+				return ip.String(), nil
+			}
+		}
+	}
+	return "", fmt.Errorf("no IPv6 address found")
+}
+
+// GetGlobalIPv6 returns a global-scope IPv6 address, falling back to any local IPv6.
+func GetGlobalIPv6() (string, error) {
+	interfaces, err := net.Interfaces()
+	if err != nil {
+		return "", err
+	}
+
+	for _, iface := range interfaces {
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+		for _, addr := range addrs {
+			ip, _, err := net.ParseCIDR(addr.String())
+			if err != nil {
+				continue
+			}
+			if ip.To16() != nil && ip.To4() == nil && !ip.IsLoopback() && !ip.IsLinkLocalUnicast() {
+				return ip.String(), nil
+			}
+		}
+	}
+	// Fallback to any local IPv6 (loopback, link-local, ULA) for local testing.
+	return GetLocalIPv6()
+}

--- a/pkg/logic/common/logic.go
+++ b/pkg/logic/common/logic.go
@@ -570,54 +570,46 @@ func (kd *KeibiDrop) JoinRoom() error {
 		}
 	}
 
-	// Try direct P2P first. If it fails and bridge is configured, fall back.
-	{
+	// When a bridge is configured, skip direct P2P entirely and connect via the relay.
+	// Direct P2P is unreliable when the peer's relay-registered IP is a loopback address
+	// (e.g. Android with no global IPv6 registers ::1), which would cause the initiator to
+	// connect to itself instead of the peer.
+	if kd.BridgeAddr != "" {
+		logger.Info("Bridge mode: joining via relay", "addr", kd.BridgeAddr)
+
+		outConn, err := kd.dialBridge(logger, 0)
+		if err != nil {
+			return fmt.Errorf("bridge dial (outbound): %w", err)
+		}
+		if err := session.PerformOutboundHandshakeOnConn(kd.session, outConn); err != nil {
+			outConn.Close()
+			return fmt.Errorf("bridge outbound handshake: %w", err)
+		}
+
+		inConn, err := kd.dialBridge(logger, 1)
+		if err != nil {
+			return fmt.Errorf("bridge dial (inbound): %w", err)
+		}
+		if err := session.PerformInboundHandshake(kd.session, inConn); err != nil {
+			inConn.Close()
+			return fmt.Errorf("bridge inbound handshake: %w", err)
+		}
+	} else {
+		// Direct P2P: dial outbound, then accept inbound.
 		peerAddr := net.JoinHostPort(kd.PeerIPv6IP, strconv.Itoa(kd.session.PeerPort))
-		directErr := session.PerformOutboundHandshake(kd.session, peerAddr)
-
-		if directErr == nil {
-			// Direct outbound succeeded. Accept inbound from peer.
-			logger.Info("Direct P2P outbound connected")
-			conn, err := kd.listener.Accept()
-			if err != nil {
-				logger.Error("Failed to accept", "error", err)
-				return err
-			}
-			if err := session.PerformInboundHandshake(kd.session, conn); err != nil {
-				logger.Error("Failed inbound handshake", "error", err)
-				return err
-			}
-		} else if kd.BridgeAddr != "" {
-			// Direct failed. Fall back to bridge relay.
-			logger.Warn("Direct P2P failed, falling back to bridge", "error", directErr, "bridge", kd.BridgeAddr)
-
-			// Reset session crypto state for fresh handshake via bridge.
-			kd.session.SEKOutbound = nil
-			kd.session.CipherMu.Lock()
-			kd.session.CipherSuite = ""
-			kd.session.CipherMu.Unlock()
-
-			outConn, err := kd.dialBridge(logger)
-			if err != nil {
-				return fmt.Errorf("bridge dial (outbound): %w", err)
-			}
-			if err := session.PerformOutboundHandshakeOnConn(kd.session, outConn); err != nil {
-				outConn.Close()
-				return fmt.Errorf("bridge outbound handshake: %w", err)
-			}
-
-			inConn, err := kd.dialBridge(logger)
-			if err != nil {
-				return fmt.Errorf("bridge dial (inbound): %w", err)
-			}
-			if err := session.PerformInboundHandshake(kd.session, inConn); err != nil {
-				inConn.Close()
-				return fmt.Errorf("bridge inbound handshake: %w", err)
-			}
-		} else {
-			// Direct failed, no bridge configured.
-			logger.Error("Direct P2P failed and no bridge configured", "error", directErr)
-			return directErr
+		if err := session.PerformOutboundHandshake(kd.session, peerAddr); err != nil {
+			logger.Error("Direct P2P failed and no bridge configured", "error", err)
+			return err
+		}
+		logger.Info("Direct P2P outbound connected")
+		conn, err := kd.listener.Accept()
+		if err != nil {
+			logger.Error("Failed to accept", "error", err)
+			return err
+		}
+		if err := session.PerformInboundHandshake(kd.session, conn); err != nil {
+			logger.Error("Failed inbound handshake", "error", err)
+			return err
 		}
 	}
 
@@ -749,7 +741,7 @@ func (kd *KeibiDrop) CreateRoom() error {
 			// Bridge fallback.
 			logger.Info("Bridge mode: connecting to relay", "addr", kd.BridgeAddr)
 
-			inConn, err := kd.dialBridge(logger)
+			inConn, err := kd.dialBridge(logger, 0)
 			if err != nil {
 				return fmt.Errorf("bridge dial (inbound): %w", err)
 			}
@@ -758,7 +750,7 @@ func (kd *KeibiDrop) CreateRoom() error {
 				return fmt.Errorf("bridge inbound handshake: %w", err)
 			}
 
-			outConn, err := kd.dialBridge(logger)
+			outConn, err := kd.dialBridge(logger, 1)
 			if err != nil {
 				return fmt.Errorf("bridge dial (outbound): %w", err)
 			}

--- a/pkg/logic/common/resilience.go
+++ b/pkg/logic/common/resilience.go
@@ -54,8 +54,8 @@ func (kd *KeibiDrop) InitConnectionResilience() error {
 	}
 	if kd.BridgeAddr != "" {
 		kd.ReconnectManager.BridgeAddr = kd.BridgeAddr
-		kd.ReconnectManager.DialBridge = func() (net.Conn, error) {
-			return kd.dialBridge(kd.logger)
+		kd.ReconnectManager.DialBridge = func(connIdx uint8) (net.Conn, error) {
+			return kd.dialBridge(kd.logger, connIdx)
 		}
 	}
 	kd.ReconnectManager.OnReconnected = kd.onReconnected

--- a/pkg/session/reconnect.go
+++ b/pkg/session/reconnect.go
@@ -48,7 +48,7 @@ type ReconnectManager struct {
 
 	// Bridge relay (for firewall traversal). If set, reconnect uses bridge instead of direct.
 	BridgeAddr string
-	DialBridge func() (net.Conn, error) // Dial bridge with room token
+	DialBridge func(connIdx uint8) (net.Conn, error) // Dial bridge with room token and connection index
 
 	// Callbacks
 	OnReconnecting  func()                               // Called when reconnection starts
@@ -238,7 +238,7 @@ func (r *ReconnectManager) reconnectAsInitiator() error {
 	if r.BridgeAddr != "" && r.DialBridge != nil {
 		logger.Info("Reconnecting via bridge", "addr", r.BridgeAddr)
 
-		outConn, err := r.DialBridge()
+		outConn, err := r.DialBridge(0)
 		if err != nil {
 			return fmt.Errorf("bridge dial (outbound): %w", err)
 		}
@@ -247,7 +247,7 @@ func (r *ReconnectManager) reconnectAsInitiator() error {
 			return fmt.Errorf("bridge outbound handshake: %w", err)
 		}
 
-		inConn, err := r.DialBridge()
+		inConn, err := r.DialBridge(1)
 		if err != nil {
 			return fmt.Errorf("bridge dial (inbound): %w", err)
 		}
@@ -306,7 +306,7 @@ func (r *ReconnectManager) reconnectAsResponder() error {
 	if r.BridgeAddr != "" && r.DialBridge != nil {
 		logger.Info("Reconnecting via bridge", "addr", r.BridgeAddr)
 
-		inConn, err := r.DialBridge()
+		inConn, err := r.DialBridge(0)
 		if err != nil {
 			return fmt.Errorf("bridge dial (inbound): %w", err)
 		}
@@ -315,7 +315,7 @@ func (r *ReconnectManager) reconnectAsResponder() error {
 			return fmt.Errorf("bridge inbound handshake: %w", err)
 		}
 
-		outConn, err := r.DialBridge()
+		outConn, err := r.DialBridge(1)
 		if err != nil {
 			return fmt.Errorf("bridge dial (outbound): %w", err)
 		}


### PR DESCRIPTION
Adds `connIdx` to `dialBridge` so the two connections per peer get distinct tokens. Prevents the bridge from pairing a peer with itself when its connections arrive before the remote peer's.

Fixes #139