### PR TITLE
fix(connect): 15s P2P accept deadline prevents stuck connecting (#146)

### DIFF
--- a/pkg/logic/common/listener_test.go
+++ b/pkg/logic/common/listener_test.go
@@ -17,6 +17,7 @@ import (
 	"net/url"
 	"os"
 	"testing"
+	"time"
 )
 
 // TestListenerAcceptsIPv4 verifies the listener is dual-stack and accepts IPv4.
@@ -85,5 +86,83 @@ func TestLANAddressesSkippedInInternetMode(t *testing.T) {
 	// We verify the flag is correct — the logic test is the guard condition.
 	if kd.IsLocalMode {
 		t.Fatal("IsLocalMode should still be false after setting PeerLocalAddrs")
+	}
+}
+
+// TestListenerClosedOnBridgeFallback verifies that after closing the listener
+// (as CreateRoom does when P2P times out), TCP dials are refused, and the
+// reopened listener accepts connections again.
+// Regression test for #146: stale listener caused phantom P2P connections.
+func TestListenerClosedOnBridgeFallback(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	relayURL, _ := url.Parse("https://localhost:9999")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const port = 26704
+	kd, err := NewKeibiDropWithIP(ctx, logger, false, relayURL, port, 26705, "", t.TempDir(), false, false, "::1")
+	if err != nil {
+		t.Fatalf("NewKeibiDropWithIP failed: %v", err)
+	}
+
+	// Verify the listener works before close.
+	conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		t.Fatalf("Dial before close failed: %v", err)
+	}
+	conn.Close()
+
+	// Close the listener and nil it — simulates CreateRoom bridge fallback.
+	kd.listener.Close()
+	kd.listener = nil
+
+	// Dial MUST be refused now. This is the core of the #146 fix:
+	// before the fix, the listener stayed open and the kernel accepted
+	// phantom connections into the backlog.
+	_, dialErr := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), 500*time.Millisecond)
+	if dialErr == nil {
+		t.Fatal("Dial after listener close should be refused, but succeeded (phantom accept)")
+	}
+
+	// Reopen on the same port — simulates the reopen step.
+	addr := net.JoinHostPort("", fmt.Sprintf("%d", port))
+	newLn, err := net.Listen("tcp", addr)
+	if err != nil {
+		t.Fatalf("Reopen listener failed: %v", err)
+	}
+	kd.listener = newLn
+
+	// New listener must accept connections.
+	conn2, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		t.Fatalf("Dial after reopen failed: %v", err)
+	}
+	conn2.Close()
+}
+
+// TestAcceptDeadlineExitsOnTimeout verifies that Accept with SetDeadline
+// returns a deadline error promptly, matching the pattern used in JoinRoom
+// for inbound P2P accept.
+// Regression test for #146: goroutine leak when Accept had no deadline.
+func TestAcceptDeadlineExitsOnTimeout(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	relayURL, _ := url.Parse("https://localhost:9999")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	kd, err := NewKeibiDropWithIP(ctx, logger, false, relayURL, 26706, 26707, "", t.TempDir(), false, false, "::1")
+	if err != nil {
+		t.Fatalf("NewKeibiDropWithIP failed: %v", err)
+	}
+
+	_ = kd.listener.(*net.TCPListener).SetDeadline(time.Now().Add(200 * time.Millisecond))
+	_, acceptErr := kd.listener.Accept()
+	_ = kd.listener.(*net.TCPListener).SetDeadline(time.Time{})
+
+	if acceptErr == nil {
+		t.Fatal("Expected deadline error from Accept, got nil")
+	}
+	if !os.IsTimeout(acceptErr) {
+		t.Fatalf("Expected timeout error, got: %v", acceptErr)
 	}
 }

--- a/pkg/logic/common/logic.go
+++ b/pkg/logic/common/logic.go
@@ -698,39 +698,24 @@ func (kd *KeibiDrop) JoinRoom() error {
 			// fall back to bridge for both directions.
 			logger.Info("Direct P2P outbound connected, waiting for inbound (15s timeout)")
 
-			type acceptResult struct {
-				conn net.Conn
-				err  error
-			}
-			ch := make(chan acceptResult, 1)
-			go func() {
-				c, e := kd.listener.Accept()
-				ch <- acceptResult{c, e}
-			}()
+			_ = kd.listener.(*net.TCPListener).SetDeadline(time.Now().Add(15 * time.Second))
+			inConn, acceptErr := kd.listener.Accept()
+			_ = kd.listener.(*net.TCPListener).SetDeadline(time.Time{})
 
-			select {
-			case res := <-ch:
-				if res.err != nil {
-					logger.Warn("Inbound accept failed", "error", res.err)
-					needBridge = kd.BridgeAddr != ""
-					if !needBridge {
-						return res.err
-					}
-				} else {
-					if err := session.PerformInboundHandshake(kd.session, res.conn); err != nil {
-						logger.Error("Failed inbound handshake", "error", err)
-						return err
-					}
-					kd.ConnectionMode = "direct"
-					if kd.OnEvent != nil {
-						kd.OnEvent("connection_mode:direct")
-					}
-				}
-			case <-time.After(15 * time.Second):
-				logger.Warn("Inbound accept timed out (15s), peer likely behind firewall")
+			if acceptErr != nil {
+				logger.Warn("Inbound accept failed", "error", acceptErr)
 				needBridge = kd.BridgeAddr != ""
 				if !needBridge {
 					return fmt.Errorf("inbound accept timed out and no bridge configured")
+				}
+			} else {
+				if err := session.PerformInboundHandshake(kd.session, inConn); err != nil {
+					logger.Error("Failed inbound handshake", "error", err)
+					return err
+				}
+				kd.ConnectionMode = "direct"
+				if kd.OnEvent != nil {
+					kd.OnEvent("connection_mode:direct")
 				}
 			}
 
@@ -903,28 +888,28 @@ func (kd *KeibiDrop) CreateRoom() error {
 		}
 
 		if !useBridge {
-			if kd.BridgeAddr != "" {
-				_ = kd.listener.(*net.TCPListener).SetDeadline(time.Now().Add(15 * time.Second))
-			}
+			_ = kd.listener.(*net.TCPListener).SetDeadline(time.Now().Add(15 * time.Second))
 		}
 
 		var conn net.Conn
 		var acceptErr error
 		if !useBridge {
 			conn, acceptErr = kd.listener.Accept()
-			if kd.BridgeAddr != "" {
-				_ = kd.listener.(*net.TCPListener).SetDeadline(time.Time{})
-			}
+			_ = kd.listener.(*net.TCPListener).SetDeadline(time.Time{})
 		}
 
 		if !useBridge && acceptErr != nil {
-			if kd.BridgeAddr != "" {
-				logger.Warn("Direct P2P accept timed out, falling back to bridge", "error", acceptErr)
-				useBridge = true
-			} else {
-				logger.Error("Failed to accept", "error", acceptErr)
+			// Close the listener so late-arriving joiners get
+			// "connection refused" instead of a phantom TCP accept.
+			kd.listener.Close()
+			kd.listener = nil
+
+			if kd.BridgeAddr == "" {
+				logger.Error("Direct P2P accept timed out and no bridge configured", "error", acceptErr)
 				return acceptErr
 			}
+			logger.Warn("Direct P2P accept timed out, falling back to bridge", "error", acceptErr)
+			useBridge = true
 		}
 
 		if !useBridge {
@@ -1002,6 +987,16 @@ func (kd *KeibiDrop) CreateRoom() error {
 				return fmt.Errorf("bridge outbound handshake: %w", err)
 			}
 		}
+	}
+
+	// Reopen listener if it was closed during bridge fallback.
+	if kd.listener == nil {
+		addr := net.JoinHostPort("", strconv.Itoa(kd.inboundPort))
+		newLn, lnErr := net.Listen("tcp", addr)
+		if lnErr != nil {
+			return fmt.Errorf("reopen listener: %w", lnErr)
+		}
+		kd.listener = newLn
 	}
 
 	kd.filesystemReady = make(chan struct{})

--- a/tests/integration_timing_gap_test.go
+++ b/tests/integration_timing_gap_test.go
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// ABOUTME: Integration test for issue #146 — timing gap between creator and joiner.
+// ABOUTME: Proves the joiner is not stuck when connecting after the creator's P2P timeout.
+
+package tests
+
+import (
+	"context"
+	"log/slog"
+	"net/url"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/KeibiSoft/KeibiDrop/pkg/logic/common"
+	"github.com/stretchr/testify/require"
+)
+
+// TestConnect_TimingGap_JoinerAfterCreatorP2PTimeout reproduces issue #146:
+// the creator registers and times out on P2P (15s), then the joiner starts.
+// Before the fix, the joiner wasted 15s on a phantom P2P connection to the
+// creator's stale listener, then both peers got stuck.
+// After the fix, the joiner's P2P dial is refused and both fall back to bridge.
+//
+// This test uses explicit CreateRoom/JoinRoom (not Connect) to control which
+// peer is creator and which is joiner, avoiding fingerprint tiebreak randomness.
+func TestConnect_TimingGap_JoinerAfterCreatorP2PTimeout(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping timing gap test in short mode (takes ~20s)")
+	}
+	require := require.New(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+
+	relay := NewMockRelay()
+	bridge, err := NewMockBridge()
+	require.NoError(err)
+
+	handler := slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo})
+	logger := slog.New(handler)
+
+	aliceInPort := getFreePortInRange(t, 26100, 26249)
+	aliceOutPort := getFreePortInRange(t, 26250, 26399)
+	bobInPort := getFreePortInRange(t, 26400, 26549)
+	bobOutPort := getFreePortInRange(t, 26550, 26699)
+
+	relayURL, err := url.Parse(relay.URL())
+	require.NoError(err)
+
+	kdAlice, err := common.NewKeibiDropWithIP(ctx, logger.With("peer", "alice"),
+		false, relayURL, aliceInPort, aliceOutPort,
+		t.TempDir(), t.TempDir(), false, false, "::1")
+	require.NoError(err)
+
+	kdBob, err := common.NewKeibiDropWithIP(ctx, logger.With("peer", "bob"),
+		false, relayURL, bobInPort, bobOutPort,
+		t.TempDir(), t.TempDir(), false, false, "::1")
+	require.NoError(err)
+
+	// Set bridge on both peers so they can fall back.
+	kdAlice.BridgeAddr = bridge.FormatAddr()
+	kdBob.BridgeAddr = bridge.FormatAddr()
+
+	aliceFp, err := kdAlice.ExportFingerprint()
+	require.NoError(err)
+	bobFp, err := kdBob.ExportFingerprint()
+	require.NoError(err)
+
+	require.NoError(kdAlice.AddPeerFingerprint(bobFp))
+	require.NoError(kdBob.AddPeerFingerprint(aliceFp))
+
+	var runWg sync.WaitGroup
+	runWg.Add(2)
+	go func() { defer runWg.Done(); kdAlice.Run() }()
+	go func() { defer runWg.Done(); kdBob.Run() }()
+
+	// Step 1: Alice is the creator (explicit role, no tiebreak randomness).
+	aliceReady := make(chan error, 1)
+	go func() { aliceReady <- kdAlice.CreateRoom() }()
+
+	// Wait for Alice to register on relay.
+	WaitForCondition(t, 10*time.Second, 50*time.Millisecond, func() bool {
+		return relay.EntryCount() > 0
+	}, "waiting for Alice to register on relay")
+
+	// Step 2: Wait for creator's 15s P2P accept to time out.
+	t.Log("Waiting 18s for creator's P2P timeout and bridge fallback...")
+	time.Sleep(18 * time.Second)
+
+	// Step 3: NOW start joiner. This is the timing gap scenario from #146.
+	t.Log("Starting joiner (Bob) after creator's P2P timeout...")
+	bobStart := time.Now()
+	bobReady := make(chan error, 1)
+	go func() { bobReady <- kdBob.JoinRoom() }()
+
+	// Both should connect via bridge within 30s.
+	select {
+	case err := <-aliceReady:
+		require.NoError(err, "Alice CreateRoom failed")
+		t.Logf("Alice connected (mode: %s)", kdAlice.ConnectionMode)
+	case <-ctx.Done():
+		t.Fatal("timeout waiting for Alice CreateRoom")
+	}
+
+	select {
+	case err := <-bobReady:
+		require.NoError(err, "Bob JoinRoom failed")
+	case <-ctx.Done():
+		t.Fatal("timeout waiting for Bob JoinRoom — joiner stuck (issue #146)")
+	}
+
+	bobDuration := time.Since(bobStart)
+	t.Logf("Bob connected in %s (mode: %s)", bobDuration, kdBob.ConnectionMode)
+
+	require.Equal("bridge", kdAlice.ConnectionMode, "Alice should be on bridge")
+	require.Equal("bridge", kdBob.ConnectionMode, "Bob should be on bridge")
+
+	// Cleanup
+	kdAlice.StopConnectionResilience()
+	kdBob.StopConnectionResilience()
+	kdAlice.Shutdown()
+	kdBob.Shutdown()
+	done := make(chan struct{})
+	go func() { runWg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+	}
+	relay.Close()
+	bridge.Close()
+	cancel()
+}

--- a/tests/mock_bridge_test.go
+++ b/tests/mock_bridge_test.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// ABOUTME: Mock bridge relay for integration tests.
+// ABOUTME: Pairs TCP connections by matching 32-byte room tokens.
+
+package tests
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"sync"
+)
+
+// MockBridge is a minimal TCP bridge that pairs connections by room token.
+// Each client sends a 32-byte token; two clients with the same token are
+// paired and their data is relayed bidirectionally.
+type MockBridge struct {
+	listener net.Listener
+	mu       sync.Mutex
+	pending  map[[32]byte]net.Conn
+	done     chan struct{}
+}
+
+// NewMockBridge starts a mock bridge on a random port.
+func NewMockBridge() (*MockBridge, error) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, err
+	}
+	mb := &MockBridge{
+		listener: ln,
+		pending:  make(map[[32]byte]net.Conn),
+		done:     make(chan struct{}),
+	}
+	go mb.acceptLoop()
+	return mb, nil
+}
+
+// Addr returns the bridge's listen address.
+func (mb *MockBridge) Addr() string {
+	return mb.listener.Addr().String()
+}
+
+// Close shuts down the bridge.
+func (mb *MockBridge) Close() {
+	mb.listener.Close()
+	<-mb.done
+}
+
+func (mb *MockBridge) acceptLoop() {
+	defer close(mb.done)
+	for {
+		conn, err := mb.listener.Accept()
+		if err != nil {
+			return
+		}
+		go mb.handleConn(conn)
+	}
+}
+
+func (mb *MockBridge) handleConn(conn net.Conn) {
+	var token [32]byte
+	if _, err := io.ReadFull(conn, token[:]); err != nil {
+		conn.Close()
+		return
+	}
+
+	mb.mu.Lock()
+	if peer, ok := mb.pending[token]; ok {
+		delete(mb.pending, token)
+		mb.mu.Unlock()
+		go relay(conn, peer)
+		return
+	}
+	mb.pending[token] = conn
+	mb.mu.Unlock()
+}
+
+func relay(a, b net.Conn) {
+	var wg sync.WaitGroup
+	wg.Add(2)
+	cp := func(dst, src net.Conn) {
+		defer wg.Done()
+		io.Copy(dst, src)
+		dst.Close()
+	}
+	go cp(a, b)
+	go cp(b, a)
+	wg.Wait()
+}
+
+// PendingCount returns how many unpaired connections are waiting.
+func (mb *MockBridge) PendingCount() int {
+	mb.mu.Lock()
+	defer mb.mu.Unlock()
+	return len(mb.pending)
+}
+
+// FormatAddr returns "host:port" suitable for KeibiDrop.BridgeAddr.
+func (mb *MockBridge) FormatAddr() string {
+	return fmt.Sprintf("127.0.0.1:%d", mb.listener.Addr().(*net.TCPAddr).Port)
+}


### PR DESCRIPTION
## Summary

- Creator's `listener.Accept()` had no deadline when `BridgeAddr` was empty, causing infinite hang on "Connecting..."
- Always set 15s deadline on Accept in `CreateRoom`, close listener on timeout to block phantom TCP accepts
- Replace goroutine+select with synchronous `SetDeadline`+`Accept` in `JoinRoom` (fixes goroutine leak)

## Test plan

- [x] Unit tests: `TestListenerClosedOnBridgeFallback`, `TestAcceptDeadlineExitsOnTimeout`
- [x] Integration test: `TestConnect_TimingGap_JoinerAfterCreatorP2PTimeout` (mock relay + bridge, 18s gap)
- [x] Phone-to-desktop: verified phone P2P timeout fires at 15s via log, direct P2P connects when both peers press Connect within window
- [ ] Marius to verify on his setup