### PR TITLE
fix(transfer): honest desktop download progress

### DIFF
--- a/pkg/filesystem/fs_android.go
+++ b/pkg/filesystem/fs_android.go
@@ -31,3 +31,12 @@ func NewFS(_ *slog.Logger) *FS { return &FS{} }
 func (fs *FS) Mount(_ string, _ bool, _ string) error { return nil }
 
 func (fs *FS) Unmount() {}
+
+// RefreshCallbacks is a no-op on android — there is no FUSE Root to re-wire.
+func (fs *FS) RefreshCallbacks() {}
+
+// IsMounted always returns false on android — no FUSE host is ever mounted.
+func (fs *FS) IsMounted() bool { return false }
+
+// ClearFiles is a no-op on android — there are no FUSE file/dir maps to clear.
+func (fs *FS) ClearFiles() {}

--- a/pkg/logic/common/logic.go
+++ b/pkg/logic/common/logic.go
@@ -502,18 +502,29 @@ func (kd *KeibiDrop) CancelDownload(remoteName string) error {
 // [0.0, 1.0]. Returns -1 if the file has no active or resumable download.
 func (kd *KeibiDrop) GetDownloadProgress(remoteName string) float64 {
 	kd.activeDownloadsMu.Lock()
-	bm, ok := kd.activeBitmaps[remoteName]
+	resolvedBitmapKey, ok := resolveKeyWithFallback(remoteName, func(k string) bool {
+		return kd.activeBitmaps[k] != nil
+	})
+	var bm *filesystem.ChunkBitmap
+	if ok {
+		bm = kd.activeBitmaps[resolvedBitmapKey]
+	}
 	kd.activeDownloadsMu.Unlock()
 	if ok && bm != nil {
 		return bm.Progress()
 	}
 
 	kd.SyncTracker.RemoteFilesMu.RLock()
-	rf, ok := kd.SyncTracker.RemoteFiles[remoteName]
-	kd.SyncTracker.RemoteFilesMu.RUnlock()
+	resolvedRFKey, ok := resolveKeyWithFallback(remoteName, func(k string) bool {
+		_, exists := kd.SyncTracker.RemoteFiles[k]
+		return exists
+	})
 	if !ok {
+		kd.SyncTracker.RemoteFilesMu.RUnlock()
 		return -1
 	}
+	rf := kd.SyncTracker.RemoteFiles[resolvedRFKey]
+	kd.SyncTracker.RemoteFilesMu.RUnlock()
 	localPath := filepath.Join(kd.ToSave, rf.RelativePath)
 	bitmapPath := filesystem.BitmapPath(localPath)
 	diskBm, err := filesystem.LoadChunkBitmap(bitmapPath, int64(rf.Size))

--- a/pkg/logic/common/progress_key.go
+++ b/pkg/logic/common/progress_key.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+// ABOUTME: Key-resolution helper for GetDownloadProgress — mirrors the fallback used by sibling FFI functions.
+// ABOUTME: Handles FUSE-origin senders that register bitmap keys with a leading "/" vs bare callers.
+
+package common
+
+import "strings"
+
+// resolveKeyWithFallback returns the canonical key and true when exists(key)
+// using the same three-step precedence that KD_GetFileSizeByName and
+// KD_SaveFileByName apply:
+//
+//  1. exact name
+//  2. "/" + name  (bare query, slash-keyed map entry)
+//  3. strings.TrimPrefix(name, "/")  (slash query, bare map entry)
+//
+// An exact match always wins; the two fallbacks are only tried in order when
+// the exact key is absent.  Returns ("", false) when none of the three forms
+// is present.
+func resolveKeyWithFallback(name string, exists func(string) bool) (string, bool) {
+	if exists(name) {
+		return name, true
+	}
+	if withSlash := "/" + name; exists(withSlash) {
+		return withSlash, true
+	}
+	if stripped := strings.TrimPrefix(name, "/"); stripped != name && exists(stripped) {
+		return stripped, true
+	}
+	return "", false
+}

--- a/pkg/logic/common/progress_key_test.go
+++ b/pkg/logic/common/progress_key_test.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+// ABOUTME: Tests for resolveKeyWithFallback — the key-normalisation helper used by GetDownloadProgress.
+// ABOUTME: Covers exact-key, slash-prefix fallback, strip-slash fallback, precedence, and not-found.
+
+package common
+
+import "testing"
+
+func TestResolveKeyWithFallback(t *testing.T) {
+	t.Run("exact key present", func(t *testing.T) {
+		m := map[string]struct{}{"foo": {}}
+		exists := func(k string) bool { _, ok := m[k]; return ok }
+		got, found := resolveKeyWithFallback("foo", exists)
+		if !found {
+			t.Fatal("expected found=true, got false")
+		}
+		if got != "foo" {
+			t.Errorf("got key %q, want %q", got, "foo")
+		}
+	})
+
+	t.Run("slash-prefix key, bare query", func(t *testing.T) {
+		m := map[string]struct{}{"/foo": {}}
+		exists := func(k string) bool { _, ok := m[k]; return ok }
+		got, found := resolveKeyWithFallback("foo", exists)
+		if !found {
+			t.Fatal("expected found=true, got false")
+		}
+		if got != "/foo" {
+			t.Errorf("got key %q, want %q", got, "/foo")
+		}
+	})
+
+	t.Run("bare key, slash-prefix query", func(t *testing.T) {
+		m := map[string]struct{}{"foo": {}}
+		exists := func(k string) bool { _, ok := m[k]; return ok }
+		got, found := resolveKeyWithFallback("/foo", exists)
+		if !found {
+			t.Fatal("expected found=true, got false")
+		}
+		if got != "foo" {
+			t.Errorf("got key %q, want %q", got, "foo")
+		}
+	})
+
+	t.Run("both present, exact wins", func(t *testing.T) {
+		m := map[string]struct{}{"foo": {}, "/foo": {}}
+		exists := func(k string) bool { _, ok := m[k]; return ok }
+		got, found := resolveKeyWithFallback("foo", exists)
+		if !found {
+			t.Fatal("expected found=true, got false")
+		}
+		if got != "foo" {
+			t.Errorf("got key %q, want %q (exact-key must win)", got, "foo")
+		}
+	})
+
+	t.Run("unknown key returns not found", func(t *testing.T) {
+		m := map[string]struct{}{}
+		exists := func(k string) bool { _, ok := m[k]; return ok }
+		got, found := resolveKeyWithFallback("bar", exists)
+		if found {
+			t.Fatalf("expected found=false, got true (key=%q)", got)
+		}
+		if got != "" {
+			t.Errorf("expected empty string on miss, got %q", got)
+		}
+	})
+}

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -42,8 +42,6 @@ fn is_hidden_file(name: &str) -> bool {
 
 /// Per-file download state tracked on the Rust side.
 struct DownloadInfo {
-    local_path: String,
-    expected_size: i64,
     downloading: bool,
     saved: bool,
     paused: bool,
@@ -250,17 +248,13 @@ fn start_file_watcher(
                     // Check download state
                     let (downloading, progress, saved, paused) = if let Some(info) = dl.get(&name) {
                         if info.downloading {
-                            // Poll local file size for progress
-                            let local_size = std::fs::metadata(&info.local_path)
-                                .map(|m| m.len() as f64)
-                                .unwrap_or(0.0);
-                            let expected = if info.expected_size > 0 {
-                                info.expected_size as f64
-                            } else {
-                                1.0
-                            };
-                            let prog = (local_size / expected).min(1.0);
-                            (true, prog as f32, false, false)
+                            // Progress from the chunk bitmap, not on-disk size: the
+                            // destination file is pre-allocated to full size, so size
+                            // would read 100% for the entire transfer.
+                            let c_name = CString::new(name.clone()).unwrap();
+                            let prog = bindings::KD_GetDownloadProgress(c_name.as_ptr() as *mut i8);
+                            let p = if prog >= 0 { prog as f32 / 100.0 } else { 0.0 };
+                            (true, p, false, false)
                         } else if info.paused {
                             // Paused: show progress from bitmap via FFI
                             let c_name = CString::new(name.clone()).unwrap();
@@ -271,10 +265,18 @@ fn start_file_watcher(
                             (false, if info.saved { 1.0 } else { 0.0 }, info.saved, false)
                         }
                     } else {
-                        // Check if file already exists in save path
+                        // Not tracked in-session. A leftover ".kdbitmap" sidecar means
+                        // an incomplete download (e.g. from a previous run) — not saved.
                         let local = format!("{}/{}", save_path, name);
-                        let already_saved = Path::new(&local).exists();
-                        (false, if already_saved { 1.0 } else { 0.0 }, already_saved, false)
+                        if Path::new(&format!("{}.kdbitmap", local)).exists() {
+                            let c_name = CString::new(name.clone()).unwrap();
+                            let prog = bindings::KD_GetDownloadProgress(c_name.as_ptr() as *mut i8);
+                            let p = if prog >= 0 { prog as f32 / 100.0 } else { 0.0 };
+                            (false, p, false, false)
+                        } else {
+                            let already_saved = Path::new(&local).exists();
+                            (false, if already_saved { 1.0 } else { 0.0 }, already_saved, false)
+                        }
                     };
 
                     files.push(FileInfo {
@@ -1230,10 +1232,6 @@ fn main() {
             let downloads = downloads_save.clone();
             let save_path = save_path_save.clone();
 
-            // Get file size by name
-            let c_name = CString::new(name.clone()).unwrap();
-            let size = bindings::KD_GetFileSizeByName(c_name.as_ptr() as *mut i8) as i64;
-
             let local_path = format!("{}/{}", save_path, name);
             // Create parent directories (handles nested paths like screenshots/foo.png)
             if let Some(parent) = Path::new(&local_path).parent() {
@@ -1251,8 +1249,6 @@ fn main() {
                 dl.insert(
                     name.clone(),
                     DownloadInfo {
-                        local_path: local_path.clone(),
-                        expected_size: size,
                         downloading: true,
                         saved: false,
                         paused: false,
@@ -1394,8 +1390,6 @@ fn main() {
             let downloads = downloads_all.clone();
             let base = save_path_all.clone();
             for name in to_save_names {
-                let c_name = CString::new(name.clone()).unwrap();
-                let size = bindings::KD_GetFileSizeByName(c_name.as_ptr() as *mut i8) as i64;
                 let local_path = format!("{}/{}", base, name);
                 // Create parent directories (handles nested paths like screenshots/foo.png)
                 if let Some(parent) = Path::new(&local_path).parent() {
@@ -1409,8 +1403,6 @@ fn main() {
                     dl.insert(
                         name.clone(),
                         DownloadInfo {
-                            local_path: local_path.clone(),
-                            expected_size: size,
                             downloading: true,
                             saved: false,
                             paused: false,


### PR DESCRIPTION
Desktop progress showed 100% for the entire transfer: the UI derived progress from on-disk file size, but the core pre-allocates the destination to full size up front. Now it reads chunk-based progress from the core, treats a leftover `.kdbitmap` sidecar as incomplete, and adds a `/`-prefix key fallback in `GetDownloadProgress` for FUSE-origin keys.

Verified live (Android → desktop, local mode): the bar climbs honestly, hits 100% only at completion, and the file is valid then.

The second commit (`fix(android)`) adds the missing `fs_android.go` FS stubs the gomobile build needs — a pre-existing build break, included only because it was required to rebuild/test the AAR. Can split into its own PR if you prefer.