### PR TITLE
fix(kd): tiebreak local connect on the advertised discovery name

### DIFF
--- a/cmd/kd/main.go
+++ b/cmd/kd/main.go
@@ -300,10 +300,17 @@ func dispatch(kd *common.KeibiDrop, req Request, cancel context.CancelFunc, ln n
 		if err := kd.SetPeerDirectAddress(peerAddr); err != nil {
 			return errResponse(err.Error())
 		}
+		// Tiebreak on the name we actually advertise (daemonDisc), not a throwaway discovery
+		// instance — otherwise the role tiebreak runs on a name the peer never saw, so both sides
+		// can pick the same role and deadlock (the desktop analog of the mobile reconnect bug).
 		myName := ""
-		disc := discovery.New(kd.InboundPort(), slog.Default())
-		myName = disc.Name()
-		disc.Stop()
+		if daemonDisc != nil {
+			myName = daemonDisc.Name()
+		} else {
+			disc := discovery.New(kd.InboundPort(), slog.Default())
+			myName = disc.Name()
+			disc.Stop()
+		}
 		if myName < peerName {
 			return cmdCreateOrJoin(kd, "create")
 		}


### PR DESCRIPTION
`connect-lan` tiebreaks the creator/joiner role on a name from a throwaway `discovery.New()` instance — a fresh random name, **not** `daemonDisc.Name()` (the name the peer actually sees in discovery). The two sides then compare different names, can pick the same role, and local-mode connect deadlocks.

Fix: tiebreak on the live `daemonDisc` name when discovery is active (fall back to the old behavior only when it isn't). Desktop analog of the mobile local-mode reconnect fix (KeibiDropMobile #30).

Verified: `go build ./cmd/kd`, `go vet ./cmd/kd`, `go test ./cmd/kd/...` all green.