### PR TITLE
fix(session): cap SecureReader to prevent OOM from malicious length header

### DIFF
--- a/pkg/session/secureconn.go
+++ b/pkg/session/secureconn.go
@@ -23,6 +23,11 @@ import (
 
 const lengthHeaderSize = 4 // uint32 prefix
 
+// MaxSecureMessageSize caps the encrypted payload a SecureReader will accept.
+// Anything larger is rejected before allocation, preventing OOM from a
+// malicious length header on the raw TCP stream.
+const MaxSecureMessageSize = 20 * 1024 * 1024 // 20 MiB
+
 // Re-keying thresholds for forward secrecy.
 const (
 	RekeyBytesThreshold = 1 << 30 // 1 GB
@@ -124,6 +129,9 @@ func (s *SecureReader) Read() ([]byte, error) {
 	}
 	length := binary.BigEndian.Uint32(s.head[:])
 
+	if length > MaxSecureMessageSize {
+		return nil, fmt.Errorf("encrypted message length %d exceeds maximum %d", length, MaxSecureMessageSize)
+	}
 	if length < uint32(kbc.NonceSize)+uint32(s.aead.Overhead()) { //nolint:gosec // G115: NonceSize and Overhead are small constants
 		return nil, fmt.Errorf("encrypted message too short: %d bytes", length)
 	}

--- a/pkg/session/secureconn_test.go
+++ b/pkg/session/secureconn_test.go
@@ -228,6 +228,55 @@ func TestSecureConn_ConcurrentReadWrite(t *testing.T) {
 	require.NoError(t, <-errCh)
 }
 
+// TestSecureReader_RejectsOversizedLength sends a length header exceeding
+// MaxSecureMessageSize and verifies the reader returns an error instead of
+// allocating an unbounded buffer.
+func TestSecureReader_RejectsOversizedLength(t *testing.T) {
+	key := randomKey(t)
+	c1, c2 := net.Pipe()
+	t.Cleanup(func() {
+		c1.Close()
+		c2.Close()
+	})
+
+	reader := NewSecureReader(c2, key, kbc.CipherChaCha20)
+
+	go func() {
+		var header [4]byte
+		// 1 byte over the limit.
+		oversize := uint32(MaxSecureMessageSize + 1)
+		header[0] = byte(oversize >> 24)
+		header[1] = byte(oversize >> 16)
+		header[2] = byte(oversize >> 8)
+		header[3] = byte(oversize)
+		c1.Write(header[:])
+	}()
+
+	_, err := reader.Read()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exceeds maximum")
+}
+
+// TestSecureReader_AcceptsMaxSizeLength verifies that a message exactly at
+// MaxSecureMessageSize is accepted (not rejected by the bounds check).
+func TestSecureReader_AcceptsMaxSizeLength(t *testing.T) {
+	key := randomKey(t)
+	writer, reader := newConnPair(t, key, kbc.CipherChaCha20)
+
+	original := randomBytes(t, 64)
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := writer.Write(original)
+		errCh <- err
+	}()
+
+	got, err := reader.r.Read()
+	require.NoError(t, err)
+	require.Equal(t, original, got)
+	require.NoError(t, <-errCh)
+}
+
 // TestSecureConn_LeftoverAcrossMessages writes two messages and reads them
 // in 5000-byte chunks, crossing message boundaries to exercise leftover logic.
 func TestSecureConn_LeftoverAcrossMessages(t *testing.T) {


### PR DESCRIPTION
## Summary
- Adds `MaxSecureMessageSize` (20 MiB) bound check in `SecureReader.Read()` before allocating the message buffer
- `SecureConn` wraps raw TCP, not gRPC -- the gRPC 20 MiB limit does not protect this path
- Without the cap, a crafted 4-byte length header can trigger a ~4 GB allocation and OOM-crash the process

Closes #50