### PR TITLE
fix(resilience): nil deref on disconnect, save peer, v0.3.1

### DIFF
--- a/pkg/logic/common/ascii_art.go
+++ b/pkg/logic/common/ascii_art.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	Version    = "0.0.0"
+	Version    = "0.3.1"
 	CommitHash = "dev" // default fallback
 )
 

--- a/pkg/logic/common/resilience.go
+++ b/pkg/logic/common/resilience.go
@@ -7,7 +7,6 @@
 package common
 
 import (
-	"context"
 	"fmt"
 	"log/slog"
 	"net"
@@ -34,8 +33,8 @@ func (kd *KeibiDrop) InitConnectionResilience() error {
 	// Initialize health monitor
 	kd.HealthMonitor = session.NewHealthMonitor(kd.session, kd.KDClient, kd.logger)
 	kd.HealthMonitor.OnDisconnect = kd.onDisconnect
-	kd.HealthMonitor.OnHealthChange = func(old, new session.ConnectionHealth) {
-		logger.Info("Connection health changed", "from", old, "to", new)
+	kd.HealthMonitor.OnHealthChange = func(old, cur session.ConnectionHealth) {
+		logger.Info("Connection health changed", "from", old, "to", cur)
 	}
 
 	// Initialize reconnection manager
@@ -54,7 +53,11 @@ func (kd *KeibiDrop) InitConnectionResilience() error {
 			if err := kd.getRoomFromRelay(fingerprint); err != nil {
 				return "", 0, err
 			}
-			return kd.PeerIPv6IP, kd.session.PeerPort, nil
+			sess := kd.session
+			if sess == nil {
+				return "", 0, fmt.Errorf("session nil during relay lookup")
+			}
+			return kd.PeerIPv6IP, sess.PeerPort, nil
 		}
 	}
 	kd.ReconnectManager.AcceptConn = func(timeout time.Duration) (net.Conn, error) {
@@ -192,7 +195,7 @@ func (kd *KeibiDrop) onReconnected() {
 	logger.Info("Connection restored")
 
 	// Update cached peer info.
-	if kd.ReconnectManager != nil {
+	if kd.ReconnectManager != nil && kd.session != nil {
 		kd.ReconnectManager.CachedPeerIP = kd.PeerIPv6IP
 		kd.ReconnectManager.CachedPeerPort = kd.session.PeerPort
 	}
@@ -201,6 +204,13 @@ func (kd *KeibiDrop) onReconnected() {
 	if kd.RelayKeepalive != nil {
 		kd.RelayKeepalive.Resume()
 		_ = kd.RelayKeepalive.ForceRefresh()
+	}
+
+	// Stop old health monitor BEFORE tearing down gRPC so it doesn't
+	// fire heartbeats against the dead client and trigger a spurious
+	// second reconnection.
+	if kd.HealthMonitor != nil {
+		kd.HealthMonitor.Stop()
 	}
 
 	// Tear down stale gRPC infrastructure.
@@ -228,12 +238,12 @@ func (kd *KeibiDrop) onReconnected() {
 	}
 
 	// Restart health monitoring with the fresh client.
-	if kd.HealthMonitor != nil {
-		kd.HealthMonitor.Stop()
-	}
-	if kd.KDClient != nil {
+	if kd.KDClient != nil && kd.session != nil {
 		kd.HealthMonitor = session.NewHealthMonitor(kd.session, kd.KDClient, kd.logger)
 		kd.HealthMonitor.OnDisconnect = kd.onDisconnect
+		kd.HealthMonitor.OnHealthChange = func(old, cur session.ConnectionHealth) {
+			logger.Info("Connection health changed", "from", old, "to", cur)
+		}
 		kd.HealthMonitor.Start()
 	}
 
@@ -244,7 +254,8 @@ func (kd *KeibiDrop) onReconnected() {
 // notifyRestoredFiles sends ADD_FILE for each restored LocalFile so the peer
 // can see them. Only called after same-peer reconnection with confirmed files.
 func (kd *KeibiDrop) notifyRestoredFiles(logger *slog.Logger) {
-	if kd.KDClient == nil {
+	client := kd.KDClient
+	if client == nil {
 		return
 	}
 	kd.SyncTracker.LocalFilesMu.RLock()
@@ -255,11 +266,14 @@ func (kd *KeibiDrop) notifyRestoredFiles(logger *slog.Logger) {
 	kd.SyncTracker.LocalFilesMu.RUnlock()
 
 	for _, file := range files {
+		if kd.ctx.Err() != nil {
+			return
+		}
 		info, err := os.Stat(filepath.Clean(file.RealPathOfFile))
 		if err != nil {
 			continue
 		}
-		_, _ = kd.KDClient.Notify(context.Background(), &bindings.NotifyRequest{
+		_, _ = client.Notify(kd.ctx, &bindings.NotifyRequest{
 			Type: bindings.NotifyType(types.AddFile),
 			Path: file.RelativePath,
 			Attr: &bindings.Attr{
@@ -277,10 +291,11 @@ func (kd *KeibiDrop) notifyRestoredFiles(logger *slog.Logger) {
 // resumePartialDownloads checks the registry for bitmaps belonging to the
 // current peer and auto-resumes them. Called after successful reconnection.
 func (kd *KeibiDrop) resumePartialDownloads(logger *slog.Logger) {
-	if kd.dlRegistry == nil || kd.session == nil || kd.SyncTracker == nil {
+	sess := kd.session
+	if kd.dlRegistry == nil || sess == nil || kd.SyncTracker == nil {
 		return
 	}
-	tag := kd.dlRegistry.peerTag(kd.session.ExpectedPeerFingerprint, kd.registryKey)
+	tag := kd.dlRegistry.peerTag(sess.ExpectedPeerFingerprint, kd.registryKey)
 	paths := kd.dlRegistry.ForPeer(tag)
 	if len(paths) == 0 {
 		return

--- a/pkg/logic/common/resilience_nilguard_test.go
+++ b/pkg/logic/common/resilience_nilguard_test.go
@@ -1,0 +1,115 @@
+// ABOUTME: Tests that nil-guard snapshots in resilience.go prevent panics during shutdown races.
+// ABOUTME: Covers notifyRestoredFiles, resumePartialDownloads, onReconnected, and RelayLookup.
+package common
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/KeibiSoft/KeibiDrop/pkg/session"
+	synctracker "github.com/KeibiSoft/KeibiDrop/pkg/sync-tracker"
+)
+
+func newNilGuardTestKD() *KeibiDrop {
+	ctx, cancel := context.WithCancel(context.Background())
+	kd := &KeibiDrop{
+		logger:      slog.New(slog.NewTextHandler(os.Stderr, nil)),
+		SyncTracker: synctracker.NewSyncTracker(),
+		ctx:         ctx,
+		Cancel:      cancel,
+	}
+	return kd
+}
+
+func TestNotifyRestoredFiles_NilClient_NoPanic(t *testing.T) {
+	kd := newNilGuardTestKD()
+	defer kd.Cancel()
+
+	kd.SyncTracker.LocalFiles["file.txt"] = &synctracker.File{
+		Name:           "file.txt",
+		RelativePath:   "file.txt",
+		RealPathOfFile: "/tmp/nonexistent-test-file.txt",
+		Size:           100,
+	}
+
+	kd.notifyRestoredFiles(kd.logger)
+}
+
+func TestNotifyRestoredFiles_CancelledContext_NoPanic(t *testing.T) {
+	kd := newNilGuardTestKD()
+	kd.Cancel()
+
+	kd.SyncTracker.LocalFiles["file.txt"] = &synctracker.File{
+		Name:           "file.txt",
+		RelativePath:   "file.txt",
+		RealPathOfFile: "/tmp/nonexistent-test-file.txt",
+		Size:           100,
+	}
+
+	kd.notifyRestoredFiles(kd.logger)
+}
+
+func TestResumePartialDownloads_NilSession_NoPanic(t *testing.T) {
+	kd := newNilGuardTestKD()
+	defer kd.Cancel()
+
+	kd.dlRegistry = newDownloadRegistry("", nil)
+
+	kd.resumePartialDownloads(kd.logger)
+}
+
+func TestResumePartialDownloads_NilRegistry_NoPanic(t *testing.T) {
+	kd := newNilGuardTestKD()
+	defer kd.Cancel()
+
+	kd.resumePartialDownloads(kd.logger)
+}
+
+// TestNilSessionGuard_SkipsCachedPeerUpdate verifies the guard pattern used in
+// onReconnected (resilience.go:198). Calling onReconnected directly requires full
+// gRPC infrastructure, so this tests the guard inline. If the guard is removed
+// from production code, grep for "kd.session != nil" in onReconnected to verify.
+func TestNilSessionGuard_SkipsCachedPeerUpdate(t *testing.T) {
+	kd := newNilGuardTestKD()
+	defer kd.Cancel()
+
+	kd.ReconnectManager = session.NewReconnectManager(nil, kd.logger)
+	kd.ReconnectManager.CachedPeerPort = 9999
+
+	if kd.ReconnectManager != nil && kd.session != nil {
+		kd.ReconnectManager.CachedPeerPort = kd.session.PeerPort
+	}
+
+	if kd.ReconnectManager.CachedPeerPort != 9999 {
+		t.Fatalf("CachedPeerPort should be unchanged, got %d", kd.ReconnectManager.CachedPeerPort)
+	}
+}
+
+// TestNilSessionGuard_RelayLookupReturnsError verifies the guard pattern used in
+// the RelayLookup closure (resilience.go:56-59). The closure is defined inline in
+// InitConnectionResilience which requires a live session, so this tests the
+// pattern directly.
+func TestNilSessionGuard_RelayLookupReturnsError(t *testing.T) {
+	kd := newNilGuardTestKD()
+	defer kd.Cancel()
+
+	lookup := func(fingerprint string) (string, int, error) {
+		sess := kd.session
+		if sess == nil {
+			return "", 0, fmt.Errorf("session nil during relay lookup")
+		}
+		return kd.PeerIPv6IP, sess.PeerPort, nil
+	}
+
+	_, _, err := lookup("abc123")
+	if err == nil {
+		t.Fatal("expected error for nil session")
+	}
+	if !strings.Contains(err.Error(), "session nil") {
+		t.Fatalf("expected session-nil error, got: %v", err)
+	}
+}

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keibidrop-rust"
-version = "0.1.0"
+version = "0.3.1"
 edition = "2021"
 
 [dependencies]

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -565,12 +565,15 @@ fn connect_room(
         running.store(true, Ordering::Relaxed);
         start_file_watcher(running.clone(), weak.clone(), downloads, save_path, current_folder.clone());
 
-        // Transition to connected screen
+        let peer_persistent = bindings::KD_IsPeerPersistent() != 0;
+        let peer_already_contact = bindings::KD_IsPeerAlreadyContact() != 0;
         let _ = slint::invoke_from_event_loop(move || {
             if let Some(app) = weak.upgrade() {
                 app.set_room_action(0);
                 app.set_status_message(slint::SharedString::default());
                 app.set_error_message(slint::SharedString::default());
+                app.set_peer_is_persistent(peer_persistent);
+                app.set_peer_already_saved(peer_already_contact);
                 app.set_current_screen(target_screen);
             }
         });

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: keibidrop
 base: core22
-version: '0.2.0-beta.1'
+version: '0.3.1'
 summary: E2E encrypted peer-to-peer file sharing
 description: |
   KeibiDrop is an end-to-end encrypted peer-to-peer file sharing tool with


### PR DESCRIPTION
Fix nil deref panic in notifyRestoredFiles during disconnect.
Snapshot KDClient/session into locals to avoid shutdown races.
Stop health monitor before gRPC teardown in onReconnected.
Wire peer_is_persistent in connect_room so Save Peer shows.
Bump to 0.3.1.

Tests: `go test -race ./pkg/logic/common/...` — all pass.