### PR TITLE
Add adaptive pre-fetch + on-demand strategy based on file size

### DIFF
--- a/cmd/cli/keibidrop-cli.go
+++ b/cmd/cli/keibidrop-cli.go
@@ -756,6 +756,7 @@ func main() {
 		os.Exit(1) //nolint:gocritic
 	}
 	kd.AutoCache = cfg.LiveCollab // live_collab → macFUSE auto_cache (same-size live edits, macOS)
+	kd.PrefetchAutoMB = cfg.PrefetchAutoMB
 	for _, warn := range cfg.Warnings() {
 		logger.Warn("config flag note", "note", warn)
 	}

--- a/cmd/kd/main.go
+++ b/cmd/kd/main.go
@@ -154,6 +154,7 @@ func runDaemon() {
 	kd.BridgeAddr = cfg.BridgeAddr
 	kd.StrictMode = cfg.StrictMode
 	kd.AutoCache = cfg.LiveCollab // live_collab → macFUSE auto_cache (same-size live edits, macOS)
+	kd.PrefetchAutoMB = cfg.PrefetchAutoMB
 	for _, warn := range cfg.Warnings() {
 		logger.Warn("config flag note", "note", warn)
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,6 +31,7 @@ type Config struct {
 	NoFUSE            bool   `toml:"no_fuse"`
 	Incognito         bool   `toml:"incognito"`
 	PrefetchOnOpen    bool   `toml:"prefetch_on_open"`
+	PrefetchAutoMB    int    `toml:"prefetch_auto_mb"` // auto-prefetch files >= this many MB (sequential fill + on-demand jumps); 0 disables (pure on-demand). Default 100. prefetch_on_open=true forces prefetch for any size.
 	PushOnWrite       bool   `toml:"push_on_write"`
 	LiveCollab        bool   `toml:"live_collab"`        // prioritize seeing peers' same-size in-place edits live (macFUSE auto_cache); trades off local mmap-write integrity (git). See note in template.
 	PassphraseProtect bool   `toml:"passphrase_protect"` // opt into Tier 2 (Argon2id passphrase) for identity at-rest encryption
@@ -43,12 +44,13 @@ const DefaultBridge = "bridge.keibisoft.com:26600"
 func DefaultConfig() Config {
 	home, _ := os.UserHomeDir()
 	cfg := Config{
-		Relay:        DefaultRelay,
-		SavePath:     filepath.Join(home, "KeibiDrop", "Received"),
-		MountPath:    filepath.Join(home, "KeibiDrop", "Mount"),
-		InboundPort:  InboundPort,
-		OutboundPort: OutboundPort,
-		BridgeAddr:   DefaultBridge,
+		Relay:          DefaultRelay,
+		SavePath:       filepath.Join(home, "KeibiDrop", "Received"),
+		MountPath:      filepath.Join(home, "KeibiDrop", "Mount"),
+		InboundPort:    InboundPort,
+		OutboundPort:   OutboundPort,
+		BridgeAddr:     DefaultBridge,
+		PrefetchAutoMB: 100, // files >= 100MB auto-prefetch (sequential fill + on-demand jumps); smaller stay pure on-demand
 	}
 	switch runtime.GOOS {
 	case "darwin":
@@ -218,12 +220,13 @@ strict_mode = %v
 # Set to true to force ephemeral keys every session (no persistent identity).
 incognito = %v
 
-# FUSE download strategy. false (default, recommended) = on-demand: stream bytes
-# as they are read, so large files open and seek instantly and only what is read
-# is downloaded. true = prefetch-on-open: download the whole file in the
-# background when it is opened (good for offline use / smooth sequential
-# playback, but downloads everything). Persisted here so the choice survives
-# restarts.
+# FUSE download strategy (persisted so the choice survives restarts).
+# prefetch_auto_mb: files >= this many MB are prefetched on open — sequential fill
+#   at wire speed PLUS on-demand jumps so a seek into a not-yet-downloaded region
+#   never lags. Smaller files stay pure on-demand (instant open, fetch only what's
+#   read). 0 disables auto-prefetch. Default 100.
+# prefetch_on_open: force prefetch for ANY size (overrides prefetch_auto_mb).
+prefetch_auto_mb = %v
 prefetch_on_open = %v
 
 # Prioritize live collaboration over local mmap-write integrity (default false).
@@ -235,7 +238,7 @@ prefetch_on_open = %v
 live_collab = %v
 `, cfg.Relay, cfg.SavePath, cfg.MountPath, cfg.LogFile,
 		cfg.InboundPort, cfg.OutboundPort, cfg.BridgeAddr,
-		cfg.NoFUSE, cfg.StrictMode, cfg.Incognito, cfg.PrefetchOnOpen, cfg.LiveCollab)
+		cfg.NoFUSE, cfg.StrictMode, cfg.Incognito, cfg.PrefetchAutoMB, cfg.PrefetchOnOpen, cfg.LiveCollab)
 
 	return os.WriteFile(path, []byte(content), 0600) // #nosec G306
 }
@@ -280,6 +283,11 @@ func applyEnvOverrides(cfg *Config) {
 	}
 	if b, ok := envBool("KEIBIDROP_PREFETCH_ON_OPEN", "PREFETCH_ON_OPEN_ENV"); ok {
 		cfg.PrefetchOnOpen = b
+	}
+	if v := envFirst("KEIBIDROP_PREFETCH_AUTO_MB", "PREFETCH_AUTO_MB_ENV"); v != "" {
+		if mb, err := strconv.Atoi(v); err == nil {
+			cfg.PrefetchAutoMB = mb
+		}
 	}
 	if b, ok := envBool("KEIBIDROP_PUSH_ON_WRITE", "PUSH_ON_WRITE_ENV"); ok {
 		cfg.PushOnWrite = b

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -50,20 +50,24 @@ func TestApplyEnvOverrides_DefaultsNotSet(t *testing.T) {
 func TestSaveLoad_PrefetchOnOpenPersists(t *testing.T) {
 	t.Setenv("KEIBIDROP_CONFIG_DIR", t.TempDir())
 
-	// Default must be on-demand (prefetch off) — the recommended default.
+	// Defaults: on-demand (prefetch off) + auto-prefetch threshold 100MB.
 	if DefaultConfig().PrefetchOnOpen {
 		t.Fatal("default PrefetchOnOpen should be false (on-demand)")
 	}
+	if DefaultConfig().PrefetchAutoMB != 100 {
+		t.Fatalf("default PrefetchAutoMB should be 100, got %d", DefaultConfig().PrefetchAutoMB)
+	}
 
-	// Persist both FUSE toggles ON.
+	// Persist the FUSE toggles + a custom auto threshold.
 	cfg := DefaultConfig()
 	cfg.PrefetchOnOpen = true
 	cfg.LiveCollab = true
+	cfg.PrefetchAutoMB = 250
 	if err := Save(cfg); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
 
-	// A fresh Load must observe both (proves Save actually wrote them).
+	// A fresh Load must observe all three (proves Save actually wrote them).
 	got, err := Load()
 	if err != nil {
 		t.Fatalf("Load: %v", err)
@@ -73,5 +77,8 @@ func TestSaveLoad_PrefetchOnOpenPersists(t *testing.T) {
 	}
 	if !got.LiveCollab {
 		t.Error("live_collab did not persist across Save/Load")
+	}
+	if got.PrefetchAutoMB != 250 {
+		t.Errorf("prefetch_auto_mb did not persist: got %d want 250", got.PrefetchAutoMB)
 	}
 }

--- a/pkg/filesystem/api.go
+++ b/pkg/filesystem/api.go
@@ -31,6 +31,7 @@ type FS struct {
 
 	// Collab sync options (set from env before Mount).
 	PrefetchOnOpen bool // If true, fetch entire file on Open() and write to local disk.
+	PrefetchAutoMB int  // files >= this many MB auto-prefetch on open (0=off; PrefetchOnOpen forces any size)
 	PushOnWrite    bool // If true, async push deltas to peer on Write().
 	AutoCache      bool // If true (live_collab), add the macFUSE auto_cache mount option so a peer's same-size in-place edit is seen live. Trades off mmap-write integrity (git) on macOS; no-op on Linux/Windows.
 
@@ -125,6 +126,7 @@ func (fs *FS) Mount(mountPoint string, isSecond bool, downloadPath string) error
 		OpenStreamProvider: fs.OpenStreamProvider,
 
 		PrefetchOnOpen: fs.PrefetchOnOpen,
+		PrefetchAutoMB: fs.PrefetchAutoMB,
 		PushOnWrite:    fs.PushOnWrite,
 
 		FsCtx: fs.ctx,

--- a/pkg/filesystem/fs_android.go
+++ b/pkg/filesystem/fs_android.go
@@ -23,6 +23,7 @@ type FS struct {
 	OnLocalChange      func(event types.FileEvent)
 	OpenStreamProvider func() types.FileStreamProvider
 	PrefetchOnOpen     bool
+	PrefetchAutoMB     int
 	PushOnWrite        bool
 	AutoCache          bool // Unused on Android (no FUSE); present so shared setup code compiles.
 }

--- a/pkg/filesystem/fuse_directory.go
+++ b/pkg/filesystem/fuse_directory.go
@@ -258,6 +258,21 @@ func (d *Dir) Create(path string, flags int, mode uint32) (errCode int, retFh ui
 	return errc, fi.Fh
 }
 
+// shouldPrefetchOnOpen decides whether to background-prefetch a file of the given
+// size on Open: forced when prefetchOnOpen is set, otherwise auto for files
+// >= autoMB megabytes (autoMB <= 0 disables auto). Smaller files stay pure
+// on-demand (instant open, fetch only what's read). Prefetch always cooperates
+// with on-demand jumps, so a seek into a not-yet-filled region never lags.
+func shouldPrefetchOnOpen(prefetchOnOpen bool, autoMB int, size uint64) bool {
+	if prefetchOnOpen {
+		return true
+	}
+	if autoMB <= 0 {
+		return false
+	}
+	return size >= uint64(autoMB)*1024*1024
+}
+
 // shouldUseDirectIo determines if a file should bypass kernel page cache.
 // Returns true for files that need real-time sync (write access, not in .git/).
 // Returns false for .git/ files (to allow mmap for git operations).
@@ -691,11 +706,14 @@ func (d *Dir) OpenEx(path string, fi *winfuse.FileInfo_t) (errCode int) {
 	d.OpenMapLock.Unlock()
 	d.AfmLock.Unlock()
 
-	// Prefetch-on-open (Netflix-style): when enabled, fill the rest of the file
-	// in the background while on-demand reads serve immediate seeks. The two
-	// cooperate via the chunk bitmap (prefetch skips chunks reads already got).
-	// Guarded so a second handle on the same file doesn't start a duplicate.
-	if remoteHasUpdate && d.PrefetchOnOpen && fh.PrefetchCancel == nil {
+	// Prefetch-on-open (Netflix-style): fill the rest of the file in the background
+	// while on-demand reads serve immediate seeks; the two cooperate via the chunk
+	// bitmap (prefetch skips chunks reads already got). Strategy: force when
+	// PrefetchOnOpen, otherwise auto for files >= PrefetchAutoMB — large files get
+	// wire-speed sequential fill + lag-free jumps, while small files stay pure
+	// on-demand (instant open, fetch only what's read). Guarded so a second handle
+	// on the same file doesn't start a duplicate.
+	if remoteHasUpdate && shouldPrefetchOnOpen(d.PrefetchOnOpen, d.PrefetchAutoMB, remoteTotalSize) && fh.PrefetchCancel == nil {
 		d.startPrefetch(logger, fh, path)
 	}
 

--- a/pkg/filesystem/prefetch_strategy_test.go
+++ b/pkg/filesystem/prefetch_strategy_test.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2026 KeibiSoft S.R.L.
+
+package filesystem
+
+import "testing"
+
+// TestShouldPrefetchOnOpen pins the size-based strategy: small files stay pure
+// on-demand, files >= the threshold prefetch (+ on-demand jumps), the explicit
+// toggle forces any size, and a 0 threshold disables auto-prefetch entirely.
+func TestShouldPrefetchOnOpen(t *testing.T) {
+	const MB = 1024 * 1024
+	cases := []struct {
+		name           string
+		prefetchOnOpen bool
+		autoMB         int
+		size           uint64
+		want           bool
+	}{
+		{"50MB < 100MB default -> on-demand", false, 100, 50 * MB, false},
+		{"just under 100MB -> on-demand", false, 100, 100*MB - 1, false},
+		{"exactly 100MB -> prefetch", false, 100, 100 * MB, true},
+		{"1.5GB -> prefetch", false, 100, 1536 * MB, true},
+		{"force toggle prefetches a 1MB file", true, 100, 1 * MB, true},
+		{"force toggle even with auto disabled", true, 0, 1 * MB, true},
+		{"auto disabled (0) -> always on-demand", false, 0, 10000 * MB, false},
+		{"custom 300MB threshold: 200MB on-demand", false, 300, 200 * MB, false},
+		{"custom 300MB threshold: 400MB prefetch", false, 300, 400 * MB, true},
+		{"zero-size file -> on-demand", false, 100, 0, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := shouldPrefetchOnOpen(c.prefetchOnOpen, c.autoMB, c.size); got != c.want {
+				t.Errorf("shouldPrefetchOnOpen(prefetchOnOpen=%v, autoMB=%d, size=%d) = %v, want %v",
+					c.prefetchOnOpen, c.autoMB, c.size, got, c.want)
+			}
+		})
+	}
+}

--- a/pkg/filesystem/types.go
+++ b/pkg/filesystem/types.go
@@ -182,6 +182,7 @@ type Dir struct {
 
 	// Collab sync options (propagated from FS).
 	PrefetchOnOpen bool // If true, fetch entire file on Open() and write to local disk.
+	PrefetchAutoMB int  // files >= this many MB auto-prefetch on open (0=off)
 	PushOnWrite    bool // If true, async push deltas to peer on Write().
 
 	RemoteFilesLock sync.RWMutex

--- a/pkg/logic/common/types.go
+++ b/pkg/logic/common/types.go
@@ -76,6 +76,7 @@ type KeibiDrop struct {
 	// peer's same-size in-place edit is seen live. Set by the caller from
 	// config.LiveCollab (not a constructor arg). Default false = git-safe.
 	AutoCache bool
+	PrefetchAutoMB int // files >= this many MB auto-prefetch on open; set from config.PrefetchAutoMB (0=off)
 
 	// Signals for loop management.
 	signals      chan TaskSignal

--- a/pkg/logic/common/types.go
+++ b/pkg/logic/common/types.go
@@ -75,7 +75,7 @@ type KeibiDrop struct {
 	// AutoCache (live_collab) enables the macFUSE auto_cache mount option so a
 	// peer's same-size in-place edit is seen live. Set by the caller from
 	// config.LiveCollab (not a constructor arg). Default false = git-safe.
-	AutoCache bool
+	AutoCache      bool
 	PrefetchAutoMB int // files >= this many MB auto-prefetch on open; set from config.PrefetchAutoMB (0=off)
 
 	// Signals for loop management.

--- a/pkg/logic/common/utils.go
+++ b/pkg/logic/common/utils.go
@@ -329,6 +329,7 @@ func (kd *KeibiDrop) setupFilesystem(logger *slog.Logger, ready chan struct{}) e
 	fs.PrefetchOnOpen = kd.PrefetchOnOpen
 	fs.PushOnWrite = kd.PushOnWrite
 	fs.AutoCache = kd.AutoCache // live_collab → macFUSE auto_cache (set before Mount)
+	fs.PrefetchAutoMB = kd.PrefetchAutoMB
 
 	// Notification worker with per-path debounce and batching.
 	//

--- a/rustbridge/main.go
+++ b/rustbridge/main.go
@@ -172,6 +172,7 @@ func KD_Initialize(relayURL *C.char, inbound, outbound C.int, toMount, toSave *C
 		kd.StrictMode = true
 	}
 	kd.AutoCache = cfg.LiveCollab // live_collab → macFUSE auto_cache (same-size live edits, macOS)
+	kd.PrefetchAutoMB = cfg.PrefetchAutoMB
 	for _, warn := range cfg.Warnings() {
 		logger.Warn("config flag note", "note", warn)
 	}


### PR DESCRIPTION
The rationale is as follows:
on virtual mount point:

Pure pre-fetch on open is the highest speed (fewest round trips).
Pure on-demand is the highest amount of roundtrips, thus the slowest speed.

if files small <100MB ; do on-demand as the worse case is to just touch many small files.

if files > 100 MB, lets say a 4GB Movie, then prefetch on open, and on-demand jumps that also pre-fetch from that point, similar to how a person would skip through it.
(movie just as an example, can be any other program)

