### PR TITLE
Fix event drop and transfer counter underflow

### DIFF
--- a/mobile/mobile.go
+++ b/mobile/mobile.go
@@ -628,7 +628,14 @@ func (api *API) SetupEventCallbacks() {
 			select {
 			case api.eventCh <- event:
 			default:
-				// Channel full, drop oldest.
+				select {
+				case <-api.eventCh:
+				default:
+				}
+				select {
+				case api.eventCh <- event:
+				default:
+				}
 			}
 		}
 	})

--- a/pkg/session/health.go
+++ b/pkg/session/health.go
@@ -94,7 +94,11 @@ func (m *HealthMonitor) Stop() {
 }
 
 func (m *HealthMonitor) TransferStarted() { m.activeTransfers.Add(1) }
-func (m *HealthMonitor) TransferEnded()   { m.activeTransfers.Add(-1) }
+func (m *HealthMonitor) TransferEnded() {
+	if m.activeTransfers.Add(-1) < 0 {
+		m.activeTransfers.Store(0)
+	}
+}
 
 // Health returns the current connection health state.
 func (m *HealthMonitor) Health() ConnectionHealth {


### PR DESCRIPTION
Mobile event channel was dropping newest events when full instead of oldest. Critical events (reconnected, gave_up) could be lost during heavy activity.

Transfer counter now guards against underflow after health monitor gets replaced during reconnection, preventing false disconnects during file transfers.

Fixes #144
Fixes #150