### PR TITLE
Fix reconnect events and health status mapping for mobile

### DIFF
--- a/mobile/mobile.go
+++ b/mobile/mobile.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/KeibiSoft/KeibiDrop/pkg/discovery"
 	"github.com/KeibiSoft/KeibiDrop/pkg/identity"
+	"github.com/KeibiSoft/KeibiDrop/pkg/session"
 
 	"github.com/KeibiSoft/KeibiDrop/pkg/logic/common"
 )
@@ -605,9 +606,9 @@ func (api *API) GetConnectionStatus() int {
 		return 2 // no monitor = assume connected
 	}
 	switch api.kd.HealthMonitor.Health() {
-	case 0:
+	case session.HealthHealthy:
 		return 2 // connected
-	case 1:
+	case session.HealthDegraded:
 		return 3 // reconnecting
 	default:
 		return 0 // disconnected

--- a/pkg/logic/common/resilience.go
+++ b/pkg/logic/common/resilience.go
@@ -60,6 +60,8 @@ func (kd *KeibiDrop) InitConnectionResilience() error {
 	}
 	kd.ReconnectManager.OnReconnected = kd.onReconnected
 
+	kd.wireReconnectEvents()
+
 	// Start all components
 	kd.HealthMonitor.Start()
 
@@ -176,6 +178,28 @@ func (kd *KeibiDrop) onReconnected() {
 		kd.HealthMonitor.OnDisconnect = kd.onDisconnect
 		kd.HealthMonitor.Start()
 	}
+}
+
+func (kd *KeibiDrop) wireReconnectEvents() {
+	if kd.ReconnectManager == nil {
+		return
+	}
+
+	// wrapCb chains an event emission after an existing callback.
+	wrapCb := func(orig func(), event string) func() {
+		return func() {
+			if orig != nil {
+				orig()
+			}
+			if kd.OnEvent != nil {
+				kd.OnEvent(event)
+			}
+		}
+	}
+
+	kd.ReconnectManager.OnReconnecting = wrapCb(kd.ReconnectManager.OnReconnecting, "reconnecting:")
+	kd.ReconnectManager.OnReconnected = wrapCb(kd.ReconnectManager.OnReconnected, "reconnected:")
+	kd.ReconnectManager.OnGaveUp = wrapCb(kd.ReconnectManager.OnGaveUp, "gave_up:")
 }
 
 // ConnectionStatus returns the current connection health status.

--- a/pkg/logic/common/resilience_event_test.go
+++ b/pkg/logic/common/resilience_event_test.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+// ABOUTME: Tests that wireReconnectEvents pushes reconnecting/reconnected/gave_up events.
+// ABOUTME: Verifies mobile apps receive the same events as desktop (rustbridge).
+package common
+
+import (
+	"log/slog"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/KeibiSoft/KeibiDrop/pkg/session"
+)
+
+func collectEvents(kd *KeibiDrop) *[]string {
+	var mu sync.Mutex
+	events := make([]string, 0, 8)
+	kd.OnEvent = func(event string) {
+		mu.Lock()
+		events = append(events, event)
+		mu.Unlock()
+	}
+	return &events
+}
+
+func newEventTestKD() *KeibiDrop {
+	kd := &KeibiDrop{
+		logger: slog.New(slog.NewTextHandler(os.Stderr, nil)),
+	}
+	kd.ReconnectManager = session.NewReconnectManager(nil, kd.logger)
+	return kd
+}
+
+func TestWireReconnectEvents_EventFired(t *testing.T) {
+	tests := []struct {
+		name    string
+		trigger func(rm *session.ReconnectManager)
+		want    string
+	}{
+		{"reconnecting", func(rm *session.ReconnectManager) { rm.OnReconnecting() }, "reconnecting:"},
+		{"reconnected", func(rm *session.ReconnectManager) { rm.OnReconnected() }, "reconnected:"},
+		{"gave_up", func(rm *session.ReconnectManager) { rm.OnGaveUp() }, "gave_up:"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			kd := newEventTestKD()
+			events := collectEvents(kd)
+
+			kd.wireReconnectEvents()
+			tc.trigger(kd.ReconnectManager)
+
+			if len(*events) != 1 || (*events)[0] != tc.want {
+				t.Fatalf("expected [%s], got %v", tc.want, *events)
+			}
+		})
+	}
+}
+
+func TestWireReconnectEvents_OriginalCallbackPreserved(t *testing.T) {
+	kd := newEventTestKD()
+	events := collectEvents(kd)
+
+	originalCalled := false
+	kd.ReconnectManager.OnReconnected = func() { originalCalled = true }
+
+	kd.wireReconnectEvents()
+	kd.ReconnectManager.OnReconnected()
+
+	if !originalCalled {
+		t.Fatal("original OnReconnected callback was not called")
+	}
+	if len(*events) != 1 || (*events)[0] != "reconnected:" {
+		t.Fatalf("expected [reconnected:], got %v", *events)
+	}
+}
+
+func TestWireReconnectEvents_NilReconnectManagerIsNoop(t *testing.T) {
+	kd := &KeibiDrop{
+		logger: slog.New(slog.NewTextHandler(os.Stderr, nil)),
+	}
+	kd.wireReconnectEvents()
+}

--- a/rustbridge/main.go
+++ b/rustbridge/main.go
@@ -463,11 +463,10 @@ func KD_GetConnectionStatus() C.int {
 	if kd.HealthMonitor == nil {
 		return 2 // no monitor = assume connected
 	}
-	// Map: 0=healthy→2, 1=degraded→3, 2=disconnected→0
 	switch kd.HealthMonitor.Health() {
-	case 0:
+	case session.HealthHealthy:
 		return 2 // connected
-	case 1:
+	case session.HealthDegraded:
 		return 3 // reconnecting
 	default:
 		return 0 // disconnected
@@ -563,32 +562,8 @@ func KD_SetupEventCallbacks() {
 		}
 	}
 
-	// Wire reconnect manager events.
-	if kd.ReconnectManager != nil {
-		origOnReconnecting := kd.ReconnectManager.OnReconnecting
-		kd.ReconnectManager.OnReconnecting = func() {
-			if origOnReconnecting != nil {
-				origOnReconnecting()
-			}
-			pushEvent("reconnecting:")
-		}
-
-		origOnReconnected := kd.ReconnectManager.OnReconnected
-		kd.ReconnectManager.OnReconnected = func() {
-			if origOnReconnected != nil {
-				origOnReconnected()
-			}
-			pushEvent("reconnected:")
-		}
-
-		origOnGaveUp := kd.ReconnectManager.OnGaveUp
-		kd.ReconnectManager.OnGaveUp = func() {
-			if origOnGaveUp != nil {
-				origOnGaveUp()
-			}
-			pushEvent("gave_up:")
-		}
-	}
+	// Reconnect manager events (reconnecting/reconnected/gave_up) are
+	// wired centrally in wireReconnectEvents via kd.OnEvent.
 }
 
 func pushEvent(evt string) {


### PR DESCRIPTION
## Summary
- Fix off-by-one enum mapping in GetConnectionStatus that caused phone to show "Reconnecting..." immediately after connecting (HealthHealthy=1 was mapped as reconnecting)
- Wire reconnecting/reconnected/gave_up events from Go reconnect manager to mobile UI via OnEvent
- Remove duplicate event wiring from rustbridge (now handled centrally)

Closes #145

## Test plan
- [x] Connect phone and desktop via LAN local mode
- [x] Phone shows green "Connected" (not yellow "Reconnecting...")
- [x] Kill desktop, phone transitions to yellow "Reconnecting..."
- [x] Unit tests for event wiring (5 tests)