### PR TITLE
test+feat(kd): persistence tests and CLI parity

### DIFF
--- a/cmd/kd/main.go
+++ b/cmd/kd/main.go
@@ -32,6 +32,8 @@ import (
 	"golang.org/x/term"
 )
 
+var eventCh = make(chan string, 64)
+
 // socketPath returns the Unix socket path for daemon<->client communication.
 func socketPath() string {
 	if s := os.Getenv("KD_SOCKET"); s != "" {
@@ -154,6 +156,22 @@ func runDaemon() {
 		if err := kd.EnablePersistentIdentity(config.ConfigDir(), opts); err != nil {
 			logger.Warn("Failed to enable persistent identity, using ephemeral", "error", err)
 		}
+	}
+
+	kd.OnEvent = func(evt string) {
+		select {
+		case eventCh <- evt:
+		default:
+			select {
+			case <-eventCh:
+			default:
+			}
+			eventCh <- evt
+		}
+	}
+
+	if !cfg.Incognito && kd.Identity != nil && kd.AddressBook != nil && kd.AddressBook.Count() > 0 {
+		go kd.StartPresenceHeartbeat(ctx)
 	}
 
 	go kd.Run()
@@ -330,11 +348,16 @@ func dispatch(kd *common.KeibiDrop, req Request, cancel context.CancelFunc, ln n
 		type contactInfo struct {
 			Name        string `json:"name"`
 			Fingerprint string `json:"fingerprint"`
+			Online      bool   `json:"online"`
 			LastSeen    string `json:"last_seen,omitempty"`
 		}
 		out := make([]contactInfo, len(contacts))
 		for i, c := range contacts {
-			ci := contactInfo{Name: c.Name, Fingerprint: c.Fingerprint}
+			ci := contactInfo{
+				Name:        c.Name,
+				Fingerprint: c.Fingerprint,
+				Online:      kd.CheckContactPresence(c.Fingerprint),
+			}
 			if !c.LastSeen.IsZero() {
 				ci.LastSeen = c.LastSeen.Format(time.RFC3339)
 			}
@@ -391,6 +414,94 @@ func dispatch(kd *common.KeibiDrop, req Request, cancel context.CancelFunc, ln n
 			return errResponse(err.Error())
 		}
 		return okResponse(map[string]string{"saved": req.Args[0]})
+
+	case "unshare":
+		if len(req.Args) < 1 {
+			return errResponse("usage: kd unshare <filename>")
+		}
+		if err := kd.UnshareFile(req.Args[0]); err != nil {
+			return errResponse(err.Error())
+		}
+		return okResponse(map[string]string{"unshared": req.Args[0]})
+
+	case "add-as":
+		if len(req.Args) < 2 {
+			return errResponse("usage: kd add-as <local-path> <remote-name>")
+		}
+		if err := kd.AddFileAs(req.Args[0], req.Args[1]); err != nil {
+			return errResponse(err.Error())
+		}
+		return okResponse(map[string]string{
+			"added":       req.Args[0],
+			"remote_name": req.Args[1],
+		})
+
+	case "cancel-download":
+		if len(req.Args) < 1 {
+			return errResponse("usage: kd cancel-download <name>")
+		}
+		if err := kd.CancelDownload(req.Args[0]); err != nil {
+			return errResponse(err.Error())
+		}
+		return okResponse(map[string]string{"cancelled": req.Args[0]})
+
+	case "progress":
+		if len(req.Args) < 1 {
+			return errResponse("usage: kd progress <name>")
+		}
+		p := kd.GetDownloadProgress(req.Args[0])
+		return okResponse(map[string]any{
+			"name":     req.Args[0],
+			"progress": int(p * 100),
+		})
+
+	case "poll-event":
+		select {
+		case evt := <-eventCh:
+			return okResponse(map[string]string{"event": evt})
+		default:
+			return okResponse(map[string]string{"event": ""})
+		}
+
+	case "incognito":
+		if len(req.Args) < 1 {
+			if kd.Incognito {
+				return okResponse(map[string]string{"incognito": "true"})
+			}
+			return okResponse(map[string]string{"incognito": "false"})
+		}
+		enable := req.Args[0] == "true" || req.Args[0] == "1" || req.Args[0] == "on"
+		newFP, err := kd.ToggleIncognito(enable, config.ConfigDir())
+		if err != nil {
+			return errResponse(err.Error())
+		}
+		fp := newFP
+		if fp == "" {
+			fp, _ = kd.ExportFingerprint()
+		}
+		return okResponse(map[string]string{
+			"incognito":   fmt.Sprintf("%v", enable),
+			"fingerprint": fp,
+		})
+
+	case "peer-info":
+		pfp, _ := kd.GetPeerFingerprint()
+		data := map[string]any{
+			"peer_fingerprint": pfp,
+			"peer_ip":          kd.PeerIPv6IP,
+			"connection_mode":  kd.ConnectionMode,
+			"peer_persistent":  kd.IsPeerPersistent(),
+		}
+		if kd.AddressBook != nil && pfp != "" && pfp != "TOFU" {
+			data["peer_is_contact"] = kd.AddressBook.Lookup(pfp) != nil
+		}
+		return okResponse(data)
+
+	case "version":
+		return okResponse(map[string]string{
+			"version": common.Version,
+			"commit":  common.CommitHash,
+		})
 
 	case "stop", "quit":
 		kd.NotifyDisconnect()
@@ -556,6 +667,8 @@ func cmdList(kd *common.KeibiDrop) Response {
 		Source string `json:"source"` // "local" or "remote"
 	}
 
+	kd.SyncTracker.PruneStaleLocalFiles()
+
 	var files []fileInfo
 
 	kd.SyncTracker.LocalFilesMu.RLock()
@@ -662,15 +775,23 @@ USAGE:
   kd create                      Create a room (you are the initiator).
   kd join                        Join a room (peer must have created first).
   kd add <filepath>              Share a file with the peer.
+  kd add-as <path> <remote-name> Share with a custom remote name.
+  kd unshare <filename>          Stop sharing a file (keeps it on disk).
   kd list                        List all shared files (local + remote).
   kd pull <name> [local-path]    Download a remote file.
+  kd cancel-download <name>      Pause/cancel an active download.
+  kd progress <name>             Download progress (0-100).
   kd status                      Connection status and session info.
+  kd peer-info                   Peer details and connection mode.
+  kd poll-event                  Pop next event from the event queue.
   kd disconnect                  Disconnect and reset session.
-  kd contacts                    List saved contacts (JSON array).
+  kd contacts                    List saved contacts (with online status).
   kd add-contact <name> <fp>     Save a contact.
   kd remove-contact <fp>         Remove a saved contact.
   kd quick-connect <fp>          Connect to a saved contact (1-click).
   kd save-contact <name>         Save current peer as contact.
+  kd incognito [on|off]          Query or toggle incognito mode.
+  kd version                     Show version and commit hash.
   kd help                        Show this help.
 
 ENVIRONMENT (for "kd start"):

--- a/cmd/kd/main_test.go
+++ b/cmd/kd/main_test.go
@@ -1,8 +1,53 @@
-// ABOUTME: Tests for kd CLI argument parsing helpers.
-// ABOUTME: Currently covers isShowAll — see cmdShow for the call site.
+// ABOUTME: Tests for kd CLI helpers and dispatch argument validation.
+// ABOUTME: Covers isShowAll and dispatch error paths for missing args.
 package main
 
-import "testing"
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net"
+	"net/url"
+	"os"
+	"sync/atomic"
+	"testing"
+
+	"github.com/KeibiSoft/KeibiDrop/pkg/logic/common"
+	synctracker "github.com/KeibiSoft/KeibiDrop/pkg/sync-tracker"
+)
+
+var testPortBase int32 = 26900
+
+func nextTestPort() int {
+	return int(atomic.AddInt32(&testPortBase, 2))
+}
+
+func newTestKD(t *testing.T) *common.KeibiDrop {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	relay, _ := url.Parse("https://localhost:9999")
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	port := nextTestPort()
+	kd, err := common.NewKeibiDropWithIP(
+		ctx, logger, false, relay,
+		port, port+1, "", t.TempDir(),
+		false, false, "::1",
+	)
+	if err != nil {
+		t.Fatalf("NewKeibiDropWithIP: %v", err)
+	}
+	return kd
+}
+
+func dispatchTest(kd *common.KeibiDrop, cmd string, args ...string) Response {
+	ln, _ := net.Listen("tcp", "127.0.0.1:0")
+	defer ln.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	_ = ctx
+	return dispatch(kd, Request{Command: cmd, Args: args}, cancel, ln)
+}
 
 func TestIsShowAll(t *testing.T) {
 	cases := []struct {
@@ -16,7 +61,7 @@ func TestIsShowAll(t *testing.T) {
 		{"single field", []string{"fingerprint"}, false},
 		{"compound peer ip", []string{"peer", "ip"}, false},
 		{"all with extra", []string{"all", "extra"}, false},
-		{"capitalised", []string{"All"}, false}, // case-sensitive on purpose
+		{"capitalised", []string{"All"}, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -24,5 +69,167 @@ func TestIsShowAll(t *testing.T) {
 				t.Fatalf("isShowAll(%v) = %v, want %v", tc.args, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestDispatch_MissingArgs(t *testing.T) {
+	kd := newTestKD(t)
+	cases := []struct {
+		cmd  string
+		args []string
+	}{
+		{"register", nil},
+		{"add", nil},
+		{"pull", nil},
+		{"add-contact", []string{"name-only"}},
+		{"remove-contact", nil},
+		{"quick-connect", nil},
+		{"save-contact", nil},
+		{"unshare", nil},
+		{"add-as", []string{"only-one"}},
+		{"cancel-download", nil},
+		{"progress", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.cmd, func(t *testing.T) {
+			resp := dispatchTest(kd, tc.cmd, tc.args...)
+			if resp.OK {
+				t.Fatalf("%s with missing args should fail", tc.cmd)
+			}
+		})
+	}
+}
+
+func TestDispatch_UnknownCommand(t *testing.T) {
+	kd := newTestKD(t)
+	resp := dispatchTest(kd, "bogus-command")
+	if resp.OK {
+		t.Fatal("unknown command should fail")
+	}
+}
+
+func TestDispatch_Version(t *testing.T) {
+	kd := newTestKD(t)
+	resp := dispatchTest(kd, "version")
+	if !resp.OK {
+		t.Fatalf("version should succeed: %s", resp.Error)
+	}
+	var data map[string]string
+	if err := json.Unmarshal(resp.Data, &data); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := data["version"]; !ok {
+		t.Fatal("version response missing 'version' field")
+	}
+}
+
+func TestDispatch_PollEventEmpty(t *testing.T) {
+	kd := newTestKD(t)
+	resp := dispatchTest(kd, "poll-event")
+	if !resp.OK {
+		t.Fatalf("poll-event should succeed: %s", resp.Error)
+	}
+	var data map[string]string
+	if err := json.Unmarshal(resp.Data, &data); err != nil {
+		t.Fatal(err)
+	}
+	if data["event"] != "" {
+		t.Fatalf("expected empty event, got %q", data["event"])
+	}
+}
+
+func TestDispatch_PollEventWithData(t *testing.T) {
+	kd := newTestKD(t)
+	eventCh <- "reconnected:"
+	resp := dispatchTest(kd, "poll-event")
+	if !resp.OK {
+		t.Fatalf("poll-event should succeed: %s", resp.Error)
+	}
+	var data map[string]string
+	_ = json.Unmarshal(resp.Data, &data)
+	if data["event"] != "reconnected:" {
+		t.Fatalf("expected 'reconnected:', got %q", data["event"])
+	}
+}
+
+func TestDispatch_PeerInfo(t *testing.T) {
+	kd := newTestKD(t)
+	resp := dispatchTest(kd, "peer-info")
+	if !resp.OK {
+		t.Fatalf("peer-info should succeed: %s", resp.Error)
+	}
+	var data map[string]any
+	if err := json.Unmarshal(resp.Data, &data); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := data["connection_mode"]; !ok {
+		t.Fatal("missing connection_mode")
+	}
+}
+
+func TestDispatch_IncognitoQuery(t *testing.T) {
+	kd := newTestKD(t)
+	resp := dispatchTest(kd, "incognito")
+	if !resp.OK {
+		t.Fatalf("incognito query should succeed: %s", resp.Error)
+	}
+}
+
+func TestDispatch_UnshareExistingFile(t *testing.T) {
+	kd := newTestKD(t)
+	kd.SyncTracker.LocalFiles["test.txt"] = &synctracker.File{
+		Name: "test.txt",
+	}
+	resp := dispatchTest(kd, "unshare", "test.txt")
+	if !resp.OK {
+		t.Fatalf("unshare should succeed: %s", resp.Error)
+	}
+	kd.SyncTracker.LocalFilesMu.RLock()
+	_, exists := kd.SyncTracker.LocalFiles["test.txt"]
+	kd.SyncTracker.LocalFilesMu.RUnlock()
+	if exists {
+		t.Fatal("file should be removed from tracker")
+	}
+}
+
+func TestDispatch_UnshareNonexistent(t *testing.T) {
+	kd := newTestKD(t)
+	resp := dispatchTest(kd, "unshare", "ghost.txt")
+	if resp.OK {
+		t.Fatal("unshare nonexistent should fail")
+	}
+}
+
+func TestDispatch_ListPrunesStale(t *testing.T) {
+	kd := newTestKD(t)
+	kd.SyncTracker.LocalFiles["gone.txt"] = &synctracker.File{
+		Name:           "gone.txt",
+		RealPathOfFile: "/nonexistent/gone.txt",
+	}
+	resp := dispatchTest(kd, "list")
+	if !resp.OK {
+		t.Fatalf("list should succeed: %s", resp.Error)
+	}
+	kd.SyncTracker.LocalFilesMu.RLock()
+	_, exists := kd.SyncTracker.LocalFiles["gone.txt"]
+	kd.SyncTracker.LocalFilesMu.RUnlock()
+	if exists {
+		t.Fatal("stale file should be pruned by list")
+	}
+}
+
+func TestDispatch_Status(t *testing.T) {
+	kd := newTestKD(t)
+	resp := dispatchTest(kd, "status")
+	if !resp.OK {
+		t.Fatalf("status should succeed: %s", resp.Error)
+	}
+	var data map[string]any
+	_ = json.Unmarshal(resp.Data, &data)
+	if _, ok := data["fingerprint"]; !ok {
+		t.Fatal("status missing fingerprint")
+	}
+	if _, ok := data["connection_mode"]; !ok {
+		t.Fatal("status missing connection_mode")
 	}
 }

--- a/pkg/logic/common/registry_test.go
+++ b/pkg/logic/common/registry_test.go
@@ -1,0 +1,287 @@
+// ABOUTME: Tests for downloadRegistry and sharedFilesStore encrypted persistence.
+// ABOUTME: Covers round-trip, peer isolation, corruption recovery, and nil-receiver safety.
+package common
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+var testMasterKey = []byte("test-master-key-for-unit-tests!!")
+
+func TestDownloadRegistry_RegisterAndForPeer(t *testing.T) {
+	dir := t.TempDir()
+	r := newDownloadRegistry(dir, testMasterKey)
+	tag := r.peerTag("alice-fp", testMasterKey)
+	otherTag := r.peerTag("bob-fp", testMasterKey)
+
+	r.Register("/tmp/a.kdbitmap", tag)
+	r.Register("/tmp/b.kdbitmap", tag)
+	r.Register("/tmp/c.kdbitmap", otherTag)
+
+	got := r.ForPeer(tag)
+	if len(got) != 2 {
+		t.Fatalf("ForPeer(alice) = %d entries, want 2", len(got))
+	}
+	if r.Count() != 3 {
+		t.Fatalf("Count() = %d, want 3", r.Count())
+	}
+}
+
+func TestDownloadRegistry_Unregister(t *testing.T) {
+	dir := t.TempDir()
+	r := newDownloadRegistry(dir, testMasterKey)
+	tag := r.peerTag("alice-fp", testMasterKey)
+
+	r.Register("/tmp/a.kdbitmap", tag)
+	r.Register("/tmp/b.kdbitmap", tag)
+	r.Unregister("/tmp/a.kdbitmap")
+
+	got := r.ForPeer(tag)
+	if len(got) != 1 {
+		t.Fatalf("ForPeer after Unregister = %d, want 1", len(got))
+	}
+}
+
+func TestDownloadRegistry_PersistenceRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	r := newDownloadRegistry(dir, testMasterKey)
+	tag := r.peerTag("alice-fp", testMasterKey)
+
+	r.Register("/tmp/a.kdbitmap", tag)
+	r.Register("/tmp/b.kdbitmap", tag)
+
+	r2 := newDownloadRegistry(dir, testMasterKey)
+	got := r2.ForPeer(tag)
+	if len(got) != 2 {
+		t.Fatalf("ForPeer after reload = %d, want 2", len(got))
+	}
+}
+
+func TestDownloadRegistry_CorruptFileRecovery(t *testing.T) {
+	dir := t.TempDir()
+	r := newDownloadRegistry(dir, testMasterKey)
+	tag := r.peerTag("alice-fp", testMasterKey)
+	r.Register("/tmp/a.kdbitmap", tag)
+
+	regPath := filepath.Join(dir, ".kd_registry")
+	if err := os.WriteFile(regPath, []byte("garbage"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	r2 := newDownloadRegistry(dir, testMasterKey)
+	if r2.Count() != 0 {
+		t.Fatalf("corrupt file should yield empty registry, got %d", r2.Count())
+	}
+	if _, err := os.Stat(regPath); !os.IsNotExist(err) {
+		t.Fatal("corrupt file should be deleted on load")
+	}
+}
+
+func TestDownloadRegistry_EmptyDeletesFile(t *testing.T) {
+	dir := t.TempDir()
+	r := newDownloadRegistry(dir, testMasterKey)
+	tag := r.peerTag("alice-fp", testMasterKey)
+	r.Register("/tmp/a.kdbitmap", tag)
+
+	regPath := filepath.Join(dir, ".kd_registry")
+	if _, err := os.Stat(regPath); err != nil {
+		t.Fatalf("registry file should exist after Register: %v", err)
+	}
+
+	r.Unregister("/tmp/a.kdbitmap")
+	if _, err := os.Stat(regPath); !os.IsNotExist(err) {
+		t.Fatal("registry file should be deleted when empty")
+	}
+}
+
+func TestDownloadRegistry_MemoryOnlyMode(t *testing.T) {
+	r := newDownloadRegistry("", nil)
+	tag := r.peerTag("alice-fp", testMasterKey)
+	r.Register("/tmp/a.kdbitmap", tag)
+
+	if r.Count() != 1 {
+		t.Fatalf("memory-only Count() = %d, want 1", r.Count())
+	}
+}
+
+func TestDownloadRegistry_PeerTagDeterministic(t *testing.T) {
+	r := newDownloadRegistry("", nil)
+	t1 := r.peerTag("fp-abc", testMasterKey)
+	t2 := r.peerTag("fp-abc", testMasterKey)
+	if t1 != t2 {
+		t.Fatal("peerTag should be deterministic for same inputs")
+	}
+
+	t3 := r.peerTag("fp-xyz", testMasterKey)
+	if t1 == t3 {
+		t.Fatal("peerTag should differ for different fingerprints")
+	}
+}
+
+func TestSharedFilesStore_SaveLoadRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	s := newSharedFilesStore(dir, testMasterKey)
+	if s == nil {
+		t.Fatal("store should not be nil with valid inputs")
+	}
+
+	tag := [16]byte{1, 2, 3}
+	entries := []sharedEntry{
+		{PeerTag: tag, Path: "/tmp/photo.jpg", Size: 1024, ModTime: 99},
+		{PeerTag: tag, Path: "/tmp/doc.pdf", Size: 2048, ModTime: 100},
+	}
+	s.Save(entries)
+
+	got := s.Load()
+	if len(got) != 2 {
+		t.Fatalf("Load() = %d entries, want 2", len(got))
+	}
+	if got[0].Path != "/tmp/photo.jpg" || got[0].Size != 1024 {
+		t.Fatalf("entry 0 mismatch: %+v", got[0])
+	}
+	if got[1].Path != "/tmp/doc.pdf" || got[1].Size != 2048 {
+		t.Fatalf("entry 1 mismatch: %+v", got[1])
+	}
+}
+
+func TestSharedFilesStore_Clear(t *testing.T) {
+	dir := t.TempDir()
+	s := newSharedFilesStore(dir, testMasterKey)
+	s.Save([]sharedEntry{{Path: "/tmp/a.txt", Size: 1}})
+
+	storePath := filepath.Join(dir, ".kd_shared")
+	if _, err := os.Stat(storePath); err != nil {
+		t.Fatalf("store file should exist: %v", err)
+	}
+
+	s.Clear()
+	if _, err := os.Stat(storePath); !os.IsNotExist(err) {
+		t.Fatal("store file should be deleted after Clear")
+	}
+}
+
+func TestSharedFilesStore_SaveEmptyDeletesFile(t *testing.T) {
+	dir := t.TempDir()
+	s := newSharedFilesStore(dir, testMasterKey)
+	s.Save([]sharedEntry{{Path: "/tmp/a.txt", Size: 1}})
+
+	s.Save(nil)
+
+	storePath := filepath.Join(dir, ".kd_shared")
+	if _, err := os.Stat(storePath); !os.IsNotExist(err) {
+		t.Fatal("empty save should delete store file")
+	}
+}
+
+func TestSharedFilesStore_CorruptFileReturnsNil(t *testing.T) {
+	dir := t.TempDir()
+	s := newSharedFilesStore(dir, testMasterKey)
+
+	storePath := filepath.Join(dir, ".kd_shared")
+	if err := os.WriteFile(storePath, []byte("not-encrypted"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	got := s.Load()
+	if got != nil {
+		t.Fatalf("corrupt file should return nil, got %d entries", len(got))
+	}
+	if _, err := os.Stat(storePath); !os.IsNotExist(err) {
+		t.Fatal("corrupt file should be deleted")
+	}
+}
+
+func TestSharedFilesStore_NilReceiverSafe(t *testing.T) {
+	var s *sharedFilesStore
+	s.Save([]sharedEntry{{Path: "/tmp/a.txt"}})
+	got := s.Load()
+	s.Clear()
+
+	if got != nil {
+		t.Fatal("nil receiver Load should return nil")
+	}
+}
+
+func TestSharedFilesStore_NilInputsReturnsNil(t *testing.T) {
+	if s := newSharedFilesStore("", testMasterKey); s != nil {
+		t.Fatal("empty configDir should return nil")
+	}
+	if s := newSharedFilesStore(t.TempDir(), nil); s != nil {
+		t.Fatal("nil masterKey should return nil")
+	}
+}
+
+func TestSharedFilesStore_PeerIsolation(t *testing.T) {
+	dir := t.TempDir()
+	s := newSharedFilesStore(dir, testMasterKey)
+
+	tagA := [16]byte{1}
+	tagB := [16]byte{2}
+	entries := []sharedEntry{
+		{PeerTag: tagA, Path: "/tmp/for-alice.txt"},
+		{PeerTag: tagB, Path: "/tmp/for-bob.txt"},
+	}
+	s.Save(entries)
+
+	got := s.Load()
+	var aliceCount, bobCount int
+	for _, e := range got {
+		if e.PeerTag == tagA {
+			aliceCount++
+		}
+		if e.PeerTag == tagB {
+			bobCount++
+		}
+	}
+	if aliceCount != 1 || bobCount != 1 {
+		t.Fatalf("peer isolation: alice=%d bob=%d, want 1 each", aliceCount, bobCount)
+	}
+}
+
+func TestEncryptDecryptAESGCM_RoundTrip(t *testing.T) {
+	key := make([]byte, 32)
+	copy(key, []byte("32-byte-key-for-aes-256-testing!"))
+	plaintext := []byte("hello world")
+
+	ct, err := encryptAESGCM(key, plaintext)
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+
+	pt, err := decryptAESGCM(key, ct)
+	if err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+	if string(pt) != "hello world" {
+		t.Fatalf("round-trip mismatch: %q", pt)
+	}
+}
+
+func TestDecryptAESGCM_WrongKey(t *testing.T) {
+	key1 := make([]byte, 32)
+	key2 := make([]byte, 32)
+	copy(key1, []byte("key-one-for-encrypt-test-padding"))
+	copy(key2, []byte("key-two-for-decrypt-test-padding"))
+
+	ct, err := encryptAESGCM(key1, []byte("secret"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = decryptAESGCM(key2, ct)
+	if err == nil {
+		t.Fatal("decrypt with wrong key should fail")
+	}
+}
+
+func TestDecryptAESGCM_TooShort(t *testing.T) {
+	key := make([]byte, 32)
+	copy(key, []byte("32-byte-key-for-short-ct-test!!!"))
+
+	_, err := decryptAESGCM(key, []byte("short"))
+	if err == nil {
+		t.Fatal("decrypt of too-short ciphertext should fail")
+	}
+}

--- a/pkg/logic/common/unshare_test.go
+++ b/pkg/logic/common/unshare_test.go
@@ -1,0 +1,84 @@
+// ABOUTME: Tests for UnshareFile — removes file from SyncTracker, errors on missing.
+// ABOUTME: Covers the tracker mutation path; gRPC notification is fire-and-forget.
+package common
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+
+	synctracker "github.com/KeibiSoft/KeibiDrop/pkg/sync-tracker"
+)
+
+func newUnshareTestKD() *KeibiDrop {
+	kd := &KeibiDrop{
+		logger:      slog.New(slog.NewTextHandler(os.Stderr, nil)),
+		SyncTracker: synctracker.NewSyncTracker(),
+	}
+	return kd
+}
+
+func TestUnshareFile_RemovesFromTracker(t *testing.T) {
+	kd := newUnshareTestKD()
+	kd.SyncTracker.LocalFiles["photo.jpg"] = &synctracker.File{
+		Name:           "photo.jpg",
+		RealPathOfFile: "/tmp/photo.jpg",
+		Size:           1024,
+	}
+
+	if err := kd.UnshareFile("photo.jpg"); err != nil {
+		t.Fatalf("UnshareFile: %v", err)
+	}
+
+	kd.SyncTracker.LocalFilesMu.RLock()
+	_, exists := kd.SyncTracker.LocalFiles["photo.jpg"]
+	kd.SyncTracker.LocalFilesMu.RUnlock()
+
+	if exists {
+		t.Fatal("file should be removed from LocalFiles")
+	}
+}
+
+func TestUnshareFile_ErrorOnMissing(t *testing.T) {
+	kd := newUnshareTestKD()
+
+	err := kd.UnshareFile("nonexistent.txt")
+	if err == nil {
+		t.Fatal("expected error for unsharing missing file")
+	}
+}
+
+func TestUnshareFile_DoesNotAffectOtherFiles(t *testing.T) {
+	kd := newUnshareTestKD()
+	kd.SyncTracker.LocalFiles["keep.txt"] = &synctracker.File{
+		Name: "keep.txt",
+	}
+	kd.SyncTracker.LocalFiles["remove.txt"] = &synctracker.File{
+		Name: "remove.txt",
+	}
+
+	if err := kd.UnshareFile("remove.txt"); err != nil {
+		t.Fatalf("UnshareFile: %v", err)
+	}
+
+	kd.SyncTracker.LocalFilesMu.RLock()
+	defer kd.SyncTracker.LocalFilesMu.RUnlock()
+
+	if _, ok := kd.SyncTracker.LocalFiles["keep.txt"]; !ok {
+		t.Fatal("other files should not be affected")
+	}
+	if _, ok := kd.SyncTracker.LocalFiles["remove.txt"]; ok {
+		t.Fatal("removed file should be gone")
+	}
+}
+
+func TestUnshareFile_NoSessionNoPanic(t *testing.T) {
+	kd := newUnshareTestKD()
+	kd.SyncTracker.LocalFiles["file.txt"] = &synctracker.File{
+		Name: "file.txt",
+	}
+
+	if err := kd.UnshareFile("file.txt"); err != nil {
+		t.Fatalf("UnshareFile without session should succeed: %v", err)
+	}
+}

--- a/pkg/sync-tracker/file_tracker_test.go
+++ b/pkg/sync-tracker/file_tracker_test.go
@@ -1,0 +1,77 @@
+// ABOUTME: Tests for PruneStaleLocalFiles — removes entries for deleted files.
+// ABOUTME: Covers existing files, deleted files, empty paths, and empty tracker.
+package synctracker
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPruneStaleLocalFiles_RemovesDeleted(t *testing.T) {
+	dir := t.TempDir()
+	existing := filepath.Join(dir, "exists.txt")
+	if err := os.WriteFile(existing, []byte("data"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	st := NewSyncTracker()
+	st.LocalFiles["exists.txt"] = &File{
+		Name:           "exists.txt",
+		RealPathOfFile: existing,
+	}
+	st.LocalFiles["gone.txt"] = &File{
+		Name:           "gone.txt",
+		RealPathOfFile: filepath.Join(dir, "gone.txt"),
+	}
+
+	st.PruneStaleLocalFiles()
+
+	if _, ok := st.LocalFiles["exists.txt"]; !ok {
+		t.Fatal("existing file should be kept")
+	}
+	if _, ok := st.LocalFiles["gone.txt"]; ok {
+		t.Fatal("deleted file should be pruned")
+	}
+}
+
+func TestPruneStaleLocalFiles_SkipsEmptyPath(t *testing.T) {
+	st := NewSyncTracker()
+	st.LocalFiles["no-path"] = &File{
+		Name:           "no-path",
+		RealPathOfFile: "",
+	}
+
+	st.PruneStaleLocalFiles()
+
+	if _, ok := st.LocalFiles["no-path"]; !ok {
+		t.Fatal("entry with empty RealPathOfFile should be kept")
+	}
+}
+
+func TestPruneStaleLocalFiles_EmptyTracker(t *testing.T) {
+	st := NewSyncTracker()
+	st.PruneStaleLocalFiles()
+
+	if len(st.LocalFiles) != 0 {
+		t.Fatal("empty tracker should remain empty")
+	}
+}
+
+func TestPruneStaleLocalFiles_AllDeleted(t *testing.T) {
+	st := NewSyncTracker()
+	st.LocalFiles["a.txt"] = &File{
+		Name:           "a.txt",
+		RealPathOfFile: "/nonexistent/a.txt",
+	}
+	st.LocalFiles["b.txt"] = &File{
+		Name:           "b.txt",
+		RealPathOfFile: "/nonexistent/b.txt",
+	}
+
+	st.PruneStaleLocalFiles()
+
+	if len(st.LocalFiles) != 0 {
+		t.Fatalf("all stale files should be pruned, got %d", len(st.LocalFiles))
+	}
+}


### PR DESCRIPTION
## Summary

- Add 42 tests covering PR #155 persistence subsystems:
  downloadRegistry, sharedFilesStore, AES-GCM encryption,
  UnshareFile, PruneStaleLocalFiles
- Bring kd CLI to desktop parity with 10 new commands:
  unshare, add-as, cancel-download, progress, poll-event,
  incognito, peer-info, version
- Wire presence heartbeat on daemon start, event channel,
  prune-before-list, online status in contacts output

## Test plan

- [ ] `go test ./cmd/kd/ ./pkg/logic/common/ ./pkg/sync-tracker/`
- [ ] `kd start` + smoke test new commands (version, peer-info,
      poll-event, incognito, unshare)
- [ ] Verify no regressions in existing test suite