### PR TITLE
fix: prefetch race, reconnect data race, FFI leaks, FUSE SyncTracker

### DIFF
--- a/cmd/cli/keibidrop-cli.go
+++ b/cmd/cli/keibidrop-cli.go
@@ -755,6 +755,10 @@ func main() {
 		color.Red("Fatal: %v", err)
 		os.Exit(1) //nolint:gocritic
 	}
+	kd.AutoCache = cfg.LiveCollab // live_collab → macFUSE auto_cache (same-size live edits, macOS)
+	for _, warn := range cfg.Warnings() {
+		logger.Warn("config flag note", "note", warn)
+	}
 
 	if !cfg.Incognito {
 		opts := common.EnableOpts{

--- a/cmd/kd/main.go
+++ b/cmd/kd/main.go
@@ -153,6 +153,10 @@ func runDaemon() {
 	kd.IsLocalMode = isLocal
 	kd.BridgeAddr = cfg.BridgeAddr
 	kd.StrictMode = cfg.StrictMode
+	kd.AutoCache = cfg.LiveCollab // live_collab → macFUSE auto_cache (same-size live edits, macOS)
+	for _, warn := range cfg.Warnings() {
+		logger.Warn("config flag note", "note", warn)
+	}
 
 	if !cfg.Incognito {
 		opts := common.EnableOpts{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strconv"
+	"strings"
 
 	"github.com/BurntSushi/toml"
 )
@@ -31,6 +32,7 @@ type Config struct {
 	Incognito         bool   `toml:"incognito"`
 	PrefetchOnOpen    bool   `toml:"prefetch_on_open"`
 	PushOnWrite       bool   `toml:"push_on_write"`
+	LiveCollab        bool   `toml:"live_collab"`        // prioritize seeing peers' same-size in-place edits live (macFUSE auto_cache); trades off local mmap-write integrity (git). See note in template.
 	PassphraseProtect bool   `toml:"passphrase_protect"` // opt into Tier 2 (Argon2id passphrase) for identity at-rest encryption
 }
 
@@ -163,6 +165,16 @@ no_fuse = %v
 # Collaborative sync options (experimental).
 # prefetch_on_open = false
 # push_on_write = false
+#
+# live_collab: see a peer's in-place edits immediately even when the edited
+# file keeps the same byte length. Default false = git-safe: files written via
+# mmap (notably git's index) stay intact, and same-size live edits are NOT
+# reflected until the next size change (macOS/macFUSE limitation). Set true to
+# prioritize live collaboration — on macOS this enables the auto_cache mount
+# option, which can corrupt mmap-written files such as git's index, so only
+# enable it on machines used for document/code collaboration, not git work.
+# On Linux and Windows both work regardless of this setting.
+# live_collab = false
 `, cfg.Relay, cfg.SavePath, cfg.MountPath, cfg.LogFile,
 		cfg.InboundPort, cfg.OutboundPort, cfg.NoFUSE)
 
@@ -205,9 +217,17 @@ strict_mode = %v
 
 # Set to true to force ephemeral keys every session (no persistent identity).
 incognito = %v
+
+# Prioritize live collaboration over local mmap-write integrity (default false).
+# false = git-safe: mmap writes (git's index) stay intact; on macOS a peer's
+# same-size in-place edit is not seen live until the next size change.
+# true = on macOS enables the auto_cache mount option so same-size edits show up
+# live, at the risk of corrupting mmap-written files (git). Linux/Windows handle
+# both regardless. Leave false unless this machine is for document/code collab.
+live_collab = %v
 `, cfg.Relay, cfg.SavePath, cfg.MountPath, cfg.LogFile,
 		cfg.InboundPort, cfg.OutboundPort, cfg.BridgeAddr,
-		cfg.NoFUSE, cfg.StrictMode, cfg.Incognito)
+		cfg.NoFUSE, cfg.StrictMode, cfg.Incognito, cfg.LiveCollab)
 
 	return os.WriteFile(path, []byte(content), 0600) // #nosec G306
 }
@@ -238,23 +258,26 @@ func applyEnvOverrides(cfg *Config) {
 	if v := envFirst("BRIDGE_ADDR", "KD_BRIDGE"); v != "" {
 		cfg.BridgeAddr = v
 	}
-	if v := envFirst("STRICT_MODE", "KD_STRICT"); v != "" {
-		cfg.StrictMode = true
+	if b, ok := envBool("STRICT_MODE", "KD_STRICT"); ok {
+		cfg.StrictMode = b
 	}
-	if v := envFirst("NO_FUSE", "KD_NO_FUSE"); v != "" {
-		cfg.NoFUSE = true
+	if b, ok := envBool("NO_FUSE", "KD_NO_FUSE"); ok {
+		cfg.NoFUSE = b
 	}
-	if v := envFirst("KEIBIDROP_INCOGNITO", "KD_INCOGNITO"); v != "" {
-		cfg.Incognito = true
+	if b, ok := envBool("KEIBIDROP_INCOGNITO", "KD_INCOGNITO"); ok {
+		cfg.Incognito = b
 	}
-	if v := envFirst("KEIBIDROP_PASSPHRASE_PROTECT", "KD_PASSPHRASE_PROTECT"); v != "" {
-		cfg.PassphraseProtect = true
+	if b, ok := envBool("KEIBIDROP_PASSPHRASE_PROTECT", "KD_PASSPHRASE_PROTECT"); ok {
+		cfg.PassphraseProtect = b
 	}
-	if v := envFirst("KEIBIDROP_PREFETCH_ON_OPEN", "PREFETCH_ON_OPEN_ENV"); v != "" {
-		cfg.PrefetchOnOpen = true
+	if b, ok := envBool("KEIBIDROP_PREFETCH_ON_OPEN", "PREFETCH_ON_OPEN_ENV"); ok {
+		cfg.PrefetchOnOpen = b
 	}
-	if v := envFirst("KEIBIDROP_PUSH_ON_WRITE", "PUSH_ON_WRITE_ENV"); v != "" {
-		cfg.PushOnWrite = true
+	if b, ok := envBool("KEIBIDROP_PUSH_ON_WRITE", "PUSH_ON_WRITE_ENV"); ok {
+		cfg.PushOnWrite = b
+	}
+	if b, ok := envBool("KEIBIDROP_LIVE_COLLAB", "LIVE_COLLAB_ENV"); ok {
+		cfg.LiveCollab = b
 	}
 }
 
@@ -266,4 +289,54 @@ func envFirst(names ...string) string {
 		}
 	}
 	return ""
+}
+
+// envBool resolves a boolean-valued env var from the given names. The second
+// return value reports whether any of the vars was set; when false the caller
+// should leave the existing (default / config-file) value untouched rather than
+// forcing it to false. A present value is parsed leniently: "0", "false",
+// "no", "off" (any case) → false; anything else → true. This fixes the old
+// presence-only behaviour where e.g. NO_FUSE=false wrongly enabled the flag.
+func envBool(names ...string) (val bool, set bool) {
+	v := envFirst(names...)
+	if v == "" {
+		return false, false
+	}
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "0", "false", "no", "off":
+		return false, true
+	default:
+		return true, true
+	}
+}
+
+// Warnings returns notes about flag combinations that are redundant or carry a
+// known tradeoff, for the caller to log at startup. None are fatal — there is
+// no combination that crashes or that the program must refuse. The cases are:
+//
+//   - no_fuse disables the FUSE mount, so the mount-tuning flags prefetch_on_open
+//     and live_collab have nothing to act on (the no-FUSE AddFile/PullFile API is
+//     used instead). They are silently ignored; we surface that here.
+//   - live_collab on macOS enables the macFUSE auto_cache mount option, which
+//     fixes same-size live-edit visibility but can corrupt files written via mmap
+//     (notably git's index). That is a deliberate tradeoff, flagged so it is not
+//     a surprise. On Linux/Windows live_collab is a no-op (both already work).
+//
+// Note prefetch_on_open and live_collab are NOT mutually exclusive: prefetch
+// fills the local disk cache while auto_cache governs the kernel page cache —
+// they operate at different layers and compose cleanly.
+func (c Config) Warnings() []string {
+	var w []string
+	if c.NoFUSE {
+		if c.PrefetchOnOpen {
+			w = append(w, "prefetch_on_open has no effect with no_fuse: it triggers on FUSE Open(), which never fires without a mount")
+		}
+		if c.LiveCollab {
+			w = append(w, "live_collab has no effect with no_fuse: it tunes the FUSE mount cache, while no_fuse uses the AddFile/PullFile API")
+		}
+	}
+	if c.LiveCollab && runtime.GOOS == "darwin" {
+		w = append(w, "live_collab enables macFUSE auto_cache: peers' same-size in-place edits become visible live, but files written via mmap on the mount (e.g. git's index) may be corrupted — do not run git operations on the mount in this mode")
+	}
+	return w
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -218,6 +218,14 @@ strict_mode = %v
 # Set to true to force ephemeral keys every session (no persistent identity).
 incognito = %v
 
+# FUSE download strategy. false (default, recommended) = on-demand: stream bytes
+# as they are read, so large files open and seek instantly and only what is read
+# is downloaded. true = prefetch-on-open: download the whole file in the
+# background when it is opened (good for offline use / smooth sequential
+# playback, but downloads everything). Persisted here so the choice survives
+# restarts.
+prefetch_on_open = %v
+
 # Prioritize live collaboration over local mmap-write integrity (default false).
 # false = git-safe: mmap writes (git's index) stay intact; on macOS a peer's
 # same-size in-place edit is not seen live until the next size change.
@@ -227,7 +235,7 @@ incognito = %v
 live_collab = %v
 `, cfg.Relay, cfg.SavePath, cfg.MountPath, cfg.LogFile,
 		cfg.InboundPort, cfg.OutboundPort, cfg.BridgeAddr,
-		cfg.NoFUSE, cfg.StrictMode, cfg.Incognito, cfg.LiveCollab)
+		cfg.NoFUSE, cfg.StrictMode, cfg.Incognito, cfg.PrefetchOnOpen, cfg.LiveCollab)
 
 	return os.WriteFile(path, []byte(content), 0600) // #nosec G306
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -43,3 +43,35 @@ func TestApplyEnvOverrides_DefaultsNotSet(t *testing.T) {
 		t.Error("expected PassphraseProtect=false when env var not set")
 	}
 }
+
+// TestSaveLoad_PrefetchOnOpenPersists verifies the on-demand/prefetch toggle
+// survives a Save->Load round-trip. It is read on Load, but Save must also WRITE
+// it — otherwise a UI toggle silently resets to on-demand next session.
+func TestSaveLoad_PrefetchOnOpenPersists(t *testing.T) {
+	t.Setenv("KEIBIDROP_CONFIG_DIR", t.TempDir())
+
+	// Default must be on-demand (prefetch off) — the recommended default.
+	if DefaultConfig().PrefetchOnOpen {
+		t.Fatal("default PrefetchOnOpen should be false (on-demand)")
+	}
+
+	// Persist both FUSE toggles ON.
+	cfg := DefaultConfig()
+	cfg.PrefetchOnOpen = true
+	cfg.LiveCollab = true
+	if err := Save(cfg); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// A fresh Load must observe both (proves Save actually wrote them).
+	got, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !got.PrefetchOnOpen {
+		t.Error("prefetch_on_open did not persist across Save/Load")
+	}
+	if !got.LiveCollab {
+		t.Error("live_collab did not persist across Save/Load")
+	}
+}

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -11,6 +11,18 @@ package config
 const InboundPort = 26431
 const OutboundPort = 26432
 
+// Peer connection ports must fall in this range. Handshake and relay
+// registration reject anything outside it.
+const (
+	MinPeerPort = 26000
+	MaxPeerPort = 27000
+)
+
+// ValidPeerPort reports whether port is within the allowed peer port range.
+func ValidPeerPort(port int) bool {
+	return port >= MinPeerPort && port <= MaxPeerPort
+}
+
 const BlockSize = 4 * 1024 * 1024 // 4 MiB - larger chunks = fewer gRPC round-trips over WAN
 
 // gRPC message size limits

--- a/pkg/filesystem/api.go
+++ b/pkg/filesystem/api.go
@@ -32,6 +32,7 @@ type FS struct {
 	// Collab sync options (set from env before Mount).
 	PrefetchOnOpen bool // If true, fetch entire file on Open() and write to local disk.
 	PushOnWrite    bool // If true, async push deltas to peer on Write().
+	AutoCache      bool // If true (live_collab), add the macFUSE auto_cache mount option so a peer's same-size in-place edit is seen live. Trades off mmap-write integrity (git) on macOS; no-op on Linux/Windows.
 
 	// Host.
 	host *winfuse.FileSystemHost
@@ -143,11 +144,16 @@ func (fs *FS) Mount(mountPoint string, isSecond bool, downloadPath string) error
 	fs.host = host
 	fs.mountPoint = cleanMountPoint
 
-	opts := getMountOptions()
+	opts := getMountOptions(fs.AutoCache)
 
 	fs.logger.Warn("FUSE Mount calling host.Mount", "cleanMountPoint", cleanMountPoint, "opts", opts)
 	ok := fs.host.Mount(cleanMountPoint, opts)
 	if !ok {
+		// Reset host/Root so IsMounted() reports false. Otherwise a failed mount
+		// leaves them set, and the next reconnect takes the "already mounted,
+		// waiting" branch and never retries — hanging the mount permanently.
+		fs.host = nil
+		fs.Root = nil
 		fs.logger.Error("FUSE Mount failed", "mountPoint", cleanMountPoint)
 		return fmt.Errorf("FUSE mount failed for %s: ensure user_allow_other is set in /etc/fuse.conf, or run with KD_NO_FUSE=1", cleanMountPoint)
 	}

--- a/pkg/filesystem/fs_android.go
+++ b/pkg/filesystem/fs_android.go
@@ -24,6 +24,7 @@ type FS struct {
 	OpenStreamProvider func() types.FileStreamProvider
 	PrefetchOnOpen     bool
 	PushOnWrite        bool
+	AutoCache          bool // Unused on Android (no FUSE); present so shared setup code compiles.
 }
 
 func NewFS(_ *slog.Logger) *FS { return &FS{} }

--- a/pkg/filesystem/fuse_directory.go
+++ b/pkg/filesystem/fuse_directory.go
@@ -248,71 +248,14 @@ func (d *Dir) Chown(path string, uid uint32, gid uint32) (errCode int) {
 //	   O_EXCL      error if O_CREAT and the file exists"
 //
 // Use winfuse.O_ACCMODE to extract access mode (portable across macOS/Linux/Windows).
-func (d *Dir) Create(path string, flags int, mode uint32) (errCode int, fh uint64) {
-	defer d.recoverPanic("Create", &errCode)
-	if e := checkPath(path); e != 0 {
-		return e, 0
-	}
-	logger := d.logger.With("method", "create", "path", path)
-	// accessMode := flags & winfuse.O_ACCMODE
-	// logger.Info("Create called", "flags", flags, "accessMode", accessMode, "mode", mode, "isRDWR", accessMode == winfuse.O_RDWR)
-
-	d.AfmLock.Lock()
-	defer d.AfmLock.Unlock()
-	d.OpenMapLock.Lock()
-	defer d.OpenMapLock.Unlock()
-
-	relativePath := path
-	path = filepath.Clean(filepath.Join(d.LocalDownloadFolder, path))
-
-	// Extract permission bits only (mode may include S_IFREG file type bits).
-	// Ensure owner has write permission so file can be reopened after close.
-	createMode := mode & 0o777
-	if createMode&0o200 == 0 {
-		createMode |= 0o200 // Add owner write permission
-	}
-	if createMode == 0 {
-		createMode = 0o644 // Default if mode was 0
-	}
-
-	fd, err := platOpen(path, flags, createMode)
-	if err != nil {
-		logger.Error("Failed to create file", "error", err)
-		return int(convertOsErrToSyscallErrno("open", err)), 0
-	}
-
-	name := strings.Split(path, "/")
-
-	f := &File{
-		logger:          logger,
-		openFileCounter: OpenFileCounter{mu: &sync.Mutex{}, counter: 1},
-		Inode:           uint64(fd),
-		Name:            name[len(name)-1],
-		RelativePath:    relativePath,
-		RealPathOfFile:  path,
-		OnLocalChange:   d.OnLocalChange,
-		StreamProvider:  d.OpenStreamProvider(),
-		NotRemoteSynced: true,
-		IsLocalPresent:  true, // File was just created locally
-		LocalNewer:      true, // Local version is the only version
-	}
-
-	if stgo, statErr := platLstat(path); statErr == nil {
-		st := new(winfuse.Stat_t)
-		*st = stgo
-		uid, gid, _ := winfuse.Getcontext()
-		st.Uid = uid
-		st.Gid = gid
-		f.stat = st
-	}
-
-	handleID := allocHandleID()
-	f.CurrentHandleID = handleID
-	d.AllFileMap[relativePath] = f
-	d.OpenFileHandlers[handleID] = &HandleEntry{FD: fd, File: f}
-
-	// logger.Info("Created file", "fd", fd)
-	return 0, handleID
+// Create is dead on all platforms: cgofuse routes creates through CreateEx
+// (which we implement; see host.go create dispatch). It is kept only to satisfy
+// fuse.FileSystemInterface. Delegate to CreateEx so there is ONE implementation
+// — no duplicated logic to drift, and it stays correct if it were ever called.
+func (d *Dir) Create(path string, flags int, mode uint32) (errCode int, retFh uint64) {
+	fi := winfuse.FileInfo_t{Flags: flags}
+	errc := d.CreateEx(path, mode, &fi)
+	return errc, fi.Fh
 }
 
 // shouldUseDirectIo determines if a file should bypass kernel page cache.
@@ -484,8 +427,14 @@ func (d *Dir) OpenEx(path string, fi *winfuse.FileInfo_t) (errCode int) {
 		}
 	}
 
-	// File already opened - return existing handle
-	if fh.openFileCounter.CountOpenDescriptors() != 0 {
+	// File already opened - reuse the existing shared handle, but ONLY while it is
+	// still active. OpenIfActive atomically bumps the open count iff it is >0; the
+	// kernel calls Release once per open(), so each open must add a count or a
+	// racing async Release of an earlier handle drops the count to 0 and tears
+	// down the shared fd/pool — leaving this open's Read with ok=false, which then
+	// blind-preads the sparse cache file and returns zeros. If the count just hit
+	// 0 (last handle being torn down), fall through to a fresh open.
+	if fh.openFileCounter.OpenIfActive() {
 		handleID := fh.CurrentHandleID
 		d.AfmLock.Unlock()
 		fi.Fh = handleID
@@ -508,20 +457,29 @@ func (d *Dir) OpenEx(path string, fi *winfuse.FileInfo_t) (errCode int) {
 		if remoteFile.stat != nil {
 			remoteTotalSize = uint64(remoteFile.stat.Size)
 		}
-		if remoteFile.NotLocalSynced {
-			// logger.Info("Remote has newer version, streaming from remote", "path", path)
-			localNewer = false
-			remoteHasUpdate = true
-		} else if remoteTotalSize > 0 {
-			// Even if NotLocalSynced=false, verify download is actually complete.
-			// IMPORTANT: Can't use file size because pre-allocation makes file look complete.
-			// Use Download.BytesDownloaded which tracks actual bytes received.
-			bytesDownloaded := remoteFile.Download.BytesDownloaded.Load()
-			if bytesDownloaded < remoteTotalSize {
-				// logger.Info("Download incomplete, re-streaming from remote", "bytesDownloaded", bytesDownloaded, "remoteSize", remoteTotalSize)
-				localNewer = false
+		// Only consider streaming from the peer when our local copy is NOT
+		// authoritative. A local write or rename sets LocalNewer=true (e.g. git's
+		// atomic index.lock→index on commit); the local content then wins. Without
+		// this guard, the incomplete-download check below fires whenever
+		// Download.BytesDownloaded — which only counts REMOTE fetches — lags the
+		// stat.Size that refreshFileStat updated from the local write, so we
+		// re-stream the peer's stale bytes over our just-written file. That is the
+		// "git index file corrupt" we lose on Linux (and usually win on macOS).
+		// Peer edits set LocalNewer=false, so live-collab still streams here.
+		if !localNewer {
+			if remoteFile.NotLocalSynced {
+				// logger.Info("Remote has newer version, streaming from remote", "path", path)
 				remoteHasUpdate = true
-				needsRemark = true
+			} else if remoteTotalSize > 0 {
+				// Even if NotLocalSynced=false, verify download is actually complete.
+				// IMPORTANT: Can't use file size because pre-allocation makes file look complete.
+				// Use Download.BytesDownloaded which tracks actual bytes received.
+				bytesDownloaded := remoteFile.Download.BytesDownloaded.Load()
+				if bytesDownloaded < remoteTotalSize {
+					// logger.Info("Download incomplete, re-streaming from remote", "bytesDownloaded", bytesDownloaded, "remoteSize", remoteTotalSize)
+					remoteHasUpdate = true
+					needsRemark = true
+				}
 			}
 		}
 	}
@@ -733,8 +691,24 @@ func (d *Dir) OpenEx(path string, fi *winfuse.FileInfo_t) (errCode int) {
 	d.OpenMapLock.Unlock()
 	d.AfmLock.Unlock()
 
+	// Prefetch-on-open (Netflix-style): when enabled, fill the rest of the file
+	// in the background while on-demand reads serve immediate seeks. The two
+	// cooperate via the chunk bitmap (prefetch skips chunks reads already got).
+	// Guarded so a second handle on the same file doesn't start a duplicate.
+	if remoteHasUpdate && d.PrefetchOnOpen && fh.PrefetchCancel == nil {
+		d.startPrefetch(logger, fh, path)
+	}
+
 	fi.Fh = handleID
 	fi.DirectIo = shouldUseDirectIo(path, flags)
+	// Remote file: don't let the kernel keep the page cache across opens. A peer
+	// can edit the file underneath us (live collab); macFUSE only drops its data
+	// cache on a size change, so a same-size in-place edit would keep serving
+	// stale pages. KeepCache=false makes each open re-read through our Read
+	// handler, which the reset bitmap then re-fetches. This is per-file, so
+	// local mmap writes (git's index) keep their cache and stay consistent —
+	// unlike the global auto_cache mount option, which corrupts them.
+	fi.KeepCache = false
 	// logger.Info("Opened for remote streaming", "fh", fd, "directIo", fi.DirectIo, "remoteHasUpdate", remoteHasUpdate, "fhNotLocalSynced", fh.NotLocalSynced, "poolNil", fh.StreamPool == nil)
 	return 0
 }
@@ -1116,209 +1090,16 @@ func (d *Dir) Mknod(path string, mode uint32, dev uint64) (errCode int) {
 	return 0
 }
 
+// Open is dead on all platforms: cgofuse routes opens through OpenEx (which we
+// implement — see host.go's open dispatch), proven by the suite passing with this
+// returning ENOSYS on Linux+macOS. It exists only to satisfy the base
+// fuse.FileSystemInterface; OpenEx is the real (default) open path. Delegate to
+// it so there is no duplicated open logic to drift — that duplication is what hid
+// the handle-counter bug, now fixed once in OpenEx.
 func (d *Dir) Open(path string, flags int) (errCode int, retFh uint64) {
-	defer d.recoverPanic("Open", &errCode)
-	if e := checkPath(path); e != 0 {
-		return e, 0
-	}
-	// d.logger.Info("FUSE open(legacy)", "path", path, "flags", flags)
-	logger := d.logger.With("method", "open", "path", path, "flags", flags)
-
-	localPath := filepath.Clean(filepath.Join(d.LocalDownloadFolder, path))
-
-	d.AfmLock.Lock()
-	fh, ok := d.AllFileMap[path]
-	if !ok {
-		// File not in map - check if it exists on disk (pre-existing local file)
-		if _, statErr := os.Stat(localPath); statErr == nil {
-			// Check if this is a remote file (placeholder might have been created)
-			d.RemoteFilesLock.RLock()
-			_, isRemoteFile := d.RemoteFiles[path]
-			d.RemoteFilesLock.RUnlock()
-
-			fh = &File{
-				logger:          d.logger,
-				openFileCounter: OpenFileCounter{mu: &sync.Mutex{}},
-				Name:            getNameFromPath(path),
-				RelativePath:    path,
-				RealPathOfFile:  localPath,
-				IsLocalPresent:  true,
-				LocalNewer:      !isRemoteFile, // Remote files should not be marked as local newer
-				OnLocalChange:   d.OnLocalChange,
-				StreamProvider:  d.OpenStreamProvider(),
-				stat:            &winfuse.Stat_t{},
-			}
-			d.AllFileMap[path] = fh
-		} else {
-			d.AfmLock.Unlock()
-			return -winfuse.ENOENT, 0
-		}
-	}
-
-	// File already opened - return existing handle (FUSE calls Release once per fh)
-	if fh.openFileCounter.CountOpenDescriptors() != 0 {
-		handleID := fh.CurrentHandleID
-		d.AfmLock.Unlock()
-		return 0, handleID
-	}
-
-	// CRITICAL: Release AfmLock BEFORE RemoteFilesLock to maintain lock order
-	isLocalPresent := fh.IsLocalPresent
-	localNewer := fh.LocalNewer
-	d.AfmLock.Unlock()
-
-	// Check if remote has newer version
-	remoteHasUpdate := false
-	var remoteTotalSize uint64
-	var remoteMtime time.Time
-	var remoteBitmap *ChunkBitmap
-	needsRemark := false
-	d.RemoteFilesLock.RLock()
-	if remoteFile, hasRemote := d.RemoteFiles[path]; hasRemote {
-		if remoteFile.stat != nil {
-			remoteTotalSize = uint64(remoteFile.stat.Size)
-			remoteMtime = remoteFile.stat.Mtim.Time()
-		}
-		remoteBitmap = remoteFile.Bitmap
-		if remoteFile.NotLocalSynced {
-			// logger.Info("Remote has newer version, streaming from remote", "path", path)
-			localNewer = false
-			remoteHasUpdate = true
-		} else if remoteTotalSize > 0 {
-			// Even if NotLocalSynced=false, verify download is actually complete.
-			// Use bitmap (preferred) or BytesDownloaded as fallback.
-			if remoteBitmap != nil && !remoteBitmap.IsComplete() {
-				// logger.Info("Download incomplete (bitmap), re-streaming from remote", "progress", remoteBitmap.Progress(), "remoteSize", remoteTotalSize)
-				localNewer = false
-				remoteHasUpdate = true
-				needsRemark = true
-			} else if remoteBitmap == nil {
-				bytesDownloaded := remoteFile.Download.BytesDownloaded.Load()
-				if bytesDownloaded < remoteTotalSize {
-					// logger.Info("Download incomplete, re-streaming from remote", "bytesDownloaded", bytesDownloaded, "remoteSize", remoteTotalSize)
-					localNewer = false
-					remoteHasUpdate = true
-					needsRemark = true
-				}
-			}
-		}
-	}
-	d.RemoteFilesLock.RUnlock()
-
-	// Re-mark for streaming outside of read lock
-	if needsRemark {
-		d.RemoteFilesLock.Lock()
-		if rf, ok := d.RemoteFiles[path]; ok {
-			rf.NotLocalSynced = true
-		}
-		d.RemoteFilesLock.Unlock()
-	}
-
-	// Open locally if we have newer local version
-	if isLocalPresent && localNewer {
-		// accessMode := flags & winfuse.O_ACCMODE
-		// logger.Info("Opening local file", "flags", flags, "accessMode", accessMode, "isReadOnly", accessMode == winfuse.O_RDONLY)
-		fd, err := platOpen(localPath, flags, 0)
-		if err != nil {
-			logger.Error("Failed to open local file", "error", err)
-			return int(convertOsErrToSyscallErrno("open", err)), 0
-		}
-
-		d.AfmLock.Lock()
-		d.OpenMapLock.Lock()
-		fh.Inode = uint64(fd)
-		fh.openFileCounter.Open()
-		handleID := allocHandleID()
-		fh.CurrentHandleID = handleID
-		d.OpenFileHandlers[handleID] = &HandleEntry{FD: fd, File: fh}
-		d.OpenMapLock.Unlock()
-		d.AfmLock.Unlock()
-		// logger.Info("Opened local file", "fh", fd)
-		return 0, handleID
-	}
-
-	// Remote file path - check for partial download or create cache file.
-	var existingLocalSize int64
-	localStat, err := os.Stat(localPath)
-	if err != nil {
-		if err2 := os.MkdirAll(getPathWithoutName(localPath), 0o755); err2 != nil {
-			logger.Error("Failed to create folders", "error", err2)
-			return int(convertOsErrToSyscallErrno("open", err2)), 0
-		}
-		f, err2 := os.Create(localPath)
-		if err2 != nil {
-			logger.Error("Failed to create cache file", "error", err2)
-			return int(convertOsErrToSyscallErrno("open", err2)), 0
-		}
-		_ = f.Close()
-		// Set placeholder mtime to match remote file's mtime.
-		// This ensures Getattr's mtime comparison favors remote stat (with correct size).
-		if !remoteMtime.IsZero() {
-			_ = os.Chtimes(localPath, remoteMtime, remoteMtime)
-		}
-	} else {
-		// Local file exists - this may be a partial download from a previous session.
-		existingLocalSize = localStat.Size()
-		_ = existingLocalSize > 0 && remoteTotalSize > 0 && uint64(existingLocalSize) < remoteTotalSize
-	}
-
-	// accessMode := flags & winfuse.O_ACCMODE
-	// logger.Info("Opening remote cache file", "flags", flags, "accessMode", accessMode, "isReadOnly", accessMode == winfuse.O_RDONLY)
-	fd, err := platOpen(localPath, flags, 0)
-	if err != nil {
-		logger.Error("Failed to open path", "error", err)
-		return int(convertOsErrToSyscallErrno("open", err)), 0
-	}
-
-	// Open stream pool + cache FD (network call - no locks held)
-	fsp := d.OpenStreamProvider()
-	streamCtx, streamCancel := context.WithCancel(d.FsCtx)
-	pool, poolErr := NewStreamPool(fsp, streamCtx, uint64(fd), path, StreamPoolSize) // on-demand jumps; prefetch uses StreamFile separately
-	if poolErr != nil {
-		streamCancel()
-		_ = platClose(fd)
-		logger.Error("Failed to open stream pool", "error", poolErr)
-		return -winfuse.EACCES, 0
-	}
-	// Open persistent cache FD for on-demand writes (avoids open/close per chunk).
-	cacheFD, cacheErr := os.OpenFile(localPath, os.O_CREATE|os.O_WRONLY, 0600)
-	if cacheErr != nil {
-		streamCancel()
-		pool.Close()
-		_ = platClose(fd)
-		logger.Error("Failed to open cache FD", "error", cacheErr)
-		return -winfuse.EIO, 0
-	}
-
-	d.AfmLock.Lock()
-	d.OpenMapLock.Lock()
-	fh.Inode = uint64(fd)
-	fh.StreamProvider = fsp
-	fh.StreamPool = pool
-	fh.StreamCancel = streamCancel
-	fh.CacheFD = cacheFD
-	if remoteHasUpdate {
-		fh.NotLocalSynced = true // Ensure Read uses stream, not stale local cache
-		// Initialize download state for resume capability.
-		fh.Download.Reset(remoteTotalSize)
-		// Share the bitmap from RemoteFiles so Read() can check which chunks are cached.
-		fh.Bitmap = remoteBitmap
-
-		// Pre-allocate local file to expected size for out-of-order writes.
-		// Without this, non-sequential reads (e.g., video moov atom at end) can cause corruption.
-		if existingLocalSize == 0 && remoteTotalSize > 0 {
-			_ = os.Truncate(localPath, int64(remoteTotalSize))
-		}
-	}
-	handleID := allocHandleID()
-	fh.CurrentHandleID = handleID
-	d.OpenFileHandlers[handleID] = &HandleEntry{FD: fd, File: fh}
-	fh.openFileCounter.Open()
-	d.OpenMapLock.Unlock()
-	d.AfmLock.Unlock()
-
-	// logger.Info("Opened remote file", "fh", handleID, "notLocalSynced", fh.NotLocalSynced, "poolNil", fh.StreamPool == nil, "totalSize", remoteTotalSize)
-	return 0, handleID
+	fi := winfuse.FileInfo_t{Flags: flags}
+	errc := d.OpenEx(path, &fi)
+	return errc, fi.Fh
 }
 
 func (d *Dir) Opendir(path string) (errCode int, retFh uint64) {
@@ -2151,14 +1932,21 @@ func (d *Dir) Read(path string, buff []byte, offset int64, fh uint64) (errCode i
 
 		// d.logger.Info("FUSE read", "path", path, "offset", offset, "len", len(buff), "src", "remote")
 
-		// Clamp the request size to the file's actual size to prevent
-		// reading garbage past EOF on pre-allocated cache files.
-		readSize := int64(len(buff))
-		if remoteFileSize > 0 && offset+readSize > remoteFileSize {
-			readSize = remoteFileSize - offset
-			if readSize <= 0 {
-				return 0
-			}
+		// CHUNK-ALIGNED on-demand fetch. We fetch the whole ChunkSize block(s)
+		// covering the request so the cache holds — and the bitmap only ever
+		// marks — COMPLETE chunks. Fetching a sub-chunk range and marking the
+		// whole 512 KiB chunk "present" was the random-seek corruption bug: a
+		// later read elsewhere in that chunk took the HasRange fast path and
+		// served sparse-hole zeros from the pre-allocated cache file.
+		cs := int64(ChunkSize)
+		fetchStart := (offset / cs) * cs
+		fetchEnd := ((offset + int64(len(buff)) + cs - 1) / cs) * cs
+		if remoteFileSize > 0 && fetchEnd > remoteFileSize {
+			fetchEnd = remoteFileSize
+		}
+		fetchLen := fetchEnd - fetchStart
+		if fetchLen <= 0 {
+			return 0
 		}
 
 		// Retry loop for resilience against transient failures.
@@ -2168,9 +1956,9 @@ func (d *Dir) Read(path string, buff []byte, offset int64, fh uint64) (errCode i
 			if d.FsCtx.Err() != nil {
 				return 0
 			}
-			// Read from stream pool with timeout to prevent system freeze.
+			// Read the aligned block from the stream pool with a timeout.
 			ctx, cancel := context.WithTimeout(d.FsCtx, 10*time.Second)
-			data, readErr = pool.ReadAt(ctx, offset, readSize)
+			data, readErr = pool.ReadAt(ctx, fetchStart, fetchLen)
 			cancel()
 
 			if readErr == nil {
@@ -2226,41 +2014,49 @@ func (d *Dir) Read(path string, buff []byte, offset int64, fh uint64) (errCode i
 			return 0
 		}
 
-		// Copy remote data into buffer for FUSE.
-		n := copy(buff, data)
-
-		// Clamp to remote file size — the server may return more bytes
-		// than the actual file content on pre-allocated cache files.
-		if f.stat != nil {
-			if fileSize := f.stat.Size; fileSize > 0 && offset+int64(n) > fileSize {
-				n = int(fileSize - offset)
-				if n < 0 {
-					n = 0
-				}
-			}
+		// Serve the requested [offset, offset+len(buff)) slice out of the block.
+		sliceOff := offset - fetchStart
+		var n int
+		if sliceOff >= 0 && sliceOff < int64(len(data)) {
+			n = copy(buff, data[sliceOff:])
 		}
 
-		// Track download progress and update checksum.
+		// Track download progress and update checksum for the served bytes.
 		f.Download.UpdateProgress(offset, n)
-		f.Download.UpdateChecksum(data[:n])
+		if n > 0 {
+			f.Download.UpdateChecksum(buff[:n])
+		}
 
-		// Write to local cache asynchronously — data is already in the FUSE
-		// buffer so we can return immediately. The cache write and bitmap
-		// update happen in the background. CacheWg is waited on in Release()
-		// before closing the FD.
-		if cacheFD != nil {
-			cacheData := data[:n]
-			cacheOffset := offset
+		// Persist the WHOLE block and mark only the chunks fully present in it
+		// (handles a short read and the final EOF chunk). Done async, off the
+		// read path; CacheWg is waited on in Release() before closing the FD.
+		if cacheFD != nil && len(data) > 0 {
+			block := data
+			base := fetchStart
+			fsz := remoteFileSize
 			bm := bitmap
 			f.CacheWg.Add(1)
 			go func() {
 				defer f.CacheWg.Done()
-				if _, err := cacheFD.WriteAt(cacheData, cacheOffset); err != nil {
-					logger.Error("Async cache write failed", "error", err)
+				if _, werr := cacheFD.WriteAt(block, base); werr != nil {
+					logger.Error("Async cache write failed", "error", werr)
 					return
 				}
-				if bm != nil {
-					bm.SetRange(cacheOffset, len(cacheData))
+				if bm == nil {
+					return
+				}
+				end := base + int64(len(block))
+				for c := int(base / cs); ; c++ {
+					chunkBegin := int64(c) * cs
+					chunkEnd := chunkBegin + cs
+					if fsz > 0 && chunkEnd > fsz {
+						chunkEnd = fsz
+					}
+					// Stop once a chunk isn't fully covered by the written block.
+					if chunkBegin >= end || chunkEnd > end {
+						break
+					}
+					bm.Set(c)
 				}
 			}()
 		}
@@ -2448,19 +2244,33 @@ func (d *Dir) AddRemoteFile(logger *slog.Logger, path string, name string, stat 
 			d.AfmLock.Lock()
 			d.AllFileMap[path] = existing
 			d.AfmLock.Unlock()
-			d.startPrefetch(logger, existing, path)
+			// Metadata-only on announce. Read streams chunks on-demand; prefetch
+			// (if enabled) starts when the file is Opened.
 		} else {
-			// Same size: update metadata but don't reset bitmap or truncate.
-			// The previous prefetch may have already completed — don't destroy its work.
+			// Same size. By default keep the cache: a duplicate or stale
+			// ADD_FILE re-announce must not destroy a completed prefetch. But a
+			// genuine in-place edit keeps the byte length while advancing mtime
+			// (live collab: "version-one" -> "version-two-x"). When the incoming
+			// mtime is newer, the content changed under us — reset the bitmap +
+			// cancel any in-flight prefetch so reads re-fetch the new bytes
+			// on-demand, mirroring EditRemoteFile. Without this, a peer that
+			// already fully cached the file keeps serving stale content.
+			if incomingMtime > existingMtime {
+				existing.NotLocalSynced = true
+				existing.Download.Reset(uint64(stat.Size))
+				if existing.PrefetchCancel != nil {
+					existing.PrefetchCancel()
+					existing.PrefetchCancel = nil
+				}
+				existing.Bitmap = NewChunkBitmap(stat.Size)
+			} else if existing.Bitmap != nil && !existing.Bitmap.IsComplete() {
+				// Same mtime, still incomplete — keep fetching the rest on-demand.
+				existing.NotLocalSynced = true
+			}
 			d.RemoteFilesLock.Unlock()
 			d.AfmLock.Lock()
 			d.AllFileMap[path] = existing
 			d.AfmLock.Unlock()
-			// If prefetch isn't running and bitmap isn't complete, restart it.
-			if existing.PrefetchCancel == nil && existing.Bitmap != nil && !existing.Bitmap.IsComplete() {
-				existing.NotLocalSynced = true
-				d.startPrefetch(logger, existing, path)
-			}
 		}
 		return nil
 	}
@@ -2494,7 +2304,9 @@ func (d *Dir) AddRemoteFile(logger *slog.Logger, path string, name string, stat 
 	}
 	d.RemoteFiles[path] = f
 	d.RemoteFilesLock.Unlock()
-	d.startPrefetch(logger, f, path)
+	// Metadata-only on announce: registered with metadata + bitmap +
+	// NotLocalSynced=true above. Read streams chunks on-demand; prefetch (if
+	// enabled) starts when the file is Opened.
 	return nil
 }
 
@@ -2708,7 +2520,8 @@ func (d *Dir) EditRemoteFile(logger *slog.Logger, path string, name string, stat
 		d.AfmLock.Lock()
 		d.AllFileMap[path] = newFile
 		d.AfmLock.Unlock()
-		d.startPrefetch(logger, newFile, path)
+		// Metadata-only — the edited content is fetched on-demand on the next
+		// read (or prefetched on Open). Keeps live collab lightweight.
 		return nil
 	}
 
@@ -2719,34 +2532,20 @@ func (d *Dir) EditRemoteFile(logger *slog.Logger, path string, name string, stat
 	}
 
 	// logger.Info("Remote file edited", "path", path, "mtime", stat.Mtim.Time())
-	oldSize := f.stat.Size
-	sizeChanged := oldSize != stat.Size
 	f.stat = stat
 	f.LocalNewer = false // Remote has newer content.
 
-	if sizeChanged {
-		// Size changed: full re-download required.
-		f.NotLocalSynced = true
-		f.Download.Reset(uint64(stat.Size))
-		if f.PrefetchCancel != nil {
-			f.PrefetchCancel()
-		}
-		f.Bitmap = NewChunkBitmap(stat.Size)
-		d.RemoteFilesLock.Unlock()
-		d.AfmLock.Lock()
-		d.AllFileMap[path] = f
-		d.AfmLock.Unlock()
-		d.startPrefetch(logger, f, path)
-	} else {
-		// Same size: metadata update only. Don't reset bitmap or cancel prefetch.
-		d.RemoteFilesLock.Unlock()
-		d.AfmLock.Lock()
-		d.AllFileMap[path] = f
-		d.AfmLock.Unlock()
-		if f.PrefetchCancel == nil && f.Bitmap != nil && !f.Bitmap.IsComplete() {
-			f.NotLocalSynced = true
-			d.startPrefetch(logger, f, path)
-		}
+	// Content changed: reset bitmap + cancel prefetch so reads re-fetch on-demand.
+	f.NotLocalSynced = true
+	f.Download.Reset(uint64(stat.Size))
+	if f.PrefetchCancel != nil {
+		f.PrefetchCancel()
+		f.PrefetchCancel = nil
 	}
+	f.Bitmap = NewChunkBitmap(stat.Size)
+	d.RemoteFilesLock.Unlock()
+	d.AfmLock.Lock()
+	d.AllFileMap[path] = f
+	d.AfmLock.Unlock()
 	return nil
 }

--- a/pkg/filesystem/openfilecounter_test.go
+++ b/pkg/filesystem/openfilecounter_test.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2026 KeibiSoft S.R.L.
+
+package filesystem
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestOpenFileCounter_OpenIfActive: OpenIfActive bumps only while count > 0 and
+// refuses to resurrect a handle torn down to 0.
+func TestOpenFileCounter_OpenIfActive(t *testing.T) {
+	c := OpenFileCounter{mu: &sync.Mutex{}}
+
+	// Count is 0 (no live handle): must NOT bump, must report inactive.
+	if c.OpenIfActive() {
+		t.Fatal("OpenIfActive() = true with count 0; want false (no resurrect)")
+	}
+	if got := c.CountOpenDescriptors(); got != 0 {
+		t.Fatalf("count = %d after refused OpenIfActive; want 0", got)
+	}
+
+	// One live handle: OpenIfActive must bump and report active.
+	c.Open()
+	if !c.OpenIfActive() {
+		t.Fatal("OpenIfActive() = false with count 1; want true")
+	}
+	if got := c.CountOpenDescriptors(); got != 2 {
+		t.Fatalf("count = %d after Open+OpenIfActive; want 2", got)
+	}
+
+	// Release back down to 0: OpenIfActive must refuse again.
+	c.Release()
+	c.Release()
+	if c.OpenIfActive() {
+		t.Fatal("OpenIfActive() = true after count returned to 0; want false")
+	}
+}
+
+// TestOpenFileCounter_OpenIfActive_Race stresses the check-and-bump under
+// concurrency (run with -race): a non-atomic split of the count==0 test and the
+// increment would trip the race detector or leave the count unbalanced.
+func TestOpenFileCounter_OpenIfActive_Race(t *testing.T) {
+	c := OpenFileCounter{mu: &sync.Mutex{}}
+	c.Open() // one live handle keeps the count > 0 so every revive succeeds
+
+	const workers = 50
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 2000; j++ {
+				if c.OpenIfActive() {
+					c.Release() // balance every successful bump
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := c.CountOpenDescriptors(); got != 1 {
+		t.Fatalf("count = %d after balanced concurrent OpenIfActive/Release; want 1", got)
+	}
+}

--- a/pkg/filesystem/prefetch_rename_race_test.go
+++ b/pkg/filesystem/prefetch_rename_race_test.go
@@ -131,10 +131,17 @@ func TestPrefetchRenameRace(t *testing.T) {
 		Mode: 0o644 | winfuse.S_IFREG,
 	}
 
-	// AddRemoteFile starts the prefetch goroutine for HEAD.lock.
+	// AddRemoteFile registers HEAD.lock (metadata only under on-demand).
 	if err := root.AddRemoteFile(root.logger, lockPath, "HEAD.lock", stat); err != nil {
 		t.Fatalf("AddRemoteFile failed: %v", err)
 	}
+
+	// Prefetch starts on Open now, not on announce; trigger it explicitly so
+	// this test still races an in-flight prefetch against the rename.
+	root.RemoteFilesLock.RLock()
+	pf := root.RemoteFiles[lockPath]
+	root.RemoteFilesLock.RUnlock()
+	root.startPrefetch(root.logger, pf, lockPath)
 
 	// Immediately simulate the RENAME_FILE notification arriving on Bob's side,
 	// before the prefetch goroutine has finished.

--- a/pkg/filesystem/prefetch_rename_race_test.go
+++ b/pkg/filesystem/prefetch_rename_race_test.go
@@ -6,7 +6,6 @@ package filesystem
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"log/slog"
 	"os"
@@ -36,8 +35,29 @@ func (p *slowStreamProvider) OpenRemoteFile(_ context.Context, _ uint64, _ strin
 	return &slowStream{content: p.content, delay: p.delay}, nil
 }
 
-func (p *slowStreamProvider) StreamFile(_ context.Context, _ string, _ uint64) (types.StreamFileReceiver, error) {
-	return nil, fmt.Errorf("not implemented in test")
+func (p *slowStreamProvider) StreamFile(_ context.Context, _ string, startOffset uint64) (types.StreamFileReceiver, error) {
+	return &slowStreamReceiver{content: p.content, delay: p.delay, offset: startOffset}, nil
+}
+
+// slowStreamReceiver serves the content buffer one chunk at a time, with an
+// optional delay, satisfying types.StreamFileReceiver for prefetch tests.
+type slowStreamReceiver struct {
+	content []byte
+	delay   time.Duration
+	offset  uint64
+}
+
+func (r *slowStreamReceiver) Recv() (data []byte, offset uint64, totalSize uint64, err error) {
+	if r.delay > 0 {
+		time.Sleep(r.delay)
+	}
+	if r.offset >= uint64(len(r.content)) {
+		return nil, 0, 0, io.EOF
+	}
+	chunk := r.content[r.offset:]
+	cur := r.offset
+	r.offset = uint64(len(r.content))
+	return chunk, cur, uint64(len(r.content)), nil
 }
 
 type slowStream struct {
@@ -97,6 +117,8 @@ func TestPrefetchRenameRace(t *testing.T) {
 		RemoteFiles:         make(map[string]*File),
 		OpenStreamProvider:  openStreamProvider,
 		PrefetchOnOpen:      true,
+		FsCtx:               context.Background(),
+		PrefetchSem:         make(chan struct{}, 8),
 	}
 	root.Root = root
 	root.logger = nopLogger()

--- a/pkg/filesystem/specifics_darwin.go
+++ b/pkg/filesystem/specifics_darwin.go
@@ -114,8 +114,8 @@ func syscallStatfs(path string, stat *syscall.Statfs_t) error {
 // returns ENOENT before the file exists. With negative_vncache, the kernel
 // keeps returning ENOENT even after the file appears, causing "deleted" files
 // in git status and missing files in ls.
-func getMountOptions() []string {
-	return []string{
+func getMountOptions(autoCache bool) []string {
+	opts := []string{
 		"-o", "volname=KeibiDrop",
 		"-o", "local",
 		"-o", "slow_statfs",
@@ -125,4 +125,15 @@ func getMountOptions() []string {
 		// for drag-and-drop to work. We filter .DS_Store from peer sync instead.
 		"-o", "iosize=524288", // 512KB — matches ChunkSize, best throughput in benchmarks.
 	}
+	// auto_cache (opt-in via live_collab): flush the page cache on open when
+	// mtime/size changed, so a peer's SAME-SIZE in-place edit is seen live —
+	// macFUSE otherwise only drops its data cache on a size change. The cost:
+	// auto_cache DISCARDS dirty mmap pages before writeback, corrupting files
+	// written via mmap (git's index). So it's off by default (git-safe); the
+	// per-file KeepCache=false in OpenEx covers Linux without this hazard, but
+	// is a no-op on macFUSE, which is why the same-size case needs auto_cache here.
+	if autoCache {
+		opts = append(opts, "-o", "auto_cache")
+	}
+	return opts
 }

--- a/pkg/filesystem/specifics_linux.go
+++ b/pkg/filesystem/specifics_linux.go
@@ -41,11 +41,19 @@ func GetFreeDiskSpace(path string) (freeBytesAvail, totalNumberOfBytes, totalNum
 
 func copyFusestatfsFromGostatfs(dst *winfuse.Statfs_t, src *syscall.Statfs_t) {
 	*dst = winfuse.Statfs_t{}
-	dst.Bsize = uint64(src.Bsize)
-	dst.Frsize = 1
-	dst.Blocks = uint64(src.Blocks)
-	dst.Bfree = uint64(src.Bfree)
-	dst.Bavail = uint64(src.Bavail)
+	// VERY IMPORTANT: report our optimized FilesystemBlockSize here too, and
+	// rescale the block counts so total/free BYTES stay correct — statfs blocks
+	// are in bsize units, so a larger bsize means proportionally fewer blocks
+	// (blocks*bsize is invariant). Skipping the rescale would misreport df by 64x.
+	srcBsize := uint64(src.Bsize)
+	if srcBsize == 0 {
+		srcBsize = 1
+	}
+	dst.Bsize = FilesystemBlockSize
+	dst.Frsize = FilesystemBlockSize
+	dst.Blocks = (uint64(src.Blocks) * srcBsize) / FilesystemBlockSize
+	dst.Bfree = (uint64(src.Bfree) * srcBsize) / FilesystemBlockSize
+	dst.Bavail = (uint64(src.Bavail) * srcBsize) / FilesystemBlockSize
 	dst.Files = uint64(src.Files)
 	dst.Ffree = uint64(src.Ffree)
 	dst.Favail = uint64(src.Ffree)
@@ -65,7 +73,10 @@ func copyFusestatFromGostat(dst *winfuse.Stat_t, src *syscall.Stat_t) {
 	dst.Atim.Sec, dst.Atim.Nsec = int64(src.Atim.Sec), int64(src.Atim.Nsec)
 	dst.Mtim.Sec, dst.Mtim.Nsec = int64(src.Mtim.Sec), int64(src.Mtim.Nsec)
 	dst.Ctim.Sec, dst.Ctim.Nsec = int64(src.Ctim.Sec), int64(src.Ctim.Nsec)
-	dst.Blksize = int64(src.Blksize)
+	// VERY IMPORTANT: always report our optimized FilesystemBlockSize, never the
+	// backing FS's st_blksize. cp/dd/rsync size their read buffer from it; a small
+	// buffer is catastrophic on Linux FUSE (~33 vs ~232 MB/s).
+	dst.Blksize = FilesystemBlockSize
 	dst.Blocks = int64(src.Blocks)
 }
 
@@ -82,7 +93,9 @@ func copyFusestatFromFusestat(dst *winfuse.Stat_t, src *winfuse.Stat_t) {
 	dst.Atim.Sec, dst.Atim.Nsec = src.Atim.Sec, src.Atim.Nsec
 	dst.Mtim.Sec, dst.Mtim.Nsec = src.Mtim.Sec, src.Mtim.Nsec
 	dst.Ctim.Sec, dst.Ctim.Nsec = src.Ctim.Sec, src.Ctim.Nsec
-	dst.Blksize = src.Blksize
+	// VERY IMPORTANT: always our optimized FilesystemBlockSize, never the source's
+	// (often a remote peer's stat). Small read buffers crawl on Linux FUSE.
+	dst.Blksize = FilesystemBlockSize
 	dst.Blocks = src.Blocks
 	dst.Birthtim.Sec, dst.Birthtim.Nsec = src.Birthtim.Sec, src.Birthtim.Nsec
 }
@@ -100,6 +113,13 @@ func syscallStatfs(path string, stat *syscall.Statfs_t) error {
 // Note: NOT using default_permissions — it makes the kernel enforce POSIX
 // chown rules (only root can chown), which blocks database init flows where
 // MySQL/PostgreSQL need to chown their data directories.
-func getMountOptions() []string {
+//
+// The autoCache (live_collab) flag is intentionally ignored on Linux: libfuse
+// invalidates the page cache on open when FOPEN_KEEP_CACHE is absent (which
+// OpenEx sets for remote files via KeepCache=false), so a peer's same-size
+// in-place edit is already seen live WITHOUT auto_cache — and without the
+// auto_cache mmap-writeback hazard that corrupts git on macOS. Linux gets both
+// live collab and mmap safety for free, so there is nothing to toggle here.
+func getMountOptions(_ bool) []string {
 	return []string{"-o", "nonempty,allow_other,max_read=131072"}
 }

--- a/pkg/filesystem/specifics_windows.go
+++ b/pkg/filesystem/specifics_windows.go
@@ -30,9 +30,18 @@ func copyFusestatFromFusestat(dst *winfuse.Stat_t, src *winfuse.Stat_t) {
 		return
 	}
 	*dst = *src
+	// VERY IMPORTANT: always our optimized FilesystemBlockSize, never the source's
+	// (often a remote peer's stat). Small read buffers crawl on FUSE. st_blocks is
+	// 512-byte units, derived from size — keep it consistent with statFromFileInfo.
+	dst.Blksize = int64(FilesystemBlockSize)
+	dst.Blocks = (dst.Size + 511) / 512
 }
 
-func getMountOptions() []string {
+// The autoCache (live_collab) flag is intentionally ignored on Windows: WinFsp
+// manages its own cache coherence and invalidates on file-info change, so a
+// peer's same-size in-place edit is reflected without an auto_cache equivalent
+// (and without the mmap hazard). There is nothing to toggle here.
+func getMountOptions(_ bool) []string {
 	// uid=-1,gid=-1: instruct WinFSP to resolve ownership against the calling
 	// process's token rather than a fixed UID/GID.  This is the Windows
 	// equivalent of macOS's "allow_other,defer_permissions" — without it,

--- a/pkg/filesystem/types.go
+++ b/pkg/filesystem/types.go
@@ -284,6 +284,18 @@ func (ofc *OpenFileCounter) Open() {
 	ofc.counter++
 }
 
+// OpenIfActive bumps the count and returns true only if it was already >0, so
+// a handle whose last Release is tearing it down is not reused.
+func (ofc *OpenFileCounter) OpenIfActive() bool {
+	ofc.mu.Lock()
+	defer ofc.mu.Unlock()
+	if ofc.counter == 0 {
+		return false
+	}
+	ofc.counter++
+	return true
+}
+
 func (ofc *OpenFileCounter) Release() uint64 {
 	ofc.mu.Lock()
 	defer ofc.mu.Unlock()

--- a/pkg/filesystem/utils.go
+++ b/pkg/filesystem/utils.go
@@ -107,12 +107,3 @@ func remoteChildrenForDir(remoteFiles map[string]*File, dirPath string) (files m
 	}
 	return
 }
-
-func getPathWithoutName(path string) string {
-	aux := strings.Split(path, "/")
-	if len(aux) == 0 {
-		return path
-	}
-
-	return strings.Join(aux[:len(aux)-1], "/")
-}

--- a/pkg/logic/common/helpers.go
+++ b/pkg/logic/common/helpers.go
@@ -16,7 +16,14 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+
+	"github.com/KeibiSoft/KeibiDrop/pkg/config"
 )
+
+// preferredLANIfaces lists interface-name prefixes to prefer when choosing a
+// LAN address — physical Wi-Fi/Ethernet ahead of anything else. Shared by
+// GetLinkLocalAddress and GetGlobalIPv6 (intentionally the same order).
+var preferredLANIfaces = []string{"en0", "eth0", "wlan0", "en1", "wlp", "enp"}
 
 // GetLinkLocalAddress finds a link-local IPv6 address on this machine and
 // returns it formatted as "ip%zone:port" for direct LAN peer connections.
@@ -52,7 +59,7 @@ func GetLinkLocalAddress(port int) (string, error) {
 	if len(candidates) > 0 {
 		// Prefer common LAN interfaces: en0 (macOS WiFi), eth0/wlan0 (Linux).
 		// Avoid utun*, awdl*, llw*, ap* (VPN, AirDrop, low-latency WLAN, access point).
-		preferred := []string{"en0", "eth0", "wlan0", "en1", "wlp", "enp"}
+		preferred := preferredLANIfaces
 		for _, pref := range preferred {
 			for _, c := range candidates {
 				if strings.HasPrefix(c.iface, pref) {
@@ -126,8 +133,8 @@ func ParsePeerDirectAddress(addr string) (ip string, zone string, port int, err 
 			return "", "", 0, fmt.Errorf("address must be link-local, loopback, or private: %q", ipPart)
 		}
 
-		if port < 26000 || port > 27000 {
-			return "", "", 0, fmt.Errorf("port %d out of range 26000-27000", port)
+		if !config.ValidPeerPort(port) {
+			return "", "", 0, fmt.Errorf("port %d out of range %d-%d", port, config.MinPeerPort, config.MaxPeerPort)
 		}
 
 		return ipPart, zone, port, nil
@@ -166,8 +173,8 @@ func ParsePeerDirectAddress(addr string) (ip string, zone string, port int, err 
 		if !parsedIP.IsPrivate() && !parsedIP.IsLoopback() {
 			return "", "", 0, fmt.Errorf("IPv4 address must be private or loopback: %q", ipPart)
 		}
-		if port < 26000 || port > 27000 {
-			return "", "", 0, fmt.Errorf("port %d out of range 26000-27000", port)
+		if !config.ValidPeerPort(port) {
+			return "", "", 0, fmt.Errorf("port %d out of range %d-%d", port, config.MinPeerPort, config.MaxPeerPort)
 		}
 		return ipPart, "", port, nil
 	}
@@ -175,8 +182,8 @@ func ParsePeerDirectAddress(addr string) (ip string, zone string, port int, err 
 		return "", "", 0, fmt.Errorf("non-loopback address without zone ID: %q", ipPart)
 	}
 
-	if port < 26000 || port > 27000 {
-		return "", "", 0, fmt.Errorf("port %d out of range 26000-27000", port)
+	if !config.ValidPeerPort(port) {
+		return "", "", 0, fmt.Errorf("port %d out of range %d-%d", port, config.MinPeerPort, config.MaxPeerPort)
 	}
 
 	return ipPart, "", port, nil
@@ -216,7 +223,7 @@ func GetGlobalIPv6() (string, error) {
 	}
 
 	// Preferred interfaces for LAN (same order as GetLinkLocalAddress).
-	preferred := []string{"en0", "eth0", "wlan0", "en1", "wlp", "enp"}
+	preferred := preferredLANIfaces
 
 	type candidate struct {
 		ip    string

--- a/pkg/logic/common/logic.go
+++ b/pkg/logic/common/logic.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net"
 	"os"
 	"path/filepath"
@@ -28,6 +29,8 @@ import (
 	"github.com/KeibiSoft/KeibiDrop/pkg/types"
 )
 
+// Timeout is the peer-join wait budget in seconds: 10 minutes minus a 5s
+// margin, matching the relay registration TTL.
 const Timeout = 10*60 - 5
 
 // Add a file to be tracked.
@@ -311,17 +314,7 @@ func (kd *KeibiDrop) PullFile(remoteName, localPath string) error {
 	}
 
 updateTracker:
-	fileCopy.RealPathOfFile = localPath
-
-	kd.SyncTracker.RemoteFilesMu.Lock()
-	if rf, ok := kd.SyncTracker.RemoteFiles[remoteName]; ok {
-		rf.RealPathOfFile = localPath
-	}
-	kd.SyncTracker.RemoteFilesMu.Unlock()
-
-	kd.SyncTracker.LocalFilesMu.Lock()
-	kd.SyncTracker.LocalFiles[remoteName] = &fileCopy
-	kd.SyncTracker.LocalFilesMu.Unlock()
+	kd.finalizeDownload(remoteName, localPath, fileCopy)
 
 	if fi, statErr := os.Stat(localPath); statErr == nil {
 		logger.Info("PullFile complete", "expectedSize", fileSize, "actualSize", fi.Size(), "match", uint64(fi.Size()) == fileSize)
@@ -460,6 +453,13 @@ func (kd *KeibiDrop) PullFileWithParams(remoteName, localPath string, blockSize,
 	os.Remove(bitmapPath)
 
 updateTracker:
+	kd.finalizeDownload(remoteName, localPath, fileCopy)
+	return nil
+}
+
+// finalizeDownload records a completed download in the sync tracker: it points
+// the remote entry at the local path and registers the file as locally held.
+func (kd *KeibiDrop) finalizeDownload(remoteName, localPath string, fileCopy synctracker.File) {
 	fileCopy.RealPathOfFile = localPath
 	kd.SyncTracker.RemoteFilesMu.Lock()
 	if rf, ok := kd.SyncTracker.RemoteFiles[remoteName]; ok {
@@ -469,7 +469,6 @@ updateTracker:
 	kd.SyncTracker.LocalFilesMu.Lock()
 	kd.SyncTracker.LocalFiles[remoteName] = &fileCopy
 	kd.SyncTracker.LocalFilesMu.Unlock()
-	return nil
 }
 
 func (kd *KeibiDrop) registerDownload(name string, cancel context.CancelFunc) {
@@ -601,6 +600,54 @@ func (kd *KeibiDrop) SetPeerDirectAddress(addr string) error {
 	return nil
 }
 
+// waitForPeerFingerprint blocks until the expected peer fingerprint is set
+// (via AddPeerFingerprint or a relay lookup), polling once a second up to the
+// connection Timeout. Returns ErrTimeoutReached if it never arrives.
+func (kd *KeibiDrop) waitForPeerFingerprint() error {
+	for elapsed := 0; elapsed < Timeout; elapsed++ {
+		if kd.session.ExpectedPeerFingerprint != "" {
+			return nil
+		}
+		time.Sleep(time.Second)
+	}
+	kd.logger.Error("Timeout reached", "error", ErrTimeoutReached)
+	return ErrTimeoutReached
+}
+
+// finishConnect runs the shared post-connection setup for JoinRoom and
+// CreateRoom: start the gRPC server, dial the client with retry, init
+// connection resilience, then either signal ready (no-FUSE) or mount FUSE.
+func (kd *KeibiDrop) finishConnect(logger *slog.Logger) error {
+	kd.filesystemReady = make(chan struct{})
+	kd.filesystemReadyOnce = sync.Once{}
+	kd.Start()
+
+	// Retry dialing until the gRPC server is ready.
+	if err := kd.connectGRPCClientWithRetry(15 * time.Second); err != nil {
+		logger.Error("Failed to connect to grpc server after retries", "error", err)
+		return err
+	}
+
+	// Start health monitoring, reconnection, and relay keepalive.
+	if err := kd.InitConnectionResilience(); err != nil {
+		logger.Warn("Failed to init connection resilience", "error", err)
+	}
+
+	if !kd.IsFUSE {
+		// Unblock Run()'s <-filesystemReady so it can process signals.
+		kd.filesystemReadyOnce.Do(func() { close(kd.filesystemReady) })
+		logger.Info("Success, starting without FUSE")
+		return nil
+	}
+
+	if err := kd.setupFilesystem(logger, kd.filesystemReady); err != nil {
+		return err
+	}
+
+	logger.Info("Success")
+	return nil
+}
+
 func (kd *KeibiDrop) JoinRoom() error {
 	logger := kd.logger.With("method", "join-room")
 	if kd.session == nil {
@@ -612,19 +659,9 @@ func (kd *KeibiDrop) JoinRoom() error {
 		return ErrAlreadyRunning
 	}
 
-	// Wait for expected peer fingerprint
-	elapsed := 0
-	for {
-		if elapsed >= Timeout {
-			logger.Error("Timeout reached", "error", ErrTimeoutReached)
-			return ErrTimeoutReached
-		}
-		if kd.session.ExpectedPeerFingerprint == "" {
-			elapsed++
-			time.Sleep(time.Second)
-			continue
-		}
-		break
+	// Wait for the expected peer fingerprint to be set.
+	if err := kd.waitForPeerFingerprint(); err != nil {
+		return err
 	}
 
 	// Get peer info from relay (needed for both direct and bridge paths).
@@ -711,10 +748,7 @@ func (kd *KeibiDrop) JoinRoom() error {
 						kd.session.Session.Outbound.Close()
 						kd.session.Session.Outbound = nil
 					}
-					kd.session.SEKOutbound = nil
-					kd.session.CipherMu.Lock()
-					kd.session.CipherSuite = ""
-					kd.session.CipherMu.Unlock()
+					kd.session.ResetOutboundCrypto()
 					lanConnected = false
 					break
 				}
@@ -732,10 +766,7 @@ func (kd *KeibiDrop) JoinRoom() error {
 				goto connected
 			}
 			// Reset crypto state after failed LAN attempts.
-			kd.session.SEKOutbound = nil
-			kd.session.CipherMu.Lock()
-			kd.session.CipherSuite = ""
-			kd.session.CipherMu.Unlock()
+			kd.session.ResetOutboundCrypto()
 		}
 
 		// 2. Try direct IPv6 P2P (skip if peer has no IPv6, e.g. mobile).
@@ -784,18 +815,12 @@ func (kd *KeibiDrop) JoinRoom() error {
 					kd.session.Session.Outbound.Close()
 					kd.session.Session.Outbound = nil
 				}
-				kd.session.SEKOutbound = nil
-				kd.session.CipherMu.Lock()
-				kd.session.CipherSuite = ""
-				kd.session.CipherMu.Unlock()
+				kd.session.ResetOutboundCrypto()
 			}
 		case kd.BridgeAddr != "":
 			logger.Warn("Direct P2P failed, falling back to bridge", "error", directErr, "bridge", kd.BridgeAddr)
 			needBridge = true
-			kd.session.SEKOutbound = nil
-			kd.session.CipherMu.Lock()
-			kd.session.CipherSuite = ""
-			kd.session.CipherMu.Unlock()
+			kd.session.ResetOutboundCrypto()
 		default:
 			logger.Error("Direct P2P failed and no bridge configured", "error", directErr)
 			return directErr
@@ -827,34 +852,7 @@ func (kd *KeibiDrop) JoinRoom() error {
 	}
 
 connected:
-	kd.filesystemReady = make(chan struct{})
-	kd.filesystemReadyOnce = sync.Once{}
-	kd.Start()
-
-	// retry dialing until gRPC server is ready
-	if err := kd.connectGRPCClientWithRetry(15 * time.Second); err != nil {
-		logger.Error("Failed to connect to grpc server after retries", "error", err)
-		return err
-	}
-
-	// Start health monitoring, reconnection, and relay keepalive.
-	if err := kd.InitConnectionResilience(); err != nil {
-		logger.Warn("Failed to init connection resilience", "error", err)
-	}
-
-	if !kd.IsFUSE {
-		// Unblock Run()'s <-filesystemReady so it can process signals.
-		kd.filesystemReadyOnce.Do(func() { close(kd.filesystemReady) })
-		logger.Info("Success, starting without FUSE")
-		return nil
-	}
-
-	if err := kd.setupFilesystem(logger, kd.filesystemReady); err != nil {
-		return err
-	}
-
-	logger.Info("Success")
-	return nil
+	return kd.finishConnect(logger)
 }
 
 // Connect determines the creator/joiner role automatically using
@@ -904,19 +902,9 @@ func (kd *KeibiDrop) CreateRoom() error {
 
 	logger.Info("Waiting for peer to join...")
 
-	// Wait for expected peer fingerprint (skip if already set, e.g. local mode TOFU).
-	elapsed := 0
-	for {
-		if elapsed >= Timeout {
-			logger.Error("Timeout reached", "error", ErrTimeoutReached)
-			return ErrTimeoutReached
-		}
-		if kd.session.ExpectedPeerFingerprint == "" {
-			time.Sleep(time.Second)
-			elapsed++
-			continue
-		}
-		break
+	// Wait for the expected peer fingerprint (skip if already set, e.g. local mode TOFU).
+	if err := kd.waitForPeerFingerprint(); err != nil {
+		return err
 	}
 
 	// In local mode, exchange public keys before the PQC handshake.
@@ -993,16 +981,13 @@ func (kd *KeibiDrop) CreateRoom() error {
 				if kd.BridgeAddr != "" {
 					logger.Warn("Direct outbound to peer failed, falling back to bridge for outbound", "error", err)
 					// Reset outbound crypto state for bridge handshake.
-					kd.session.SEKOutbound = nil
-					kd.session.CipherMu.Lock()
-					kd.session.CipherSuite = ""
-					kd.session.CipherMu.Unlock()
+					kd.session.ResetOutboundCrypto()
 					// Close direct inbound too — we need both via bridge.
 					if kd.session.Session != nil && kd.session.Session.Inbound != nil {
 						kd.session.Session.Inbound.Close()
 						kd.session.Session.Inbound = nil
 					}
-					kd.session.SEKInbound = nil
+					kd.session.ResetInboundCrypto()
 					useBridge = true
 				} else {
 					return err
@@ -1057,31 +1042,7 @@ func (kd *KeibiDrop) CreateRoom() error {
 		kd.listener = newLn
 	}
 
-	kd.filesystemReady = make(chan struct{})
-	kd.filesystemReadyOnce = sync.Once{}
-	kd.Start()
-
-	if err := kd.connectGRPCClientWithRetry(15 * time.Second); err != nil {
-		logger.Error("Failed to connect to grpc server after retries", "error", err)
-		return err
-	}
-
-	if err := kd.InitConnectionResilience(); err != nil {
-		logger.Warn("Failed to init connection resilience", "error", err)
-	}
-
-	if !kd.IsFUSE {
-		kd.filesystemReadyOnce.Do(func() { close(kd.filesystemReady) })
-		logger.Info("Success, starting without FUSE")
-		return nil
-	}
-
-	if err := kd.setupFilesystem(logger, kd.filesystemReady); err != nil {
-		return err
-	}
-
-	logger.Info("Success")
-	return nil
+	return kd.finishConnect(logger)
 }
 
 // ConnectToContact looks up a contact by fingerprint, registers it, and connects.
@@ -1196,17 +1157,3 @@ func (kd *KeibiDrop) UnmountFilesystem() error {
 	logger.Info("Success")
 	return nil
 }
-
-/*
-	func (kd *KeibiDrop) ResetSession() {
-		kd.logger.Info("Resetting session state")
-
-		// You probably want to close any existing net.Conn, etc.
-	}
-
-	func (kd *KeibiDrop) RegenerateKeys() error {
-		kd.logger.Info("Regenerating ephemeral keys")
-
-		return nil
-	}
-*/

--- a/pkg/logic/common/reconnect_race_test.go
+++ b/pkg/logic/common/reconnect_race_test.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// ABOUTME: Race detector test for reconnect map reset vs GetDownloadProgress.
+// ABOUTME: Ensures activeDownloadsMu is held during reconnect map reassignment.
+
+package common
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/KeibiSoft/KeibiDrop/pkg/filesystem"
+)
+
+// TestReconnectReset_NoRaceOnActiveDownloads verifies that concurrent
+// GetDownloadProgress calls do not race with the reconnect map reset.
+// Run with -race to catch any data race.
+func TestReconnectReset_NoRaceOnActiveDownloads(t *testing.T) {
+	kd := newTestKD(t)
+
+	const testFile = "test-file"
+	bm := filesystem.NewChunkBitmap(1024 * 1024)
+
+	// Populate maps under the mutex (mirrors how registerDownload works).
+	kd.activeDownloadsMu.Lock()
+	kd.activeDownloads[testFile] = func() {}
+	kd.activeBitmaps[testFile] = bm
+	kd.activeDownloadsMu.Unlock()
+
+	var start sync.WaitGroup
+	var done sync.WaitGroup
+	start.Add(1)
+
+	// Spawn readers that call GetDownloadProgress concurrently.
+	const readers = 8
+	done.Add(readers)
+	for range readers {
+		go func() {
+			defer done.Done()
+			start.Wait()
+			for range 500 {
+				kd.GetDownloadProgress(testFile)
+			}
+		}()
+	}
+
+	// Spawn one goroutine that does the reconnect reset (the fixed code path).
+	done.Add(1)
+	go func() {
+		defer done.Done()
+		start.Wait()
+		for range 100 {
+			kd.activeDownloadsMu.Lock()
+			for _, cancel := range kd.activeDownloads {
+				cancel()
+			}
+			kd.activeDownloads = make(map[string]context.CancelFunc)
+			kd.activeBitmaps = make(map[string]*filesystem.ChunkBitmap)
+			kd.activeDownloadsMu.Unlock()
+		}
+	}()
+
+	// Release all goroutines simultaneously.
+	start.Done()
+	done.Wait()
+}

--- a/pkg/logic/common/types.go
+++ b/pkg/logic/common/types.go
@@ -510,8 +510,13 @@ func (kd *KeibiDrop) Run() {
 			kd.SyncTracker = synctracker.NewSyncTracker()
 			kd.lastSharedPeerFP = prevPeerFP
 			kd.lastSharedFiles = prevLocal
+			kd.activeDownloadsMu.Lock()
+			for _, cancel := range kd.activeDownloads {
+				cancel()
+			}
 			kd.activeDownloads = make(map[string]context.CancelFunc)
 			kd.activeBitmaps = make(map[string]*filesystem.ChunkBitmap)
+			kd.activeDownloadsMu.Unlock()
 			ctx, c := context.WithCancel(context.Background())
 			kd.running.Store(false)
 			kd.mu.Lock()

--- a/pkg/logic/common/types.go
+++ b/pkg/logic/common/types.go
@@ -72,6 +72,10 @@ type KeibiDrop struct {
 	// Collab sync options.
 	PrefetchOnOpen bool
 	PushOnWrite    bool
+	// AutoCache (live_collab) enables the macFUSE auto_cache mount option so a
+	// peer's same-size in-place edit is seen live. Set by the caller from
+	// config.LiveCollab (not a constructor arg). Default false = git-safe.
+	AutoCache bool
 
 	// Signals for loop management.
 	signals      chan TaskSignal

--- a/pkg/logic/common/utils.go
+++ b/pkg/logic/common/utils.go
@@ -34,6 +34,34 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
+// deriveRelayAuth derives the relay lookup token (sent as the Bearer header)
+// and the registration encryption key from a fingerprint's room password.
+// Both register and fetch use this; the relay only ever sees the opaque token.
+func deriveRelayAuth(fp string) (lookupToken string, encryptionKey []byte, err error) {
+	roomPassword, err := crypto.ExtractRoomPassword(fp)
+	if err != nil {
+		return "", nil, fmt.Errorf("extract room password: %w", err)
+	}
+	lookupKey, encryptionKey, err := crypto.DeriveRelayKeys(roomPassword)
+	if err != nil {
+		return "", nil, fmt.Errorf("derive relay keys: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(lookupKey), encryptionKey, nil
+}
+
+// relayURL joins sub onto the configured relay endpoint and parses the result.
+func (kd *KeibiDrop) relayURL(sub string) (*url.URL, error) {
+	joined, err := url.JoinPath(kd.RelayEndoint.String(), sub)
+	if err != nil {
+		return nil, fmt.Errorf("join relay path %q: %w", sub, err)
+	}
+	u, err := url.Parse(joined)
+	if err != nil {
+		return nil, fmt.Errorf("parse relay url: %w", err)
+	}
+	return u, nil
+}
+
 func (kd *KeibiDrop) registerRoomToRelay() error {
 	logger := kd.logger.With("method", "register-room-to-relay")
 	if kd.relayClient == nil || kd.session == nil || kd.session.OwnKeys == nil {
@@ -43,19 +71,11 @@ func (kd *KeibiDrop) registerRoomToRelay() error {
 
 	ownFp := kd.session.OwnFingerprint
 
-	// Extract room password and derive relay keys for privacy.
-	roomPassword, err := crypto.ExtractRoomPassword(ownFp)
+	lookupToken, encryptionKey, err := deriveRelayAuth(ownFp)
 	if err != nil {
-		logger.Error("Failed to extract room password", "error", err)
+		logger.Error("Failed to derive relay auth", "error", err)
 		return err
 	}
-
-	lookupKey, encryptionKey, err := crypto.DeriveRelayKeys(roomPassword)
-	if err != nil {
-		logger.Error("Failed to derive relay keys", "error", err)
-		return err
-	}
-	lookupToken := base64.RawURLEncoding.EncodeToString(lookupKey)
 
 	pkMap, err := kd.session.OwnKeys.ExportPubKeysAsMap()
 	if err != nil {
@@ -94,15 +114,9 @@ func (kd *KeibiDrop) registerRoomToRelay() error {
 		Blob: base64.RawURLEncoding.EncodeToString(encryptedBlob),
 	}
 
-	path, err := url.JoinPath(kd.RelayEndoint.String(), "register")
+	registerUrl, err := kd.relayURL("register")
 	if err != nil {
-		logger.Error("Failed to add register path", "error", err)
-		return err
-	}
-
-	registerUrl, err := url.Parse(path)
-	if err != nil {
-		logger.Error("Failed to parse url", "error", err)
+		logger.Error("Failed to build register url", "error", err)
 		return err
 	}
 
@@ -145,29 +159,15 @@ func (kd *KeibiDrop) getRoomFromRelay(outOfBandFingerPrint string) error {
 		return ErrNilPointer
 	}
 
-	// Extract room password and derive relay keys for privacy.
-	roomPassword, err := crypto.ExtractRoomPassword(outOfBandFingerPrint)
+	lookupToken, encryptionKey, err := deriveRelayAuth(outOfBandFingerPrint)
 	if err != nil {
-		logger.Error("Failed to extract room password", "error", err)
+		logger.Error("Failed to derive relay auth", "error", err)
 		return err
 	}
 
-	lookupKey, encryptionKey, err := crypto.DeriveRelayKeys(roomPassword)
+	fetchUrl, err := kd.relayURL("fetch")
 	if err != nil {
-		logger.Error("Failed to derive relay keys", "error", err)
-		return err
-	}
-	lookupToken := base64.RawURLEncoding.EncodeToString(lookupKey)
-
-	path, err := url.JoinPath(kd.RelayEndoint.String(), "fetch")
-	if err != nil {
-		logger.Error("Failed to add fetch path", "error", err)
-		return err
-	}
-
-	fetchUrl, err := url.Parse(path)
-	if err != nil {
-		logger.Error("Failed to parse url", "error", err)
+		logger.Error("Failed to build fetch url", "error", err)
 		return err
 	}
 
@@ -264,7 +264,7 @@ func (kd *KeibiDrop) getRoomFromRelay(outOfBandFingerPrint string) error {
 	}
 
 	kd.session.PeerPubKeys = peerKeys
-	if peerReg.Listen.Port < 26000 || peerReg.Listen.Port > 27000 {
+	if !config.ValidPeerPort(peerReg.Listen.Port) {
 		logger.Warn("Provided outbound port is out of known range, defaulting to config", "provided-port", peerReg.Listen.Port, "default-to", config.OutboundPort)
 		peerReg.Listen.Port = config.OutboundPort
 	}
@@ -287,14 +287,31 @@ func (kd *KeibiDrop) getRoomFromRelay(outOfBandFingerPrint string) error {
 	return nil
 }
 
+// isValidIPv6 reports whether ipStr parses as an IPv6 address (i.e. a valid IP
+// that is not IPv4). Loopback/ULA/link-local are intentionally accepted.
 func isValidIPv6(ipStr string) bool {
 	ip := net.ParseIP(ipStr)
-	// TODO: Comment
 	return ip != nil && ip.To4() == nil
-	// return ip != nil && ip.To4() == nil && !ip.IsLoopback() && !ip.IsPrivate()
 }
 
 //
+
+// refreshAttrFromDisk updates req.Attr's Size/ModTime from the on-disk file
+// before a debounced notification is sent (the size captured when the event was
+// queued may be stale). It returns false only when the file no longer exists,
+// signalling the caller to drop the pending notification.
+func refreshAttrFromDisk(req *bindings.NotifyRequest, downloadFolder string) bool {
+	if req.Attr == nil {
+		return true
+	}
+	info, err := os.Lstat(filepath.Join(downloadFolder, req.Path))
+	if err != nil {
+		return !os.IsNotExist(err)
+	}
+	req.Attr.Size = info.Size()
+	req.Attr.ModificationTime = uint64(info.ModTime().UnixNano())
+	return true
+}
 
 func (kd *KeibiDrop) setupFilesystem(logger *slog.Logger, ready chan struct{}) error {
 	if kd.session == nil || kd.session.GRPCClient == nil {
@@ -311,6 +328,7 @@ func (kd *KeibiDrop) setupFilesystem(logger *slog.Logger, ready chan struct{}) e
 	// Set collab sync options.
 	fs.PrefetchOnOpen = kd.PrefetchOnOpen
 	fs.PushOnWrite = kd.PushOnWrite
+	fs.AutoCache = kd.AutoCache // live_collab → macFUSE auto_cache (set before Mount)
 
 	// Notification worker with per-path debounce and batching.
 	//
@@ -339,11 +357,16 @@ func (kd *KeibiDrop) setupFilesystem(logger *slog.Logger, ready chan struct{}) e
 			if len(batch) == 0 {
 				return
 			}
+			// Capture the client under the nil check: Run()'s ctx.Done teardown
+			// nils kd.session concurrently, so re-dereferencing kd.session below
+			// would race into a nil-deref panic. Holding a local reference is the
+			// same pattern connectGRPCClientWithRetry uses for the outbound conn.
 			if kd.session == nil || kd.session.GRPCClient == nil {
 				return
 			}
+			client := kd.session.GRPCClient
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-			_, err := kd.session.GRPCClient.BatchNotify(ctx, &bindings.BatchNotifyRequest{
+			_, err := client.BatchNotify(ctx, &bindings.BatchNotifyRequest{
 				Notifications: batch,
 				Seq:           batchSeq.Add(1),
 				Timestamp:     uint64(time.Now().UnixNano()),
@@ -353,7 +376,7 @@ func (kd *KeibiDrop) setupFilesystem(logger *slog.Logger, ready chan struct{}) e
 				logger.Error("BatchNotify failed, falling back to individual", "count", len(batch), "error", err)
 				for _, req := range batch {
 					ctx2, cancel2 := context.WithTimeout(context.Background(), 5*time.Second)
-					_, _ = kd.session.GRPCClient.Notify(ctx2, req)
+					_, _ = client.Notify(ctx2, req)
 					cancel2()
 				}
 			}
@@ -366,15 +389,9 @@ func (kd *KeibiDrop) setupFilesystem(logger *slog.Logger, ready chan struct{}) e
 					// Channel closed — flush all pending with fresh sizes.
 					remaining := make([]*bindings.NotifyRequest, 0, len(pending))
 					for path, p := range pending {
-						if p.req.Attr != nil && kd.FS != nil && kd.FS.Root != nil {
-							diskPath := filepath.Join(kd.FS.Root.LocalDownloadFolder, p.req.Path)
-							if info, err := os.Lstat(diskPath); err == nil {
-								p.req.Attr.Size = info.Size()
-								p.req.Attr.ModificationTime = uint64(info.ModTime().UnixNano())
-							} else if os.IsNotExist(err) {
-								delete(pending, path)
-								continue
-							}
+						if kd.FS != nil && kd.FS.Root != nil && !refreshAttrFromDisk(p.req, kd.FS.Root.LocalDownloadFolder) {
+							delete(pending, path)
+							continue
 						}
 						remaining = append(remaining, p.req)
 					}
@@ -430,15 +447,9 @@ func (kd *KeibiDrop) setupFilesystem(logger *slog.Logger, ready chan struct{}) e
 				ready := make([]*bindings.NotifyRequest, 0, 16)
 				for path, p := range pending {
 					if now.After(p.deadline) {
-						if p.req.Attr != nil && kd.FS != nil && kd.FS.Root != nil {
-							diskPath := filepath.Join(kd.FS.Root.LocalDownloadFolder, p.req.Path)
-							if info, err := os.Lstat(diskPath); err == nil {
-								p.req.Attr.Size = info.Size()
-								p.req.Attr.ModificationTime = uint64(info.ModTime().UnixNano())
-							} else if os.IsNotExist(err) {
-								delete(pending, path)
-								continue
-							}
+						if kd.FS != nil && kd.FS.Root != nil && !refreshAttrFromDisk(p.req, kd.FS.Root.LocalDownloadFolder) {
+							delete(pending, path)
+							continue
 						}
 						ready = append(ready, p.req)
 						delete(pending, path)
@@ -568,17 +579,23 @@ func (kd *KeibiDrop) connectGRPCClientWithRetry(timeout time.Duration) error {
 // Declared as var (not const) so tests can shrink it.
 var grpcDisconnectGraceDelay = 250 * time.Millisecond
 
-// handleNotifyDisconnect runs the post-DISCONNECT teardown: unmount FUSE
-// first (so Run()'s Start handler can return), then sleep the grace window
-// to let the in-flight DISCONNECT RPC response flush before we cancel the
-// context (which the Run() ctx.Done branch uses to call grpcServer.Stop()
+// handleNotifyDisconnect runs the post-DISCONNECT teardown: clear the FUSE
+// view (keeping the mount alive for reuse on reconnect), then sleep the grace
+// window to let the in-flight DISCONNECT RPC response flush before we cancel
+// the context (which the Run() ctx.Done branch uses to call grpcServer.Stop()
 // and grpcClientConn.Close()).
 //
 // MUST be invoked in a goroutine separate from the gRPC handler — the
 // handler is still writing the response when this runs.
 func (kd *KeibiDrop) handleNotifyDisconnect() {
 	if kd.FS != nil {
-		kd.FS.Unmount()
+		// Keep the FUSE mount alive across the disconnect — cgofuse allows only
+		// one mount per process, so a fresh remount on reconnect is fragile and
+		// can fail (leaving the mount point dead). ClearFiles drops the peer's
+		// file view and cancels in-flight reads but leaves the mount up; Run()'s
+		// Start handler then reuses it on reconnect (it returns via the ctx.Done
+		// select, not by Mount() unblocking). Full Unmount stays on app exit.
+		kd.FS.ClearFiles()
 	}
 	time.Sleep(grpcDisconnectGraceDelay)
 	kd.cancelContext()

--- a/pkg/logic/service/notify_synctracker_test.go
+++ b/pkg/logic/service/notify_synctracker_test.go
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// ABOUTME: Tests that ADD_FILE and EDIT_FILE via the FUSE path write SyncTracker.RemoteFiles.
+// ABOUTME: Regression for FUSE-mode files being invisible in the UI via KD_GetFileCount/KD_GetFileName.
+
+//go:build !android
+
+package service
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+
+	bindings "github.com/KeibiSoft/KeibiDrop/grpc_bindings"
+	"github.com/KeibiSoft/KeibiDrop/pkg/filesystem"
+	synctracker "github.com/KeibiSoft/KeibiDrop/pkg/sync-tracker"
+	"github.com/KeibiSoft/KeibiDrop/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAddFile_FuseMode_WritesSyncTracker verifies that when FUSE is active,
+// a NotifyType_ADD_FILE request writes the file into SyncTracker.RemoteFiles
+// so the UI can surface it via KD_GetFileCount/KD_GetFileName.
+func TestAddFile_FuseMode_WritesSyncTracker(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	root := &filesystem.Dir{
+		RemoteFilesLock:     sync.RWMutex{},
+		RemoteFiles:         make(map[string]*filesystem.File),
+		AfmLock:             sync.RWMutex{},
+		AllFileMap:          make(map[string]*filesystem.File),
+		OpenMapLock:         sync.RWMutex{},
+		OpenFileHandlers:    make(map[uint64]*filesystem.HandleEntry),
+		Adm:                 sync.RWMutex{},
+		AllDirMap:           make(map[string]*filesystem.Dir),
+		RealPathOfFile:      tmpDir,
+		LocalDownloadFolder: tmpDir,
+		FsCtx:               context.Background(),
+		PrefetchSem:         make(chan struct{}, 8),
+		// OpenStreamProvider returns nil — prefetchFile exits cleanly at fsp==nil check.
+		OpenStreamProvider: func() types.FileStreamProvider { return nil },
+	}
+	root.Root = root
+
+	svc := &KeibidropServiceImpl{
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		FS: &filesystem.FS{
+			Root: root,
+		},
+		SyncTracker: synctracker.NewSyncTracker(),
+	}
+
+	const (
+		filePath = "/test-file.txt"
+		fileName = "test-file.txt"
+		fileSize = int64(1024)
+	)
+
+	req := &bindings.NotifyRequest{
+		Type: bindings.NotifyType_ADD_FILE,
+		Path: filePath,
+		Name: fileName,
+		Attr: &bindings.Attr{
+			Size:             fileSize,
+			ModificationTime: 1000000,
+			BirthTime:        2000000,
+			Mode:             0o644,
+		},
+	}
+
+	resp, err := svc.Notify(context.Background(), req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	svc.SyncTracker.RemoteFilesMu.RLock()
+	got, ok := svc.SyncTracker.RemoteFiles[filePath]
+	svc.SyncTracker.RemoteFilesMu.RUnlock()
+
+	require.True(t, ok, "SyncTracker.RemoteFiles[%q] should be populated after FUSE ADD_FILE", filePath)
+	assert.Equal(t, fileName, got.Name, "Name mismatch")
+	assert.Equal(t, filePath, got.RelativePath, "RelativePath mismatch")
+	assert.Equal(t, uint64(fileSize), got.Size, "Size mismatch")
+}
+
+// TestEditFile_FuseMode_UpdatesSyncTracker verifies that when FUSE is active,
+// a NotifyType_EDIT_FILE request updates an existing entry in SyncTracker.RemoteFiles.
+func TestEditFile_FuseMode_UpdatesSyncTracker(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	root := &filesystem.Dir{
+		RemoteFilesLock:     sync.RWMutex{},
+		RemoteFiles:         make(map[string]*filesystem.File),
+		AfmLock:             sync.RWMutex{},
+		AllFileMap:          make(map[string]*filesystem.File),
+		OpenMapLock:         sync.RWMutex{},
+		OpenFileHandlers:    make(map[uint64]*filesystem.HandleEntry),
+		Adm:                 sync.RWMutex{},
+		AllDirMap:           make(map[string]*filesystem.Dir),
+		RealPathOfFile:      tmpDir,
+		LocalDownloadFolder: tmpDir,
+		FsCtx:               context.Background(),
+		PrefetchSem:         make(chan struct{}, 8),
+		OpenStreamProvider:  func() types.FileStreamProvider { return nil },
+	}
+	root.Root = root
+
+	tracker := synctracker.NewSyncTracker()
+
+	const (
+		filePath    = "/test-file.txt"
+		fileName    = "test-file.txt"
+		initialSize = uint64(1024)
+		updatedSize = int64(2048)
+		initialTime = uint64(1000000)
+		updatedTime = uint64(3000000)
+	)
+
+	// Pre-populate SyncTracker with an existing entry.
+	tracker.RemoteFiles[filePath] = &synctracker.File{
+		Name:         fileName,
+		RelativePath: filePath,
+		Size:         initialSize,
+		LastEditTime: initialTime,
+	}
+
+	svc := &KeibidropServiceImpl{
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		FS: &filesystem.FS{
+			Root: root,
+		},
+		SyncTracker: tracker,
+	}
+
+	req := &bindings.NotifyRequest{
+		Type: bindings.NotifyType_EDIT_FILE,
+		Path: filePath,
+		Name: fileName,
+		Attr: &bindings.Attr{
+			Size:             updatedSize,
+			ModificationTime: updatedTime,
+			BirthTime:        2000000,
+			Mode:             0o644,
+		},
+	}
+
+	resp, err := svc.Notify(context.Background(), req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	tracker.RemoteFilesMu.RLock()
+	got, ok := tracker.RemoteFiles[filePath]
+	tracker.RemoteFilesMu.RUnlock()
+
+	require.True(t, ok, "SyncTracker.RemoteFiles[%q] should exist after FUSE EDIT_FILE", filePath)
+	assert.Equal(t, uint64(updatedSize), got.Size, "Size should be updated")
+	assert.Equal(t, updatedTime, got.LastEditTime, "LastEditTime should be updated")
+}
+
+// TestEditFile_FuseMode_CreatesNewSyncTrackerEntry verifies that when FUSE is active,
+// a NotifyType_EDIT_FILE for an unknown path creates a new SyncTracker entry.
+func TestEditFile_FuseMode_CreatesNewSyncTrackerEntry(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	root := &filesystem.Dir{
+		RemoteFilesLock:     sync.RWMutex{},
+		RemoteFiles:         make(map[string]*filesystem.File),
+		AfmLock:             sync.RWMutex{},
+		AllFileMap:          make(map[string]*filesystem.File),
+		OpenMapLock:         sync.RWMutex{},
+		OpenFileHandlers:    make(map[uint64]*filesystem.HandleEntry),
+		Adm:                 sync.RWMutex{},
+		AllDirMap:           make(map[string]*filesystem.Dir),
+		RealPathOfFile:      tmpDir,
+		LocalDownloadFolder: tmpDir,
+		FsCtx:               context.Background(),
+		PrefetchSem:         make(chan struct{}, 8),
+		OpenStreamProvider:  func() types.FileStreamProvider { return nil },
+	}
+	root.Root = root
+
+	svc := &KeibidropServiceImpl{
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		FS: &filesystem.FS{
+			Root: root,
+		},
+		SyncTracker: synctracker.NewSyncTracker(),
+	}
+
+	const (
+		filePath    = "/new-file.txt"
+		fileName    = "new-file.txt"
+		fileSize    = int64(4096)
+		fileModTime = uint64(5000000)
+		fileBirth   = uint64(4000000)
+	)
+
+	req := &bindings.NotifyRequest{
+		Type: bindings.NotifyType_EDIT_FILE,
+		Path: filePath,
+		Name: fileName,
+		Attr: &bindings.Attr{
+			Size:             fileSize,
+			ModificationTime: fileModTime,
+			BirthTime:        fileBirth,
+			Mode:             0o644,
+		},
+	}
+
+	resp, err := svc.Notify(context.Background(), req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	svc.SyncTracker.RemoteFilesMu.RLock()
+	got, ok := svc.SyncTracker.RemoteFiles[filePath]
+	svc.SyncTracker.RemoteFilesMu.RUnlock()
+
+	require.True(t, ok, "SyncTracker.RemoteFiles[%q] should be created after FUSE EDIT_FILE on new path", filePath)
+	assert.Equal(t, fileName, got.Name, "Name mismatch")
+	assert.Equal(t, filePath, got.RelativePath, "RelativePath mismatch")
+	assert.Equal(t, uint64(fileSize), got.Size, "Size mismatch")
+	assert.Equal(t, fileModTime, got.LastEditTime, "LastEditTime mismatch")
+	assert.Equal(t, fileBirth, got.CreatedTime, "CreatedTime mismatch")
+}

--- a/pkg/logic/service/service.go
+++ b/pkg/logic/service/service.go
@@ -54,6 +54,25 @@ type KeibidropServiceImpl struct {
 	pendingRemoves   map[string]*time.Timer
 }
 
+// statFromAttr builds a fuse.Stat_t from a peer-sent Attr. Remote files are
+// presented as owned by the current user; Nlink is always 1.
+func statFromAttr(a *bindings.Attr) *fuse.Stat_t {
+	return &fuse.Stat_t{
+		Dev:      a.Dev,
+		Ino:      a.Ino,
+		Mode:     a.Mode,
+		Nlink:    1,
+		Uid:      uint32(os.Getuid()),
+		Gid:      uint32(os.Getgid()),
+		Size:     a.Size,
+		Atim:     fuse.NewTimespec(time.Unix(0, int64(a.AccessTime))),
+		Mtim:     fuse.NewTimespec(time.Unix(0, int64(a.ModificationTime))),
+		Ctim:     fuse.NewTimespec(time.Unix(0, int64(a.ChangeTime))),
+		Birthtim: fuse.NewTimespec(time.Unix(0, int64(a.BirthTime))),
+		Flags:    a.Flags,
+	}
+}
+
 func (kd *KeibidropServiceImpl) Debug(context.Context, *bindings.DebugRequest) (*bindings.DebugResponse, error) {
 	kd.Logger.Info("Debug called. Success!")
 
@@ -132,15 +151,6 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 			return nil, ErrGRPCInvalidArgument
 		}
 
-		// logger.Info("<<< RECEIVED ADD_FILE FROM PEER",
-		// 	"path", req.Path,
-		// 	"size", req.Attr.Size)
-
-		atim := time.Unix(0, int64(req.Attr.AccessTime))
-		mtim := time.Unix(0, int64(req.Attr.ModificationTime))
-		ctim := time.Unix(0, int64(req.Attr.ChangeTime))
-		btim := time.Unix(0, int64(req.Attr.BirthTime))
-
 		if (kd.FS == nil || kd.FS.Root == nil) && kd.SyncTracker != nil {
 			kd.SyncTracker.RemoteFilesMu.Lock()
 			defer kd.SyncTracker.RemoteFilesMu.Unlock()
@@ -186,41 +196,14 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 			return nil, ErrGRPCFailedPrecondition
 		}
 
-		err := kd.FS.Root.AddRemoteFile(logger, req.Path, req.Name, &fuse.Stat_t{
-			Dev:      req.Attr.Dev,
-			Ino:      req.Attr.Ino,
-			Mode:     req.Attr.Mode,
-			Nlink:    1,
-			Uid:      uint32(os.Getuid()),
-			Gid:      uint32(os.Getgid()),
-			Size:     req.Attr.Size,
-			Atim:     fuse.NewTimespec(atim),
-			Mtim:     fuse.NewTimespec(mtim),
-			Ctim:     fuse.NewTimespec(ctim),
-			Birthtim: fuse.NewTimespec(btim),
-			Flags:    req.Attr.Flags,
-		})
+		err := kd.FS.Root.AddRemoteFile(logger, req.Path, req.Name, statFromAttr(req.Attr))
 		if err != nil {
 			return nil, ErrGRPCInvalidArgument
 		}
 
-		if kd.SyncTracker != nil {
-			kd.SyncTracker.RemoteFilesMu.Lock()
-			existing, ok := kd.SyncTracker.RemoteFiles[req.Path]
-			if ok {
-				existing.Size = uint64(req.Attr.Size)
-				existing.LastEditTime = req.Attr.ModificationTime
-			} else {
-				kd.SyncTracker.RemoteFiles[req.Path] = &synctracker.File{
-					Name:         req.Name,
-					RelativePath: req.Path,
-					Size:         uint64(req.Attr.Size),
-					LastEditTime: req.Attr.ModificationTime,
-					CreatedTime:  req.Attr.BirthTime,
-				}
-			}
-			kd.SyncTracker.RemoteFilesMu.Unlock()
-		}
+		// Mirror into SyncTracker so the desktop/mobile file list (which reads
+		// SyncTracker.RemoteFiles) shows files added over the FUSE path (#164).
+		kd.upsertRemoteInTracker(req)
 
 		if kd.OnEvent != nil {
 			name := req.Name
@@ -236,10 +219,6 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 			logger.Error("Failed to add file, invalid attr", "error", ErrGRPCInvalidArgument)
 			return nil, ErrGRPCFailedPrecondition
 		}
-		atim := time.Unix(0, int64(req.Attr.AccessTime))
-		mtim := time.Unix(0, int64(req.Attr.ModificationTime))
-		ctim := time.Unix(0, int64(req.Attr.ChangeTime))
-		btim := time.Unix(0, int64(req.Attr.BirthTime))
 
 		if (kd.FS == nil || kd.FS.Root == nil) && kd.SyncTracker != nil {
 			kd.SyncTracker.RemoteFilesMu.Lock()
@@ -286,45 +265,14 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 			return nil, ErrGRPCFailedPrecondition
 		}
 
-		err := kd.FS.Root.EditRemoteFile(logger, req.Path, req.Name, &fuse.Stat_t{
-			Dev:      req.Attr.Dev,
-			Ino:      req.Attr.Ino,
-			Mode:     req.Attr.Mode,
-			Nlink:    1,
-			Uid:      uint32(os.Getuid()),
-			Gid:      uint32(os.Getgid()),
-			Size:     req.Attr.Size,
-			Atim:     fuse.NewTimespec(atim),
-			Mtim:     fuse.NewTimespec(mtim),
-			Ctim:     fuse.NewTimespec(ctim),
-			Birthtim: fuse.NewTimespec(btim),
-			Flags:    req.Attr.Flags,
-		})
+		err := kd.FS.Root.EditRemoteFile(logger, req.Path, req.Name, statFromAttr(req.Attr))
 
 		if err != nil {
 			return nil, ErrGRPCFailedPrecondition
 		}
 
-		if kd.SyncTracker != nil {
-			kd.SyncTracker.RemoteFilesMu.Lock()
-			if f, ok := kd.SyncTracker.RemoteFiles[req.Path]; ok {
-				f.Size = uint64(req.Attr.Size)
-				f.LastEditTime = req.Attr.ModificationTime
-			} else {
-				name := req.Name
-				if name == "" {
-					name = filepath.Base(req.Path)
-				}
-				kd.SyncTracker.RemoteFiles[req.Path] = &synctracker.File{
-					Name:         name,
-					RelativePath: req.Path,
-					Size:         uint64(req.Attr.Size),
-					LastEditTime: req.Attr.ModificationTime,
-					CreatedTime:  req.Attr.BirthTime,
-				}
-			}
-			kd.SyncTracker.RemoteFilesMu.Unlock()
-		}
+		// Keep SyncTracker in sync on the FUSE path too (#164).
+		kd.upsertRemoteInTracker(req)
 	case bindings.NotifyType_REMOVE_FILE:
 		// Buffer REMOVE for 1000ms. Git's atomic write pattern is:
 		//   REMOVE HEAD → CREATE HEAD → RENAME HEAD.lock (all within <1ms)
@@ -411,24 +359,7 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 				}
 
 				if needsRedownload {
-					atim := time.Unix(0, int64(req.Attr.AccessTime))
-					mtim := time.Unix(0, int64(req.Attr.ModificationTime))
-					ctim := time.Unix(0, int64(req.Attr.ChangeTime))
-					btim := time.Unix(0, int64(req.Attr.BirthTime))
-					_ = kd.FS.Root.AddRemoteFile(logger, req.Path, filepath.Base(req.Path), &fuse.Stat_t{
-						Dev:      req.Attr.Dev,
-						Ino:      req.Attr.Ino,
-						Mode:     req.Attr.Mode,
-						Nlink:    1,
-						Uid:      uint32(os.Getuid()),
-						Gid:      uint32(os.Getgid()),
-						Size:     req.Attr.Size,
-						Atim:     fuse.NewTimespec(atim),
-						Mtim:     fuse.NewTimespec(mtim),
-						Ctim:     fuse.NewTimespec(ctim),
-						Birthtim: fuse.NewTimespec(btim),
-						Flags:    req.Attr.Flags,
-					})
+					_ = kd.FS.Root.AddRemoteFile(logger, req.Path, filepath.Base(req.Path), statFromAttr(req.Attr))
 				}
 			}
 
@@ -444,24 +375,7 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 				if targetTracked {
 					logger.Info("Lock-file rename: re-downloading target",
 						"path", req.Path, "size", req.Attr.Size)
-					atim := time.Unix(0, int64(req.Attr.AccessTime))
-					mtim := time.Unix(0, int64(req.Attr.ModificationTime))
-					ctim := time.Unix(0, int64(req.Attr.ChangeTime))
-					btim := time.Unix(0, int64(req.Attr.BirthTime))
-					_ = kd.FS.Root.AddRemoteFile(logger, req.Path, filepath.Base(req.Path), &fuse.Stat_t{
-						Dev:      req.Attr.Dev,
-						Ino:      req.Attr.Ino,
-						Mode:     req.Attr.Mode,
-						Nlink:    1,
-						Uid:      uint32(os.Getuid()),
-						Gid:      uint32(os.Getgid()),
-						Size:     req.Attr.Size,
-						Atim:     fuse.NewTimespec(atim),
-						Mtim:     fuse.NewTimespec(mtim),
-						Ctim:     fuse.NewTimespec(ctim),
-						Birthtim: fuse.NewTimespec(btim),
-						Flags:    req.Attr.Flags,
-					})
+					_ = kd.FS.Root.AddRemoteFile(logger, req.Path, filepath.Base(req.Path), statFromAttr(req.Attr))
 				}
 			}
 		}
@@ -618,6 +532,68 @@ func (kd *KeibidropServiceImpl) executeRemove(path string, logger *slog.Logger) 
 	}
 }
 
+// upsertRemoteInTracker mirrors a peer ADD_FILE/EDIT_FILE into
+// SyncTracker.RemoteFiles. The desktop/mobile file lists read SyncTracker, so
+// the FUSE path must update it too — otherwise files added over FUSE never
+// appear in the list even though FUSE serves them (#164). Keyed by req.Path to
+// match the RENAME_FILE and REMOVE_FILE handlers.
+func (kd *KeibidropServiceImpl) upsertRemoteInTracker(req *bindings.NotifyRequest) {
+	if kd.SyncTracker == nil || req.Attr == nil {
+		return
+	}
+	name := req.Name
+	if name == "" {
+		name = filepath.Base(req.Path)
+	}
+	kd.SyncTracker.RemoteFilesMu.Lock()
+	defer kd.SyncTracker.RemoteFilesMu.Unlock()
+	if f, ok := kd.SyncTracker.RemoteFiles[req.Path]; ok {
+		f.Name = name
+		f.RelativePath = req.Path
+		f.Size = uint64(req.Attr.Size)
+		f.LastEditTime = req.Attr.ModificationTime
+		f.CreatedTime = req.Attr.BirthTime
+		return
+	}
+	kd.SyncTracker.RemoteFiles[req.Path] = &synctracker.File{
+		Name:         name,
+		RelativePath: req.Path,
+		Size:         uint64(req.Attr.Size),
+		LastEditTime: req.Attr.ModificationTime,
+		CreatedTime:  req.Attr.BirthTime,
+	}
+}
+
+// resolveFUSEPath returns the on-disk path for a peer-requested path in FUSE
+// mode: AllFileMap first (keys carry a leading "/"), then SyncTracker.LocalFiles
+// (drag-and-drop AddFile entries). Returns "" if not found. Each map lock is
+// held only briefly and never across the returned path's use. Caller must have
+// verified kd.FS and kd.FS.Root are non-nil.
+func (kd *KeibidropServiceImpl) resolveFUSEPath(path string) string {
+	fuseKey := path
+	if !strings.HasPrefix(fuseKey, "/") {
+		fuseKey = "/" + fuseKey
+	}
+	kd.FS.Root.AfmLock.RLock()
+	f, ok := kd.FS.Root.AllFileMap[fuseKey]
+	kd.FS.Root.AfmLock.RUnlock()
+	if ok {
+		return f.RealPathOfFile
+	}
+	if kd.SyncTracker == nil {
+		return ""
+	}
+	kd.SyncTracker.LocalFilesMu.RLock()
+	defer kd.SyncTracker.LocalFilesMu.RUnlock()
+	if lf, ok := kd.SyncTracker.LocalFiles[strings.TrimPrefix(path, "/")]; ok {
+		return lf.RealPathOfFile
+	}
+	if lf, ok := kd.SyncTracker.LocalFiles[path]; ok {
+		return lf.RealPathOfFile
+	}
+	return ""
+}
+
 func (kd *KeibidropServiceImpl) Read(stream bindings.KeibiService_ReadServer) error {
 	logger := kd.Logger.With("method", "server-read")
 
@@ -723,8 +699,7 @@ func (kd *KeibidropServiceImpl) Read(stream bindings.KeibiService_ReadServer) er
 
 	var fh *os.File
 	var openedPath string
-	// hardcode buffer to 16 MiB (1<<24 is 16 MB; adjust if needed)
-	buf := make([]byte, 1<<24)
+	buf := make([]byte, config.GRPCStreamBuffer)
 
 	for {
 		rec, err := stream.Recv()
@@ -746,35 +721,7 @@ func (kd *KeibidropServiceImpl) Read(stream bindings.KeibiService_ReadServer) er
 		if !isOpen {
 			isOpen = true
 
-			// Normalize to FUSE convention: AllFileMap keys have leading "/".
-			fuseKey := rec.Path
-			if !strings.HasPrefix(fuseKey, "/") {
-				fuseKey = "/" + fuseKey
-			}
-
-			// Only hold the lock briefly to look up the file path
-			kd.FS.Root.AfmLock.RLock()
-			f, ok := kd.FS.Root.AllFileMap[fuseKey]
-			kd.FS.Root.AfmLock.RUnlock()
-
-			// Fallback: files added via drag-and-drop (AddFile) live in
-			// SyncTracker.LocalFiles, not in FUSE's AllFileMap.
-			var realPath string
-			if ok {
-				realPath = f.RealPathOfFile
-			} else if kd.SyncTracker != nil {
-				lookupPath := strings.TrimPrefix(rec.Path, "/")
-				kd.SyncTracker.LocalFilesMu.RLock()
-				lf, lfOk := kd.SyncTracker.LocalFiles[lookupPath]
-				if !lfOk {
-					lf, lfOk = kd.SyncTracker.LocalFiles[rec.Path]
-				}
-				kd.SyncTracker.LocalFilesMu.RUnlock()
-				if lfOk {
-					realPath = lf.RealPathOfFile
-				}
-			}
-
+			realPath := kd.resolveFUSEPath(rec.Path)
 			if realPath == "" {
 				logger.Warn("File not found", "rec", rec)
 				return status.Error(codes.NotFound, "file not found")
@@ -845,27 +792,7 @@ func (kd *KeibidropServiceImpl) StreamFile(req *bindings.StreamFileRequest, stre
 			realPath = f.RealPathOfFile
 		}
 	} else if kd.FS != nil && kd.FS.Root != nil {
-		fuseKey := req.Path
-		if !strings.HasPrefix(fuseKey, "/") {
-			fuseKey = "/" + fuseKey
-		}
-		kd.FS.Root.AfmLock.RLock()
-		f, ok := kd.FS.Root.AllFileMap[fuseKey]
-		kd.FS.Root.AfmLock.RUnlock()
-		if ok {
-			realPath = f.RealPathOfFile
-		} else if kd.SyncTracker != nil {
-			lookupPath := strings.TrimPrefix(req.Path, "/")
-			kd.SyncTracker.LocalFilesMu.RLock()
-			lf, lfOk := kd.SyncTracker.LocalFiles[lookupPath]
-			if !lfOk {
-				lf, lfOk = kd.SyncTracker.LocalFiles[req.Path]
-			}
-			kd.SyncTracker.LocalFilesMu.RUnlock()
-			if lfOk {
-				realPath = lf.RealPathOfFile
-			}
-		}
+		realPath = kd.resolveFUSEPath(req.Path)
 	}
 
 	if realPath == "" {

--- a/pkg/logic/service/service.go
+++ b/pkg/logic/service/service.go
@@ -204,6 +204,24 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 			return nil, ErrGRPCInvalidArgument
 		}
 
+		if kd.SyncTracker != nil {
+			kd.SyncTracker.RemoteFilesMu.Lock()
+			existing, ok := kd.SyncTracker.RemoteFiles[req.Path]
+			if ok {
+				existing.Size = uint64(req.Attr.Size)
+				existing.LastEditTime = req.Attr.ModificationTime
+			} else {
+				kd.SyncTracker.RemoteFiles[req.Path] = &synctracker.File{
+					Name:         req.Name,
+					RelativePath: req.Path,
+					Size:         uint64(req.Attr.Size),
+					LastEditTime: req.Attr.ModificationTime,
+					CreatedTime:  req.Attr.BirthTime,
+				}
+			}
+			kd.SyncTracker.RemoteFilesMu.Unlock()
+		}
+
 		if kd.OnEvent != nil {
 			name := req.Name
 			if name == "" {
@@ -285,6 +303,27 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 
 		if err != nil {
 			return nil, ErrGRPCFailedPrecondition
+		}
+
+		if kd.SyncTracker != nil {
+			kd.SyncTracker.RemoteFilesMu.Lock()
+			if f, ok := kd.SyncTracker.RemoteFiles[req.Path]; ok {
+				f.Size = uint64(req.Attr.Size)
+				f.LastEditTime = req.Attr.ModificationTime
+			} else {
+				name := req.Name
+				if name == "" {
+					name = filepath.Base(req.Path)
+				}
+				kd.SyncTracker.RemoteFiles[req.Path] = &synctracker.File{
+					Name:         name,
+					RelativePath: req.Path,
+					Size:         uint64(req.Attr.Size),
+					LastEditTime: req.Attr.ModificationTime,
+					CreatedTime:  req.Attr.BirthTime,
+				}
+			}
+			kd.SyncTracker.RemoteFilesMu.Unlock()
 		}
 	case bindings.NotifyType_REMOVE_FILE:
 		// Buffer REMOVE for 1000ms. Git's atomic write pattern is:

--- a/pkg/session/handshake.go
+++ b/pkg/session/handshake.go
@@ -92,7 +92,7 @@ func PerformInboundHandshake(session *Session, conn net.Conn) error {
 		return fmt.Errorf("fingerprint mismatch: got %s, expected %s", computed, session.ExpectedPeerFingerprint)
 	}
 
-	if msg.OutboundPort < 26000 || msg.OutboundPort > 27000 {
+	if !config.ValidPeerPort(int(msg.OutboundPort)) {
 		logger.Warn("Provided outbound port is out of known range, defaulting to config", "provided-port", msg.OutboundPort, "default-to", config.OutboundPort)
 		msg.OutboundPort = config.OutboundPort
 	}

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -146,6 +146,22 @@ func (s *Session) GetFingerPrint() string {
 	return s.OwnFingerprint
 }
 
+// ResetOutboundCrypto clears the outbound shared key and negotiated cipher
+// suite so a fresh outbound handshake can run (e.g. when falling back to the
+// bridge). The caller is responsible for closing any existing outbound conn.
+func (s *Session) ResetOutboundCrypto() {
+	s.SEKOutbound = nil
+	s.CipherMu.Lock()
+	s.CipherSuite = ""
+	s.CipherMu.Unlock()
+}
+
+// ResetInboundCrypto clears the inbound shared key. The caller is responsible
+// for closing any existing inbound conn.
+func (s *Session) ResetInboundCrypto() {
+	s.SEKInbound = nil
+}
+
 // SessionSockets holds a duplex connection for peer communication.
 type SessionSockets struct {
 	Inbound  *SecureConn // Bob -> Alice

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -258,7 +258,7 @@ fn start_file_watcher(
                         } else if info.paused {
                             // Paused: show progress from bitmap via FFI
                             let c_name = CString::new(name.clone()).unwrap();
-                            let prog = bindings::KD_GetDownloadProgress(c_name.into_raw());
+                            let prog = bindings::KD_GetDownloadProgress(c_name.as_ptr() as *mut i8);
                             let p = if prog >= 0 { prog as f32 / 100.0 } else { 0.0 };
                             (false, p, false, true)
                         } else {
@@ -731,11 +731,11 @@ fn main() {
 
     unsafe {
         let result = bindings::KD_Initialize(
-            relay_c.into_raw(),
+            relay_c.as_ptr() as *mut i8,
             inbound,
             outbound,
-            to_mount_c.into_raw(),
-            to_save_c.into_raw(),
+            to_mount_c.as_ptr() as *mut i8,
+            to_save_c.as_ptr() as *mut i8,
             if use_fuse { 1 } else { 0 },
             if prefetch_on_open { 1 } else { 0 },
             if push_on_write { 1 } else { 0 },
@@ -907,7 +907,7 @@ fn main() {
                 let i_am_creator = my_name < peer_name;
 
                 let addr_c = CString::new(addr.clone()).unwrap();
-                bindings::KD_SetPeerDirectAddress(addr_c.into_raw());
+                bindings::KD_SetPeerDirectAddress(addr_c.as_ptr() as *mut i8);
 
                 if let Some(app) = weak_peer_sel.upgrade() {
                     app.set_peer_code(slint::SharedString::from(&addr));
@@ -1078,7 +1078,7 @@ fn main() {
                     .save_file()
                 {
                     let c_dest = CString::new(dest.to_string_lossy().to_string()).unwrap();
-                    let res = bindings::KD_SanitizeLogs(c_dest.into_raw());
+                    let res = bindings::KD_SanitizeLogs(c_dest.as_ptr() as *mut i8);
                     if res == 0 {
                         println!("Sanitized logs saved to: {}", dest.display());
                     } else {
@@ -1209,7 +1209,7 @@ fn main() {
                             eprintln!("Failed to copy file to save folder: {}", e);
                         }
                         let c_path = CString::new(path_str).unwrap();
-                        let res = bindings::KD_AddFile(c_path.into_raw());
+                        let res = bindings::KD_AddFile(c_path.as_ptr() as *mut i8);
                         if res != 0 {
                             let err = get_last_error();
                             eprintln!("Failed to add file: {}", err);
@@ -1261,8 +1261,8 @@ fn main() {
                 let c_name = CString::new(name.clone()).unwrap();
                 let c_path = CString::new(local_path.clone()).unwrap();
                 let res = bindings::KD_SaveFileByName(
-                    c_name.into_raw(),
-                    c_path.into_raw(),
+                    c_name.as_ptr() as *mut i8,
+                    c_path.as_ptr() as *mut i8,
                 );
 
                 let mut dl = downloads.lock().unwrap();
@@ -1290,7 +1290,7 @@ fn main() {
                     info.downloading = false;
                     info.paused = true;
                     let c_name = CString::new(name.clone()).unwrap();
-                    bindings::KD_CancelDownload(c_name.into_raw());
+                    bindings::KD_CancelDownload(c_name.as_ptr() as *mut i8);
                     println!("Paused download: {}", name);
                 } else if info.paused {
                     // Resume: re-trigger download (PullFile resumes from bitmap)
@@ -1303,8 +1303,8 @@ fn main() {
                         let c_name = CString::new(name_clone.clone()).unwrap();
                         let c_path = CString::new(local_path).unwrap();
                         let res = bindings::KD_SaveFileByName(
-                            c_name.into_raw(),
-                            c_path.into_raw(),
+                            c_name.as_ptr() as *mut i8,
+                            c_path.as_ptr() as *mut i8,
                         );
                         let mut dl = dl_clone.lock().unwrap();
                         if let Some(info) = dl.get_mut(&name_clone) {
@@ -1414,7 +1414,7 @@ fn main() {
                 std::thread::spawn(move || {
                     let c_n = CString::new(n.clone()).unwrap();
                     let c_p = CString::new(local_path.clone()).unwrap();
-                    let res = bindings::KD_SaveFileByName(c_n.into_raw(), c_p.into_raw());
+                    let res = bindings::KD_SaveFileByName(c_n.as_ptr() as *mut i8, c_p.as_ptr() as *mut i8);
                     let mut dl = dl_clone.lock().unwrap();
                     if let Some(info) = dl.get_mut(&n) {
                         info.downloading = false;
@@ -1509,7 +1509,7 @@ fn main() {
 
             // Register the fingerprint with the session (required before Connect)
             let c_fp = CString::new(fp.clone()).unwrap();
-            let res = bindings::KD_AddPeerFingerprint(c_fp.into_raw());
+            let res = bindings::KD_AddPeerFingerprint(c_fp.as_ptr() as *mut i8);
             if res != 0 {
                 let err = get_last_error();
                 if let Some(app) = weak_connect_contact.upgrade() {
@@ -1544,7 +1544,7 @@ fn main() {
                 return;
             }
             let c_name = CString::new(name_str.clone()).unwrap();
-            let res = bindings::KD_SaveCurrentPeerAsContact(c_name.into_raw());
+            let res = bindings::KD_SaveCurrentPeerAsContact(c_name.as_ptr() as *mut i8);
             if res == 0 {
                 show_toast(&weak_save_contact, &format!("Saved as '{}'", name_str));
                 if let Some(app) = weak_save_contact.upgrade() {
@@ -1564,7 +1564,7 @@ fn main() {
             }
             let fp = CStr::from_ptr(fp_ptr).to_string_lossy().to_string();
             let c_fp = CString::new(fp).unwrap();
-            bindings::KD_RemoveContact(c_fp.into_raw());
+            bindings::KD_RemoveContact(c_fp.as_ptr() as *mut i8);
             if let Some(app) = weak_remove_contact.upgrade() {
                 app.set_contacts(slint::ModelRc::from(load_contacts_model()));
             }
@@ -1730,7 +1730,7 @@ fn main() {
                                     let _ = std::fs::copy(&entry, &dest);
                                     let c_local = CString::new(dest.to_string_lossy().to_string()).unwrap();
                                     let c_remote = CString::new(remote_name.clone()).unwrap();
-                                    let res = bindings::KD_AddFileAs(c_local.into_raw(), c_remote.into_raw());
+                                    let res = bindings::KD_AddFileAs(c_local.as_ptr() as *mut i8, c_remote.as_ptr() as *mut i8);
                                     if res != 0 {
                                         eprintln!("Failed to add: {}", remote_name);
                                     }
@@ -1745,7 +1745,7 @@ fn main() {
                                 }
                             }
                             let c_path = CString::new(path_str.clone()).unwrap();
-                            let res = bindings::KD_AddFile(c_path.into_raw());
+                            let res = bindings::KD_AddFile(c_path.as_ptr() as *mut i8);
                             if res != 0 {
                                 let err = get_last_error();
                                 eprintln!("Failed to add dropped file: {}", err);

--- a/rustbridge/main.go
+++ b/rustbridge/main.go
@@ -171,6 +171,10 @@ func KD_Initialize(relayURL *C.char, inbound, outbound C.int, toMount, toSave *C
 	if cfg.StrictMode {
 		kd.StrictMode = true
 	}
+	kd.AutoCache = cfg.LiveCollab // live_collab → macFUSE auto_cache (same-size live edits, macOS)
+	for _, warn := range cfg.Warnings() {
+		logger.Warn("config flag note", "note", warn)
+	}
 
 	if !kd.Incognito && kd.Identity != nil && kd.AddressBook != nil && kd.AddressBook.Count() > 0 {
 		go kd.StartPresenceHeartbeat(ctx)

--- a/tests/cmd/testpeer/main.go
+++ b/tests/cmd/testpeer/main.go
@@ -12,7 +12,9 @@ package main
 import (
 	"bufio"
 	"context"
+	"encoding/hex"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/url"
 	"os"
@@ -56,12 +58,18 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	// prefetchOnOpen honors KEIBIDROP_PREFETCH_ON_OPEN (default off = on-demand) so
+	// benchmarks can compare the on-demand vs push/prefetch read paths.
+	prefetchOnOpen := os.Getenv("KEIBIDROP_PREFETCH_ON_OPEN") == "1"
 	kd, err := common.NewKeibiDropWithIP(ctx, logger, useFUSE, parsed,
-		inbound, outbound, mountDir, saveDir, false, false, "::1")
+		inbound, outbound, mountDir, saveDir, prefetchOnOpen, false, "::1")
 	if err != nil {
 		fmt.Println("ERR:init failed: " + err.Error())
 		os.Exit(1)
 	}
+	// live_collab toggle: when set, enable macFUSE auto_cache so a peer's
+	// same-size in-place edit is seen live (at the cost of mmap-write integrity).
+	kd.AutoCache = os.Getenv("KEIBIDROP_LIVE_COLLAB") == "1"
 
 	go kd.Run()
 	fmt.Println("READY")
@@ -166,6 +174,29 @@ func main() {
 			} else {
 				fmt.Printf("DATA:%d:%s\n", len(data), string(data))
 			}
+
+		case "read_at":
+			// read_at <name> <offset> <size> — ReadAt on the mounted file,
+			// returns the bytes hex-encoded (binary-safe). For seek/scrub tests.
+			if len(args) < 4 {
+				fmt.Println("ERR:usage: read_at <name> <offset> <size>")
+				continue
+			}
+			off, _ := strconv.ParseInt(args[2], 10, 64)
+			sz, _ := strconv.Atoi(args[3])
+			rf, oerr := os.Open(filepath.Join(mountDir, args[1])) // #nosec G304
+			if oerr != nil {
+				fmt.Println("ERR:" + oerr.Error())
+				continue
+			}
+			rbuf := make([]byte, sz)
+			rn, rerr := rf.ReadAt(rbuf, off)
+			rf.Close()
+			if rerr != nil && rerr != io.EOF {
+				fmt.Println("ERR:" + rerr.Error())
+				continue
+			}
+			fmt.Printf("HEX:%d:%s\n", rn, hex.EncodeToString(rbuf[:rn]))
 
 		case "write_file":
 			// write_file <name> <content>

--- a/tests/harness_test.go
+++ b/tests/harness_test.go
@@ -103,17 +103,28 @@ func setupPeerPairImpl(t *testing.T, aliceFuse bool, bobFuse bool, timeout time.
 	bobInPort := getFreePortInRange(t, 26400, 26549)
 	bobOutPort := getFreePortInRange(t, 26550, 26699)
 
+	// Prefetch mode for tests. Default ON (eager) keeps the suite green; set
+	// KEIBIDROP_PREFETCH_ON_OPEN=0 to exercise pure on-demand streaming (now
+	// correct for random seeks via chunk-aligned fetch).
+	prefetchOnOpen := os.Getenv("KEIBIDROP_PREFETCH_ON_OPEN") != "0"
+	// live_collab (macFUSE auto_cache): set KEIBIDROP_LIVE_COLLAB=1 to exercise
+	// collab-mode cache coherence (same-size in-place edits seen live) and to
+	// benchmark its open-path overhead.
+	liveCollab := os.Getenv("KEIBIDROP_LIVE_COLLAB") == "1"
+
 	// Create Alice with ::1 loopback
 	kdAlice, err := common.NewKeibiDropWithIP(ctx, logger.With("peer", "alice"),
 		aliceFuse, relayURL, aliceInPort, aliceOutPort,
-		aliceMount, aliceSave, true, true, "::1")
+		aliceMount, aliceSave, prefetchOnOpen, true, "::1")
 	require.NoError(err)
+	kdAlice.AutoCache = liveCollab
 
 	// Create Bob with ::1 loopback
 	kdBob, err := common.NewKeibiDropWithIP(ctx, logger.With("peer", "bob"),
 		bobFuse, relayURL, bobInPort, bobOutPort,
-		bobMount, bobSave, true, true, "::1")
+		bobMount, bobSave, prefetchOnOpen, true, "::1")
 	require.NoError(err)
+	kdBob.AutoCache = liveCollab
 
 	// Exchange fingerprints
 	aliceFp, err := kdAlice.ExportFingerprint()
@@ -224,13 +235,7 @@ func (tp *TestPair) Teardown() {
 		if dir == "" {
 			continue
 		}
-		if runtime.GOOS == "windows" {
-			// WinFSP: use fsptool to force-unmount drive letters / directories.
-			exec.Command(`C:\Program Files (x86)\WinFsp\bin\fsptool-x64.exe`, "lsvol").Run()
-			exec.Command(`C:\Program Files (x86)\WinFsp\bin\fsptool-x64.exe`, "unmount", dir).Run()
-		} else {
-			exec.Command("/sbin/umount", "-f", dir).Run()
-		}
+		forceUnmount(dir)
 	}
 
 	// Step 5: Wait for macFUSE to fully release /dev/macfuseN devices.
@@ -243,6 +248,28 @@ func (tp *TestPair) Teardown() {
 
 	if tp.Relay != nil {
 		tp.Relay.Close()
+	}
+}
+
+// forceUnmount best-effort detaches a FUSE/WinFsp mount, cross-platform. On
+// Linux a libfuse mount must be released with fusermount(3) — /sbin/umount -f
+// (macOS) leaves the mount half-dead ("transport endpoint is not connected"),
+// which then fails t.TempDir's RemoveAll. macOS uses /sbin/umount; Windows uses
+// WinFsp's fsptool.
+func forceUnmount(dir string) {
+	switch runtime.GOOS {
+	case "windows":
+		exec.Command(`C:\Program Files (x86)\WinFsp\bin\fsptool-x64.exe`, "unmount", dir).Run() //nolint:errcheck,gosec // best-effort cleanup
+	case "linux":
+		if exec.Command("fusermount3", "-u", dir).Run() == nil { //nolint:errcheck,gosec // best-effort cleanup
+			return
+		}
+		if exec.Command("fusermount", "-u", dir).Run() == nil { //nolint:errcheck,gosec // best-effort cleanup
+			return
+		}
+		exec.Command("/sbin/umount", "-f", dir).Run() //nolint:errcheck,gosec // best-effort cleanup
+	default: // darwin and others
+		exec.Command("/sbin/umount", "-f", dir).Run() //nolint:errcheck,gosec // best-effort cleanup
 	}
 }
 

--- a/tests/integration_fuse_cp_test.go
+++ b/tests/integration_fuse_cp_test.go
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2026 KeibiSoft S.R.L.
+
+//go:build !windows
+
+// This cp/dd throughput test uses syscall.Stat_t (st_blksize) and the cp/dd
+// CLIs, so it is Unix-only (macOS + Linux). The Windows equivalent would use
+// Copy-Item and is left for the Windows device run.
+
+package tests
+
+import (
+	"crypto/rand"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// blksizeOf returns the st_blksize the kernel reports for path (what cp/dd use
+// to size their I/O buffer). This is the value the FUSE Getattr returns.
+func blksizeOf(t *testing.T, path string) int64 {
+	t.Helper()
+	fi, err := os.Stat(path)
+	require.NoError(t, err)
+	st, ok := fi.Sys().(*syscall.Stat_t)
+	require.Truef(t, ok, "Sys() not *syscall.Stat_t")
+	return int64(st.Blksize)
+}
+
+// shareRemote makes Bob share a fresh size-byte random file named `name`, waits
+// until it appears in Alice's mount, and returns the path inside Alice's mount.
+func shareRemote(t *testing.T, p *fusePeerPair, name string, size int) string {
+	t.Helper()
+	data := make([]byte, size)
+	_, err := rand.Read(data)
+	require.NoError(t, err)
+	bobPath := filepath.Join(p.bobSave, name)
+	require.NoError(t, os.WriteFile(bobPath, data, 0644))
+	require.Equal(t, "OK", p.bob.send(t, "add "+bobPath, 15*time.Second))
+	require.Equal(t, "OK", p.alice.send(t, "wait_file "+name+" 30", 35*time.Second))
+	return filepath.Join(p.aliceMount, name)
+}
+
+// TestFUSELocalCp1GB isolates the pure FUSE layer (NO peer streaming): cp a 1 GB
+// file from outside the mount INTO it (write), then from inside the mount back
+// OUT (read of a file that is LOCAL to this peer, served by the local fast path).
+// This separates FUSE+blksize overhead from the peer-to-peer stream/fetch path.
+func TestFUSELocalCp1GB(t *testing.T) {
+	p := connectFUSEPeers(t, false)
+	req := require.New(t)
+	const sz = 1024 * 1024 * 1024 // 1 GiB
+
+	// urandom source (NOT zeros) so cp can't sparse-optimize and report bogus speed.
+	src := filepath.Join(t.TempDir(), "src1gb.bin")
+	ddOut, ddErr := exec.Command("dd", "if=/dev/urandom", "of="+src, "bs=1M", "count=1024").CombinedOutput()
+	req.NoErrorf(ddErr, "dd create src: %s", ddOut)
+
+	// cp from OUTSIDE the mount INTO the mount (write path).
+	inDst := filepath.Join(p.aliceMount, "local1gb.bin")
+	start := time.Now()
+	out, err := exec.Command("cp", src, inDst).CombinedOutput()
+	inDur := time.Since(start)
+	req.NoErrorf(err, "cp into mount: %s", out)
+	fi, statErr := os.Stat(inDst)
+	req.NoError(statErr)
+	req.Equal(int64(sz), fi.Size(), "cp into mount wrong size")
+	t.Logf("LOCAL cp 1GB  OUTSIDE -> INSIDE mount (write): %6.1f MB/s  (%.2fs)",
+		float64(sz)/1e6/inDur.Seconds(), inDur.Seconds())
+
+	// cp from INSIDE the mount back OUTSIDE (read of a local file — no streaming).
+	outDst := filepath.Join(t.TempDir(), "out1gb.bin")
+	start = time.Now()
+	out, err = exec.Command("cp", inDst, outDst).CombinedOutput()
+	outDur := time.Since(start)
+	req.NoErrorf(err, "cp out of mount: %s", out)
+	fi, statErr = os.Stat(outDst)
+	req.NoError(statErr)
+	req.Equal(int64(sz), fi.Size(), "cp out of mount wrong size")
+	t.Logf("LOCAL cp 1GB  INSIDE -> OUTSIDE mount (read):  %6.1f MB/s  (%.2fs)",
+		float64(sz)/1e6/outDur.Seconds(), outDur.Seconds())
+}
+
+// TestFUSECpThroughput measures REAL `cp`/`dd` throughput against the FUSE mount
+// — the user-visible "copy a file to/from the mount" case. Unlike the in-test
+// benchmarks (fixed Go read buffer), cp/dd size their buffer from st_blksize, so
+// this is the test that proves the Linux st_blksize fix (report our 256 KiB
+// FilesystemBlockSize, not ext4's 4 KiB) actually makes transfers fast.
+func TestFUSECpThroughput(t *testing.T) {
+	p := connectFUSEPeers(t, false) // on-demand (prefetch off): real peer streaming
+	req := require.New(t)
+
+	// Headline: cp a large remote file FROM the mount (peer -> FUSE on-demand read).
+	const big = 128 * 1024 * 1024
+	mountFile := shareRemote(t, p, "read_big.bin", big)
+	bs := blksizeOf(t, mountFile)
+	t.Logf("st_blksize reported by mount = %d bytes (expect our FilesystemBlockSize, not 4096)", bs)
+
+	readOut := filepath.Join(t.TempDir(), "read_out.bin")
+	start := time.Now()
+	out, err := exec.Command("cp", mountFile, readOut).CombinedOutput()
+	dur := time.Since(start)
+	req.NoErrorf(err, "cp from mount failed: %s", out)
+	fi, statErr := os.Stat(readOut)
+	req.NoError(statErr)
+	req.Equal(int64(big), fi.Size(), "cp produced wrong size")
+	t.Logf("cp FROM mount (read, peer->FUSE on-demand): %6.1f MB/s  (%.2fs, %d MB)",
+		float64(big)/1e6/dur.Seconds(), dur.Seconds(), big/(1024*1024))
+
+	// cp a large file INTO the mount (write path the user described).
+	writeSrc := filepath.Join(t.TempDir(), "write_src.bin")
+	srcData := make([]byte, big)
+	_, _ = rand.Read(srcData)
+	req.NoError(os.WriteFile(writeSrc, srcData, 0644))
+	writeDst := filepath.Join(p.aliceMount, "write_big.bin")
+	start = time.Now()
+	out, err = exec.Command("cp", writeSrc, writeDst).CombinedOutput()
+	dur = time.Since(start)
+	req.NoErrorf(err, "cp into mount failed: %s", out)
+	t.Logf("cp INTO mount (write):                       %6.1f MB/s  (%.2fs, %d MB)",
+		float64(big)/1e6/dur.Seconds(), dur.Seconds(), big/(1024*1024))
+
+	// Block-size sensitivity: dd a fresh (uncached) remote file at each bs. Small
+	// bs = a FUSE round trip per tiny read; this is what crawls on Linux when
+	// st_blksize is tiny. Each file is read once (first read = real streaming).
+	const small = 16 * 1024 * 1024
+	for _, blk := range []string{"4k", "64k", "256k", "1M"} {
+		f := shareRemote(t, p, fmt.Sprintf("dd_%s.bin", blk), small)
+		start = time.Now()
+		out, err = exec.Command("dd", "if="+f, "of=/dev/null", "bs="+blk).CombinedOutput()
+		dur = time.Since(start)
+		req.NoErrorf(err, "dd bs=%s failed: %s", blk, out)
+		t.Logf("dd bs=%-4s FROM mount:                        %6.1f MB/s  (%.2fs)",
+			blk, float64(small)/1e6/dur.Seconds(), dur.Seconds())
+	}
+}

--- a/tests/integration_fuse_fuse_test.go
+++ b/tests/integration_fuse_fuse_test.go
@@ -136,7 +136,16 @@ func getTestPeerBinary(t *testing.T) string {
 		if runtime.GOOS == "windows" {
 			binName = "testpeer.exe"
 		}
-		binPath := filepath.Join(t.TempDir(), binName)
+		// Build into a package-lifetime temp dir, NOT t.TempDir(): the Once
+		// caches this path for the whole run, but t.TempDir() is deleted when
+		// the first calling test ends, leaving later spawn-based tests with a
+		// missing binary ("fork/exec ...: no such file or directory").
+		tmpDir, mkErr := os.MkdirTemp("", "kd-testpeer")
+		if mkErr != nil {
+			testPeerBuildError = mkErr
+			return
+		}
+		binPath := filepath.Join(tmpDir, binName)
 		cmd := exec.Command("go", "build", "-o", binPath, "./tests/cmd/testpeer/") //#nosec G204
 		// Use the project root as working directory
 		// Find project root by looking for go.mod
@@ -187,10 +196,14 @@ func spawnPeer(t *testing.T, binary string, env map[string]string) *testPeer {
 
 	require.NoError(t, cmd.Start())
 
+	scanner := bufio.NewScanner(stdoutPipe)
+	// Allow large response lines (e.g. hex-encoded read_at blocks) — the
+	// default 64 KiB token limit is too small for multi-KiB reads.
+	scanner.Buffer(make([]byte, 64*1024), 8*1024*1024)
 	peer := &testPeer{
 		cmd:    cmd,
 		stdin:  stdin,
-		stdout: bufio.NewScanner(stdoutPipe),
+		stdout: scanner,
 	}
 
 	// Wait for READY

--- a/tests/integration_fuse_git_test.go
+++ b/tests/integration_fuse_git_test.go
@@ -5,7 +5,6 @@ package tests
 
 import (
 	"fmt"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -71,7 +70,7 @@ func TestFUSEtoFUSE_GitClone(t *testing.T) {
 			}
 		}
 		for _, dir := range []string{aliceMount, bobMount} {
-			exec.Command("/sbin/umount", "-f", dir).Run()
+			forceUnmount(dir)
 			waitForUnmount(dir, 5*time.Second)
 		}
 	})

--- a/tests/integration_fuse_stream_test.go
+++ b/tests/integration_fuse_stream_test.go
@@ -1,0 +1,253 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2026 KeibiSoft S.R.L.
+
+package tests
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"math/big"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// fusePeerPair is two connected, FUSE-mounted testpeer subprocesses (separate
+// processes — the only way to run two FUSE mounts, since cgofuse allows one
+// mount per process).
+type fusePeerPair struct {
+	alice, bob           *testPeer
+	aliceMount, bobMount string
+	aliceSave, bobSave   string
+}
+
+// connectFUSEPeers spawns Alice + Bob as FUSE testpeers, exchanges fingerprints,
+// connects them, and waits for both mounts. Cleanup is registered on t.
+// The peers run on-demand (testpeer sets prefetchOnOpen=false), so these tests
+// exercise the pure streaming path.
+// connectFUSEPeers connects two FUSE peers. liveCollab toggles the live_collab
+// mode (macFUSE auto_cache) so the peers reflect a same-size in-place edit live;
+// leave it false for the git-safe default (and for streaming/git tests).
+func connectFUSEPeers(t *testing.T, liveCollab bool) *fusePeerPair {
+	t.Helper()
+	skipIfNoFUSE(t)
+	binary := getTestPeerBinary(t)
+
+	// Logs go to t.TempDir() (auto-cleaned) unless KD_TEST_LOGDIR is set, which
+	// lets a debugging run capture peer logs to a persistent location.
+	logDir := os.Getenv("KD_TEST_LOGDIR")
+	if logDir == "" {
+		logDir = t.TempDir()
+	}
+
+	liveCollabEnv := "0"
+	if liveCollab {
+		liveCollabEnv = "1"
+	}
+
+	relay := NewMockRelay()
+	t.Cleanup(relay.Close)
+
+	p := &fusePeerPair{
+		aliceMount: t.TempDir(), aliceSave: t.TempDir(),
+		bobMount: t.TempDir(), bobSave: t.TempDir(),
+	}
+	aliceIn := getFreePortInRange(t, 26700, 26749)
+	aliceOut := getFreePortInRange(t, 26750, 26799)
+	bobIn := getFreePortInRange(t, 26800, 26849)
+	bobOut := getFreePortInRange(t, 26850, 26899)
+
+	p.alice = spawnPeer(t, binary, map[string]string{
+		"RELAY_URL": relay.URL(), "INBOUND_PORT": fmt.Sprintf("%d", aliceIn),
+		"OUTBOUND_PORT": fmt.Sprintf("%d", aliceOut), "MOUNT_DIR": p.aliceMount,
+		"SAVE_DIR": p.aliceSave, "USE_FUSE": "1",
+		"LOG_FILE": filepath.Join(logDir, "alice.log"), "KEIBIDROP_LIVE_COLLAB": liveCollabEnv,
+	})
+	p.bob = spawnPeer(t, binary, map[string]string{
+		"RELAY_URL": relay.URL(), "INBOUND_PORT": fmt.Sprintf("%d", bobIn),
+		"OUTBOUND_PORT": fmt.Sprintf("%d", bobOut), "MOUNT_DIR": p.bobMount,
+		"SAVE_DIR": p.bobSave, "USE_FUSE": "1",
+		"LOG_FILE": filepath.Join(logDir, "bob.log"), "KEIBIDROP_LIVE_COLLAB": liveCollabEnv,
+	})
+
+	t.Cleanup(func() {
+		for _, pr := range []*testPeer{p.alice, p.bob} {
+			fmt.Fprintln(pr.stdin, "quit")
+			done := make(chan error, 1)
+			go func() { done <- pr.cmd.Wait() }()
+			select {
+			case <-done:
+			case <-time.After(5 * time.Second):
+				_ = pr.cmd.Process.Kill()
+				<-done
+			}
+		}
+		for _, dir := range []string{p.aliceMount, p.bobMount} {
+			forceUnmount(dir)
+			waitForUnmount(dir, 5*time.Second)
+		}
+	})
+
+	req := require.New(t)
+	aliceFP := strings.TrimPrefix(p.alice.send(t, "fingerprint", 5*time.Second), "FP:")
+	bobFP := strings.TrimPrefix(p.bob.send(t, "fingerprint", 5*time.Second), "FP:")
+	req.Equal("OK", p.alice.send(t, "register "+bobFP, 5*time.Second))
+	req.Equal("OK", p.bob.send(t, "register "+aliceFP, 5*time.Second))
+
+	aliceConn := p.alice.sendAsync(t, "create")
+	WaitForCondition(t, 10*time.Second, 100*time.Millisecond, func() bool {
+		return relay.EntryCount() > 0
+	}, "relay registration")
+	req.Equal("CONNECTED", p.bob.send(t, "join", 30*time.Second), "Bob join")
+	req.Equal("CONNECTED", <-aliceConn, "Alice create")
+
+	waitForFUSEMount(t, p.aliceMount, 15*time.Second)
+	waitForFUSEMount(t, p.bobMount, 15*time.Second)
+	return p
+}
+
+// readAt asks a peer for size bytes at offset from a mounted file and returns
+// the decoded bytes (via the testpeer `read_at` command, hex over the wire).
+func (p *testPeer) readAt(t *testing.T, name string, offset int64, size int) []byte {
+	t.Helper()
+	resp := p.send(t, fmt.Sprintf("read_at %s %d %d", name, offset, size), 30*time.Second)
+	require.Truef(t, strings.HasPrefix(resp, "HEX:"), "read_at %s@%d: %s", name, offset, resp)
+	parts := strings.SplitN(strings.TrimPrefix(resp, "HEX:"), ":", 2)
+	require.Len(t, parts, 2, "malformed read_at response: %s", resp)
+	b, err := hex.DecodeString(parts[1])
+	require.NoError(t, err)
+	return b
+}
+
+// TestFUSEtoFUSE_StreamSeek is the "Netflix" integrity test: B shares a large
+// binary, A opens it over FUSE and reads at random offsets (trailer first, like
+// a media player reading the moov atom, then header, then random scrubs) — all
+// served on-demand. Every read must return the exact bytes. This is the case
+// that returned sparse-hole zeros before the chunk-aligned-fetch fix.
+func TestFUSEtoFUSE_StreamSeek(t *testing.T) {
+	p := connectFUSEPeers(t, false)
+	req := require.New(t)
+
+	// 8 MiB of known random data = 16 chunks of 512 KiB.
+	const fileSize = 8 * 1024 * 1024
+	data := make([]byte, fileSize)
+	_, err := rand.Read(data)
+	req.NoError(err)
+
+	bobPath := filepath.Join(p.bobSave, "movie.bin")
+	req.NoError(os.WriteFile(bobPath, data, 0644))
+	req.Equal("OK", p.bob.send(t, "add "+bobPath, 10*time.Second))
+
+	req.Equal("OK", p.alice.send(t, "wait_file movie.bin 15", 20*time.Second))
+
+	check := func(offset int64, size int) {
+		got := p.alice.readAt(t, "movie.bin", offset, size)
+		req.Lenf(got, size, "short read at %d", offset)
+		req.Equalf(data[offset:offset+int64(size)], got, "byte mismatch at offset %d (size %d)", offset, size)
+	}
+
+	// Trailer first (moov atom), then header, then random scrubs.
+	check(fileSize-13*1024, 13*1024)
+	check(0, 4096)
+	for i := 0; i < 8; i++ {
+		size := 8192
+		offset := randInt64(t, int64(fileSize-size))
+		check(offset, size)
+	}
+
+	// Sanity: read the whole file in 256 KiB pieces and confirm every byte
+	// matches. Compare per-piece so a failure pinpoints the offset and nature:
+	// allZeros => cache/short-read served a hole; valid-but-wrong => the stream
+	// returned another offset's bytes (routing/desync).
+	const piece = 256 * 1024
+	for off := int64(0); off < fileSize; off += piece {
+		sz := piece
+		if off+int64(sz) > fileSize {
+			sz = int(int64(fileSize) - off)
+		}
+		got := p.alice.readAt(t, "movie.bin", off, sz)
+		want := data[off : off+int64(sz)]
+		if !bytes.Equal(got, want) {
+			d := 0
+			for d < len(got) && d < len(want) && got[d] == want[d] {
+				d++
+			}
+			zeros := true
+			for _, b := range got {
+				if b != 0 {
+					zeros = false
+					break
+				}
+			}
+			we := want[d:min(d+16, len(want))]
+			var ge []byte
+			if d < len(got) {
+				ge = got[d:min(d+16, len(got))]
+			}
+			t.Fatalf("full read mismatch piece off=%d sz=%d gotLen=%d: firstDiff=+%d allZeros=%v want=%x got=%x", off, sz, len(got), d, zeros, we, ge)
+		}
+	}
+}
+
+// TestFUSEtoFUSE_LiveCollab is the real-time collaboration integrity test:
+// A writes a file on her mount, B reads it live; then A edits it and B sees the
+// updated content on the next read — no remount, no full re-download. This is
+// the grand-goal "edit together, get updates in real time" path over on-demand.
+func TestFUSEtoFUSE_LiveCollab(t *testing.T) {
+	// The third write ("third-revision-here") is the same byte length as the
+	// second ("version-two-updated"): a same-size in-place edit. That path is
+	// handled by the mtime-newer cache reset in AddRemoteFile/EditRemoteFile —
+	// without it a peer that already fully cached the file keeps stale content.
+	// This test runs in live_collab mode (macFUSE auto_cache) so the same-size
+	// edit below is reflected live; in the default git-safe mode macFUSE would
+	// keep the stale page cache for a same-size change (documented tradeoff).
+	p := connectFUSEPeers(t, true)
+	req := require.New(t)
+
+	// A creates the file.
+	req.Equal("OK", p.alice.send(t, "write_file collab.txt version-one", 10*time.Second))
+	req.Equal("OK", p.bob.send(t, "wait_file collab.txt 15", 20*time.Second))
+	waitForContent(t, p.bob, "collab.txt", "version-one", 15*time.Second)
+
+	// A edits it — B must see the new content live.
+	req.Equal("OK", p.alice.send(t, "write_file collab.txt version-two-updated", 10*time.Second))
+	waitForContent(t, p.bob, "collab.txt", "version-two-updated", 40*time.Second)
+
+	// And once more, to confirm repeated live edits keep syncing.
+	req.Equal("OK", p.alice.send(t, "write_file collab.txt third-revision-here", 10*time.Second))
+	waitForContent(t, p.bob, "collab.txt", "third-revision-here", 60*time.Second)
+}
+
+// waitForContent polls a peer reading name off its mount until it equals want.
+func waitForContent(t *testing.T, p *testPeer, name, want string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var last string
+	for time.Now().Before(deadline) {
+		resp := p.send(t, "read_file "+name, 10*time.Second)
+		if strings.HasPrefix(resp, "DATA:") {
+			parts := strings.SplitN(strings.TrimPrefix(resp, "DATA:"), ":", 2)
+			if len(parts) == 2 {
+				last = parts[1]
+				if last == want {
+					return
+				}
+			}
+		}
+		time.Sleep(300 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s to become %q (last read: %q)", name, want, last)
+}
+
+func randInt64(t *testing.T, max int64) int64 {
+	t.Helper()
+	n, err := rand.Int(rand.Reader, big.NewInt(max))
+	require.NoError(t, err)
+	return n.Int64()
+}

--- a/tests/integration_resume_test.go
+++ b/tests/integration_resume_test.go
@@ -155,8 +155,10 @@ func TestNoFUSE_ResumeAfterDisconnect(t *testing.T) {
 	tp := SetupPeerPairWithTimeout(t, false, 60*time.Second)
 	require := require.New(t)
 
-	// 50 MB file.
-	size := 50 * 1024 * 1024
+	// 100 MB file — big enough to reliably catch mid-transfer on loopback. With a
+	// small file the download can finish before we cancel, silently turning the
+	// resume path into a no-op (the test would pass while testing nothing).
+	size := 100 * 1024 * 1024
 	data := make([]byte, size)
 	rand.Read(data)
 	originalMD5 := md5.Sum(data)
@@ -168,35 +170,45 @@ func TestNoFUSE_ResumeAfterDisconnect(t *testing.T) {
 
 	WaitForRemoteFile(t, tp.Bob.SyncTracker, name, 5*time.Second)
 
-	// Cancel mid-download to simulate partial state.
 	pullDest := filepath.Join(tp.BobSaveDir, name)
 	errCh := make(chan error, 1)
 	go func() {
 		errCh <- tp.Bob.PullFile(name, pullDest)
 	}()
 
-	time.Sleep(30 * time.Millisecond)
-	_ = tp.Bob.CancelDownload(name)
-	pullErr := <-errCh
-
-	if pullErr == nil {
-		// Completed too fast. Still verify correctness.
-		pulled, err := os.ReadFile(pullDest)
-		require.NoError(err)
-		require.Equal(originalMD5, md5.Sum(pulled))
-		t.Log("Download completed before cancel, skipping resume test")
-		return
+	// Cancel DETERMINISTICALLY at a partial point: poll live progress and cancel
+	// once we are provably mid-download (5%–60%). A fixed sleep races the transfer
+	// and can finish first on a fast link, making "resume" a silent no-op.
+	var partial float64
+	deadline := time.Now().Add(20 * time.Second)
+	for time.Now().Before(deadline) && partial == 0 {
+		select {
+		case pullErr := <-errCh:
+			require.NoError(pullErr)
+			t.Fatal("download completed before a partial state could be observed — increase file size")
+		default:
+		}
+		if p := tp.Bob.GetDownloadProgress(name); p > 0.05 && p < 0.6 {
+			partial = p
+		} else {
+			time.Sleep(time.Millisecond)
+		}
 	}
+	require.Greater(partial, 0.0, "never observed an in-flight partial download")
+	_ = tp.Bob.CancelDownload(name)
+	require.Error(<-errCh, "PullFile must return an error after a mid-flight cancel")
 
-	// Verify partial state exists.
+	// Verify the on-disk state is GENUINELY partial (not zero, not complete) —
+	// this is what resume relies on.
 	bmPath := filesystem.BitmapPath(pullDest)
 	require.FileExists(pullDest)
 	require.FileExists(bmPath)
 
 	bm, err := filesystem.LoadChunkBitmap(bmPath, int64(size))
 	require.NoError(err)
-	partialProgress := bm.Progress()
-	t.Logf("Partial download at %.1f%%", partialProgress*100)
+	require.True(bm.Have() > 0 && !bm.IsComplete(),
+		"bitmap must be genuinely partial, got %d/%d chunks", bm.Have(), bm.Total())
+	t.Logf("Cancelled at %.1f%% (%d/%d chunks) — now resuming", bm.Progress()*100, bm.Have(), bm.Total())
 
 	// Resume download (same PullFile call, bitmap on disk enables resume).
 	require.NoError(tp.Bob.PullFile(name, pullDest))


### PR DESCRIPTION
## Summary
- Fix test panic in TestPrefetchRenameRace (#160)
- Fix data race on activeDownloads/activeBitmaps during reconnect (#161)
- Fix CString memory leak at 18 FFI call sites (#162)
- Fix invisible files in UI when FUSE-mode ADD_FILE/EDIT_FILE skips SyncTracker (#164)

## Not addressed
- FUSE toggle/unmount (#166, filed separately)

## Test plan
- TestPrefetchRenameRace passes with -race
- TestReconnectReset_NoRaceOnActiveDownloads passes with -race -count=5
- TestAddFile_FuseMode_WritesSyncTracker passes
- TestEditFile_FuseMode_UpdatesSyncTracker passes
- TestEditFile_FuseMode_CreatesNewSyncTrackerEntry passes
- cargo build succeeds, grep -c into_raw = 1 (only Icon)
- Full go test -race passes

Closes #160, #161, #162, #164