### PR TITLE
Add file metadata lock

### DIFF
--- a/pkg/filesystem/fuse_directory.go
+++ b/pkg/filesystem/fuse_directory.go
@@ -76,9 +76,13 @@ func (d *Dir) refreshFileStat(filePath string) {
 	cleanPath := filepath.Clean(filepath.Join(d.LocalDownloadFolder, filePath))
 	if st, err := platLstat(cleanPath); err == nil {
 		d.AfmLock.Lock()
-		if f, ok := d.AllFileMap[filePath]; ok && f.stat != nil {
-			f.stat.Ctim = st.Ctim
-			f.stat.Mtim = st.Mtim
+		if f, ok := d.AllFileMap[filePath]; ok {
+			f.metaMu.Lock()
+			if f.stat != nil {
+				f.stat.Ctim = st.Ctim
+				f.stat.Mtim = st.Mtim
+			}
+			f.metaMu.Unlock()
 		}
 		d.AfmLock.Unlock()
 	}
@@ -839,6 +843,12 @@ func (d *Dir) Getattr(path string, stat *winfuse.Stat_t, fh uint64) (errCode int
 	if isRemote {
 		remFile, okRemote := d.RemoteFiles[path]
 		if okRemote {
+			// Guard this File's stat under its metaMu for the whole branch: it is
+			// mutated in place below while Read/OpenEx read it via a DIFFERENT lock
+			// (OpenMapLock). Every path here returns, so the defer releases metaMu
+			// (innermost) before the map locks — deadlock-free.
+			remFile.metaMu.Lock()
+			defer remFile.metaMu.Unlock()
 			// File is on remote, let's see if it is also locally.
 			stgo, lstatErr := platLstat(cleanPath)
 			if lstatErr != nil {
@@ -2264,7 +2274,9 @@ func (d *Dir) AddRemoteFile(logger *slog.Logger, path string, name string, stat 
 			return nil
 		}
 
+		existing.metaMu.Lock()
 		existing.stat = stat
+		existing.metaMu.Unlock()
 
 		if sizeChanged {
 			// Size changed: cancel old prefetch, reset bitmap, re-download.
@@ -2576,8 +2588,10 @@ func (d *Dir) EditRemoteFile(logger *slog.Logger, path string, name string, stat
 	}
 
 	// logger.Info("Remote file edited", "path", path, "mtime", stat.Mtim.Time())
+	f.metaMu.Lock()
 	f.stat = stat
 	f.LocalNewer = false // Remote has newer content.
+	f.metaMu.Unlock()
 
 	// Content changed: reset bitmap + cancel prefetch so reads re-fetch on-demand.
 	f.NotLocalSynced = true

--- a/pkg/filesystem/fuse_directory.go
+++ b/pkg/filesystem/fuse_directory.go
@@ -310,6 +310,9 @@ func shouldUseDirectIo(path string, flags int) bool {
 // CreateEx implements FileSystemOpenEx interface for per-file direct_io control.
 func (d *Dir) CreateEx(path string, mode uint32, fi *winfuse.FileInfo_t) (errCode int) {
 	defer d.recoverPanic("CreateEx", &errCode)
+	if strings.Contains(path, "/.git/") {
+		d.logger.Info("GITOP-create", "path", path)
+	}
 	if e := checkPath(path); e != 0 {
 		return e
 	}
@@ -1127,6 +1130,9 @@ func (d *Dir) mkdirInternal(path string, mode uint32, notifyPeer bool) (errCode 
 
 func (d *Dir) Mknod(path string, mode uint32, dev uint64) (errCode int) {
 	defer d.recoverPanic("Mknod", &errCode)
+	if strings.Contains(path, "/.git/") {
+		d.logger.Info("GITOP-mknod", "path", path)
+	}
 	if e := checkPath(path); e != 0 {
 		return e
 	}
@@ -1538,6 +1544,9 @@ func (d *Dir) Rename(oldpath string, newpath string) (errCode int) {
 	d.RemoteFilesLock.Unlock()
 
 	// Notify peer about the rename (only for local files, not remote-only).
+	if strings.Contains(newpath, "/.git/") || strings.Contains(oldpath, "/.git/") {
+		logger.Info("GITRENAME", "old", oldpath, "new", newpath, "isRemote", isRemote, "onLocalChange", d.OnLocalChange != nil, "willNotify", d.OnLocalChange != nil && !isRemote)
+	}
 	if d.OnLocalChange != nil && !isRemote {
 		// Get stat of the renamed file.
 		var attr *keibidrop.Attr
@@ -1684,6 +1693,9 @@ func (d *Dir) Truncate(path string, size int64, fh uint64) (errCode int) {
 // Unlink removes a file.
 func (d *Dir) Unlink(path string) (errCode int) {
 	defer d.recoverPanic("Unlink", &errCode)
+	if strings.Contains(path, "/.git/") {
+		d.logger.Info("GITOP-unlink", "path", path)
+	}
 	if e := checkPath(path); e != 0 {
 		return e
 	}

--- a/pkg/filesystem/fuse_directory.go
+++ b/pkg/filesystem/fuse_directory.go
@@ -457,8 +457,10 @@ func (d *Dir) OpenEx(path string, fi *winfuse.FileInfo_t) (errCode int) {
 		return 0
 	}
 
+	fh.metaMu.RLock()
 	isLocalPresent := fh.IsLocalPresent
 	localNewer := fh.LocalNewer
+	fh.metaMu.RUnlock()
 	d.AfmLock.Unlock()
 
 	// Check if remote has newer version
@@ -508,6 +510,8 @@ func (d *Dir) OpenEx(path string, fi *winfuse.FileInfo_t) (errCode int) {
 		}
 		d.RemoteFilesLock.Unlock()
 	}
+
+	logger.Info("GITDBG open", "path", path, "isLocalPresent", isLocalPresent, "localNewer", localNewer, "remoteHasUpdate", remoteHasUpdate, "hasRemote", hasRemote, "needsRemark", needsRemark)
 
 	// Open locally if we have newer local version
 	if isLocalPresent && localNewer {
@@ -596,7 +600,9 @@ func (d *Dir) OpenEx(path string, fi *winfuse.FileInfo_t) (errCode int) {
 		d.OpenMapLock.Lock()
 		fh.Inode = uint64(fd)
 		fh.openFileCounter.Open()
+		fh.metaMu.Lock()
 		fh.IsLocalPresent = true
+		fh.metaMu.Unlock()
 		fh.NotRemoteSynced = true
 		handleID := allocHandleID()
 		fh.CurrentHandleID = handleID
@@ -637,8 +643,12 @@ func (d *Dir) OpenEx(path string, fi *winfuse.FileInfo_t) (errCode int) {
 	}
 
 	cacheMode := uint32(0644)
-	if fh != nil && fh.stat != nil {
-		cacheMode = fh.stat.Mode & 0o777
+	if fh != nil {
+		fh.metaMu.RLock()
+		if fh.stat != nil {
+			cacheMode = fh.stat.Mode & 0o777
+		}
+		fh.metaMu.RUnlock()
 		if cacheMode == 0 {
 			cacheMode = 0644
 		}
@@ -679,7 +689,9 @@ func (d *Dir) OpenEx(path string, fi *winfuse.FileInfo_t) (errCode int) {
 	d.OpenMapLock.Lock()
 	fh.Inode = uint64(fd)
 	fh.openFileCounter.Open()
+	fh.metaMu.Lock()
 	fh.IsLocalPresent = true
+	fh.metaMu.Unlock()
 	handleID := allocHandleID()
 	fh.CurrentHandleID = handleID
 	d.OpenFileHandlers[handleID] = &HandleEntry{FD: fd, File: fh}
@@ -895,20 +907,27 @@ func (d *Dir) Getattr(path string, stat *winfuse.Stat_t, fh uint64) (errCode int
 	}
 
 	f, ok := d.AllFileMap[path]
-	if ok && f.stat != nil && gtAtim(f.stat.Mtim, stat.Mtim) {
-		copyFusestatFromFusestat(stat, f.stat)
-	}
-	if ok && f.stat != nil && !gtAtim(f.stat.Mtim, stat.Mtim) {
-		savedUid := f.stat.Uid
-		savedGid := f.stat.Gid
-		savedMode := f.stat.Mode
-		copyFusestatFromFusestat(f.stat, stat)
-		f.stat.Uid = savedUid
-		f.stat.Gid = savedGid
-		if !platDiskModeIsAuthoritative {
-			f.stat.Mode = savedMode
+	// Guard the shared *stat under the File's metaMu: Getattr mutates f.stat in
+	// place here while Read/OpenEx read it through OpenMapLock — a different lock,
+	// hence the data race. metaMu is innermost (no map lock taken under it).
+	if ok && f != nil {
+		f.metaMu.Lock()
+		if f.stat != nil && gtAtim(f.stat.Mtim, stat.Mtim) {
+			copyFusestatFromFusestat(stat, f.stat)
 		}
-		copyFusestatFromFusestat(stat, f.stat)
+		if f.stat != nil && !gtAtim(f.stat.Mtim, stat.Mtim) {
+			savedUid := f.stat.Uid
+			savedGid := f.stat.Gid
+			savedMode := f.stat.Mode
+			copyFusestatFromFusestat(f.stat, stat)
+			f.stat.Uid = savedUid
+			f.stat.Gid = savedGid
+			if !platDiskModeIsAuthoritative {
+				f.stat.Mode = savedMode
+			}
+			copyFusestatFromFusestat(stat, f.stat)
+		}
+		f.metaMu.Unlock()
 	}
 	if ok {
 		found = ok
@@ -1319,7 +1338,10 @@ func (d *Dir) Release(path string, fh uint64) (errCode int) {
 			}
 		}
 
-		// Reset sync state for future opens
+		// Reset sync state for future opens. Guard under metaMu (OpenEx reads
+		// IsLocalPresent/NotLocalSynced via AfmLock — a different lock). Released
+		// BEFORE the AfmLock acquisition below to avoid a metaMu->AfmLock cycle.
+		f.metaMu.Lock()
 		f.IsLocalPresent = true
 		// Only mark as synced if download is actually COMPLETE.
 		// Use ChunkBitmap (preferred) or BytesDownloaded as fallback.
@@ -1344,6 +1366,7 @@ func (d *Dir) Release(path string, fh uint64) (errCode int) {
 				}
 			}
 		}
+		f.metaMu.Unlock()
 
 		// If peer stopped sharing and download is now complete, remove from AllFileMap.
 		if f.PeerStoppedSharing {
@@ -1901,9 +1924,12 @@ func (d *Dir) Read(path string, buff []byte, offset int64, fh uint64) (errCode i
 		cacheFD = f.CacheFD
 		notLocalSynced = f.NotLocalSynced
 		bitmap = f.Bitmap
+		// Read f.stat under metaMu: Getattr mutates the same struct in place.
+		f.metaMu.RLock()
 		if f.stat != nil {
 			remoteFileSize = f.stat.Size
 		}
+		f.metaMu.RUnlock()
 	}
 	d.OpenMapLock.RUnlock()
 

--- a/pkg/filesystem/fuse_directory.go
+++ b/pkg/filesystem/fuse_directory.go
@@ -474,6 +474,10 @@ func (d *Dir) OpenEx(path string, fi *winfuse.FileInfo_t) (errCode int) {
 	d.RemoteFilesLock.RLock()
 	remoteFile, hasRemote := d.RemoteFiles[path]
 	if hasRemote {
+		// Read this File's metadata (stat/NotLocalSynced) under metaMu — Release and
+		// the notify handlers write them under metaMu (reached via a different map
+		// lock). Logic unchanged; this only makes the reads race-free.
+		remoteFile.metaMu.RLock()
 		// logger.Info("=== REMOTE CHECK ===", "path", path, "hasRemote", hasRemote, "NotLocalSynced", remoteFile.NotLocalSynced)
 		if remoteFile.stat != nil {
 			remoteTotalSize = uint64(remoteFile.stat.Size)
@@ -503,6 +507,7 @@ func (d *Dir) OpenEx(path string, fi *winfuse.FileInfo_t) (errCode int) {
 				}
 			}
 		}
+		remoteFile.metaMu.RUnlock()
 	}
 	d.RemoteFilesLock.RUnlock()
 

--- a/pkg/filesystem/fuse_directory.go
+++ b/pkg/filesystem/fuse_directory.go
@@ -523,8 +523,6 @@ func (d *Dir) OpenEx(path string, fi *winfuse.FileInfo_t) (errCode int) {
 		d.RemoteFilesLock.Unlock()
 	}
 
-	logger.Info("GITDBG open", "path", path, "isLocalPresent", isLocalPresent, "localNewer", localNewer, "remoteHasUpdate", remoteHasUpdate, "hasRemote", hasRemote, "needsRemark", needsRemark)
-
 	// Open locally if we have newer local version
 	if isLocalPresent && localNewer {
 		accessMode := flags & winfuse.O_ACCMODE

--- a/pkg/filesystem/fuse_directory.go
+++ b/pkg/filesystem/fuse_directory.go
@@ -310,9 +310,6 @@ func shouldUseDirectIo(path string, flags int) bool {
 // CreateEx implements FileSystemOpenEx interface for per-file direct_io control.
 func (d *Dir) CreateEx(path string, mode uint32, fi *winfuse.FileInfo_t) (errCode int) {
 	defer d.recoverPanic("CreateEx", &errCode)
-	if strings.Contains(path, "/.git/") {
-		d.logger.Info("GITOP-create", "path", path)
-	}
 	if e := checkPath(path); e != 0 {
 		return e
 	}
@@ -1128,9 +1125,6 @@ func (d *Dir) mkdirInternal(path string, mode uint32, notifyPeer bool) (errCode 
 
 func (d *Dir) Mknod(path string, mode uint32, dev uint64) (errCode int) {
 	defer d.recoverPanic("Mknod", &errCode)
-	if strings.Contains(path, "/.git/") {
-		d.logger.Info("GITOP-mknod", "path", path)
-	}
 	if e := checkPath(path); e != 0 {
 		return e
 	}
@@ -1542,9 +1536,6 @@ func (d *Dir) Rename(oldpath string, newpath string) (errCode int) {
 	d.RemoteFilesLock.Unlock()
 
 	// Notify peer about the rename (only for local files, not remote-only).
-	if strings.Contains(newpath, "/.git/") || strings.Contains(oldpath, "/.git/") {
-		logger.Info("GITRENAME", "old", oldpath, "new", newpath, "isRemote", isRemote, "onLocalChange", d.OnLocalChange != nil, "willNotify", d.OnLocalChange != nil && !isRemote)
-	}
 	if d.OnLocalChange != nil && !isRemote {
 		// Get stat of the renamed file.
 		var attr *keibidrop.Attr
@@ -1691,9 +1682,6 @@ func (d *Dir) Truncate(path string, size int64, fh uint64) (errCode int) {
 // Unlink removes a file.
 func (d *Dir) Unlink(path string) (errCode int) {
 	defer d.recoverPanic("Unlink", &errCode)
-	if strings.Contains(path, "/.git/") {
-		d.logger.Info("GITOP-unlink", "path", path)
-	}
 	if e := checkPath(path); e != 0 {
 		return e
 	}

--- a/pkg/filesystem/types.go
+++ b/pkg/filesystem/types.go
@@ -257,6 +257,15 @@ type File struct {
 	OnLocalChange func(event types.FileEvent)
 
 	stat *winfuse.Stat_t
+
+	// metaMu guards the File's mutable metadata that concurrent FUSE ops reach
+	// through DIFFERENT map locks (AllFileMap/AfmLock vs OpenFileHandlers/
+	// OpenMapLock) — which therefore do NOT mutually exclude: the *stat struct
+	// (Getattr mutates it in place while Read/OpenEx read Size/Mode) and the
+	// sync-state bools IsLocalPresent/LocalNewer/NotLocalSynced. Confirmed by
+	// the race detector. Always taken INNERMOST: after any map lock, and never
+	// acquire a map lock while holding it (so it cannot deadlock).
+	metaMu sync.RWMutex
 }
 
 func (f *File) NotifyPeer() {}

--- a/pkg/logic/common/utils.go
+++ b/pkg/logic/common/utils.go
@@ -372,31 +372,18 @@ func (kd *KeibiDrop) setupFilesystem(logger *slog.Logger, ready chan struct{}) e
 				return
 			}
 			client := kd.session.GRPCClient
-			seq := batchSeq.Add(1)
-			// Full lifecycle trace: log every path on the wire (path/type/size/mtime).
-			for _, n := range batch {
-				var sz int64 = -1
-				var mt uint64
-				if n.Attr != nil {
-					sz = n.Attr.Size
-					mt = n.Attr.ModificationTime
-				}
-				logger.Info("notify-send", "seq", seq, "path", n.Path, "type", n.Type, "oldPath", n.OldPath, "size", sz, "mtime", mt)
-			}
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			_, err := client.BatchNotify(ctx, &bindings.BatchNotifyRequest{
 				Notifications: batch,
-				Seq:           seq,
+				Seq:           batchSeq.Add(1),
 				Timestamp:     uint64(time.Now().UnixNano()),
 			})
 			cancel()
 			if err != nil {
-				logger.Error("BatchNotify failed, falling back to individual", "count", len(batch), "seq", seq, "error", err)
+				logger.Error("BatchNotify failed, falling back to individual", "count", len(batch), "error", err)
 				for _, req := range batch {
 					ctx2, cancel2 := context.WithTimeout(context.Background(), 5*time.Second)
-					if _, ferr := client.Notify(ctx2, req); ferr != nil {
-						logger.Warn("notify-drop: individual fallback Notify failed", "path", req.Path, "type", req.Type, "error", ferr)
-					}
+					_, _ = client.Notify(ctx2, req)
 					cancel2()
 				}
 			}
@@ -408,18 +395,9 @@ func (kd *KeibiDrop) setupFilesystem(logger *slog.Logger, ready chan struct{}) e
 				if !ok {
 					// Channel closed — flush all pending with fresh sizes.
 					remaining := make([]*bindings.NotifyRequest, 0, len(pending))
-					for path, p := range pending {
-						if kd.FS != nil && kd.FS.Root != nil && !refreshAttrFromDisk(p.req, kd.FS.Root.LocalDownloadFolder) {
-							cp := filepath.Join(kd.FS.Root.LocalDownloadFolder, path)
-							_, se := os.Lstat(cp)
-							logger.Warn("notify-drop: refreshAttrFromDisk false → DROPPING notification", "path", path, "type", p.req.Type, "action", p.req.Type, "checkedPath", cp, "lstatErr", se, "wantSize", func() int64 {
-								if p.req.Attr != nil {
-									return p.req.Attr.Size
-								}
-								return -1
-							}())
-							delete(pending, path)
-							continue
+					for _, p := range pending {
+						if kd.FS != nil && kd.FS.Root != nil {
+							refreshAttrFromDisk(p.req, kd.FS.Root.LocalDownloadFolder)
 						}
 						remaining = append(remaining, p.req)
 					}
@@ -475,17 +453,8 @@ func (kd *KeibiDrop) setupFilesystem(logger *slog.Logger, ready chan struct{}) e
 				ready := make([]*bindings.NotifyRequest, 0, 16)
 				for path, p := range pending {
 					if now.After(p.deadline) {
-						if kd.FS != nil && kd.FS.Root != nil && !refreshAttrFromDisk(p.req, kd.FS.Root.LocalDownloadFolder) {
-							cp := filepath.Join(kd.FS.Root.LocalDownloadFolder, path)
-							_, se := os.Lstat(cp)
-							logger.Warn("notify-drop: refreshAttrFromDisk false → DROPPING notification", "path", path, "type", p.req.Type, "action", p.req.Type, "checkedPath", cp, "lstatErr", se, "wantSize", func() int64 {
-								if p.req.Attr != nil {
-									return p.req.Attr.Size
-								}
-								return -1
-							}())
-							delete(pending, path)
-							continue
+						if kd.FS != nil && kd.FS.Root != nil {
+							refreshAttrFromDisk(p.req, kd.FS.Root.LocalDownloadFolder)
 						}
 						ready = append(ready, p.req)
 						delete(pending, path)
@@ -503,7 +472,6 @@ func (kd *KeibiDrop) setupFilesystem(logger *slog.Logger, ready chan struct{}) e
 
 	fs.OnLocalChange = func(event types.FileEvent) {
 		if kd.session == nil || kd.session.GRPCClient == nil {
-			logger.Warn("notify-drop: session/grpc client nil at OnLocalChange", "path", event.Path, "action", event.Action)
 			return
 		}
 
@@ -533,19 +501,12 @@ func (kd *KeibiDrop) setupFilesystem(logger *slog.Logger, ready chan struct{}) e
 		}
 
 		// Non-blocking send to notification channel.
-		// If the channel is full (1024 pending), drop the notification
+		// If the channel is full (16384 pending), drop the notification
 		// rather than blocking the FUSE handler.
 		select {
 		case kd.notifyCh <- req:
-			var esz int64 = -1
-			var emt uint64
-			if event.Attr != nil {
-				esz = event.Attr.Size
-				emt = event.Attr.ModificationTime
-			}
-			logger.Info("notify-enqueue", "path", event.Path, "action", event.Action, "oldPath", event.OldPath, "size", esz, "mtime", emt)
 		default:
-			logger.Warn("notify-drop: queue full (channel 16384 saturated)", "path", event.Path, "action", event.Action)
+			logger.Warn("Notification queue full, dropping", "path", event.Path)
 		}
 	}
 

--- a/pkg/logic/common/utils.go
+++ b/pkg/logic/common/utils.go
@@ -306,7 +306,13 @@ func refreshAttrFromDisk(req *bindings.NotifyRequest, downloadFolder string) boo
 	}
 	info, err := os.Lstat(filepath.Join(downloadFolder, req.Path))
 	if err != nil {
-		return !os.IsNotExist(err)
+		// Option A: file is gone at flush — it either flickered (rename/replace)
+		// during the 200ms debounce, or is a true transient (.keep/.lock). Do NOT
+		// signal a drop: keep the ADD with the attr captured at enqueue. Silently
+		// dropping here loses REAL files that merely flickered (e.g. files generated
+		// then atomically replaced); a true phantom is harmless because the peer's
+		// on-demand Read returns EOF for a gone remote file (see fuse Read handler).
+		return true
 	}
 	req.Attr.Size = info.Size()
 	req.Attr.ModificationTime = uint64(info.ModTime().UnixNano())
@@ -341,7 +347,7 @@ func (kd *KeibiDrop) setupFilesystem(logger *slog.Logger, ready chan struct{}) e
 	// notification per path. Each update resets a 200ms timer for that path.
 	// Only when the path is stable for 200ms do we include it in the batch.
 	// RENAME/REMOVE/ADD_DIR are sent immediately (no debounce).
-	kd.notifyCh = make(chan *bindings.NotifyRequest, 2048)
+	kd.notifyCh = make(chan *bindings.NotifyRequest, 16384) // 8x headroom for git-clone bursts (~1-1.5 events/file)
 	var batchSeq atomic.Uint64
 	go func() {
 		// Per-path debounce state.
@@ -366,18 +372,31 @@ func (kd *KeibiDrop) setupFilesystem(logger *slog.Logger, ready chan struct{}) e
 				return
 			}
 			client := kd.session.GRPCClient
+			seq := batchSeq.Add(1)
+			// Full lifecycle trace: log every path on the wire (path/type/size/mtime).
+			for _, n := range batch {
+				var sz int64 = -1
+				var mt uint64
+				if n.Attr != nil {
+					sz = n.Attr.Size
+					mt = n.Attr.ModificationTime
+				}
+				logger.Info("notify-send", "seq", seq, "path", n.Path, "type", n.Type, "oldPath", n.OldPath, "size", sz, "mtime", mt)
+			}
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			_, err := client.BatchNotify(ctx, &bindings.BatchNotifyRequest{
 				Notifications: batch,
-				Seq:           batchSeq.Add(1),
+				Seq:           seq,
 				Timestamp:     uint64(time.Now().UnixNano()),
 			})
 			cancel()
 			if err != nil {
-				logger.Error("BatchNotify failed, falling back to individual", "count", len(batch), "error", err)
+				logger.Error("BatchNotify failed, falling back to individual", "count", len(batch), "seq", seq, "error", err)
 				for _, req := range batch {
 					ctx2, cancel2 := context.WithTimeout(context.Background(), 5*time.Second)
-					_, _ = client.Notify(ctx2, req)
+					if _, ferr := client.Notify(ctx2, req); ferr != nil {
+						logger.Warn("notify-drop: individual fallback Notify failed", "path", req.Path, "type", req.Type, "error", ferr)
+					}
 					cancel2()
 				}
 			}
@@ -391,6 +410,14 @@ func (kd *KeibiDrop) setupFilesystem(logger *slog.Logger, ready chan struct{}) e
 					remaining := make([]*bindings.NotifyRequest, 0, len(pending))
 					for path, p := range pending {
 						if kd.FS != nil && kd.FS.Root != nil && !refreshAttrFromDisk(p.req, kd.FS.Root.LocalDownloadFolder) {
+							cp := filepath.Join(kd.FS.Root.LocalDownloadFolder, path)
+							_, se := os.Lstat(cp)
+							logger.Warn("notify-drop: refreshAttrFromDisk false → DROPPING notification", "path", path, "type", p.req.Type, "action", p.req.Type, "checkedPath", cp, "lstatErr", se, "wantSize", func() int64 {
+								if p.req.Attr != nil {
+									return p.req.Attr.Size
+								}
+								return -1
+							}())
 							delete(pending, path)
 							continue
 						}
@@ -449,6 +476,14 @@ func (kd *KeibiDrop) setupFilesystem(logger *slog.Logger, ready chan struct{}) e
 				for path, p := range pending {
 					if now.After(p.deadline) {
 						if kd.FS != nil && kd.FS.Root != nil && !refreshAttrFromDisk(p.req, kd.FS.Root.LocalDownloadFolder) {
+							cp := filepath.Join(kd.FS.Root.LocalDownloadFolder, path)
+							_, se := os.Lstat(cp)
+							logger.Warn("notify-drop: refreshAttrFromDisk false → DROPPING notification", "path", path, "type", p.req.Type, "action", p.req.Type, "checkedPath", cp, "lstatErr", se, "wantSize", func() int64 {
+								if p.req.Attr != nil {
+									return p.req.Attr.Size
+								}
+								return -1
+							}())
 							delete(pending, path)
 							continue
 						}
@@ -468,6 +503,7 @@ func (kd *KeibiDrop) setupFilesystem(logger *slog.Logger, ready chan struct{}) e
 
 	fs.OnLocalChange = func(event types.FileEvent) {
 		if kd.session == nil || kd.session.GRPCClient == nil {
+			logger.Warn("notify-drop: session/grpc client nil at OnLocalChange", "path", event.Path, "action", event.Action)
 			return
 		}
 
@@ -501,8 +537,15 @@ func (kd *KeibiDrop) setupFilesystem(logger *slog.Logger, ready chan struct{}) e
 		// rather than blocking the FUSE handler.
 		select {
 		case kd.notifyCh <- req:
+			var esz int64 = -1
+			var emt uint64
+			if event.Attr != nil {
+				esz = event.Attr.Size
+				emt = event.Attr.ModificationTime
+			}
+			logger.Info("notify-enqueue", "path", event.Path, "action", event.Action, "oldPath", event.OldPath, "size", esz, "mtime", emt)
 		default:
-			logger.Warn("Notification queue full, dropping", "path", event.Path)
+			logger.Warn("notify-drop: queue full (channel 16384 saturated)", "path", event.Path, "action", event.Action)
 		}
 	}
 

--- a/pkg/logic/service/service.go
+++ b/pkg/logic/service/service.go
@@ -369,14 +369,18 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 			// RemoteFiles (e.g., .git/HEAD), trigger re-download now so the
 			// peer doesn't read stale content during the debounce window.
 			if !exists && req.Attr != nil && req.Attr.Size > 0 {
-				kd.FS.Root.RemoteFilesLock.RLock()
-				_, targetTracked := kd.FS.Root.RemoteFiles[req.Path]
-				kd.FS.Root.RemoteFilesLock.RUnlock()
-				if targetTracked {
-					logger.Info("Lock-file rename: re-downloading target",
-						"path", req.Path, "size", req.Attr.Size)
-					_ = kd.FS.Root.AddRemoteFile(logger, req.Path, filepath.Base(req.Path), statFromAttr(req.Attr))
-				}
+				// The rename's SOURCE was a transient temp the peer never received
+				// (git writes tmp_pack_XXX / *.lock then renames to the FINAL name),
+				// so neither map had it and the disk rename above failed with
+				// ENOENT — nothing materialized the destination. The RENAME event
+				// carries the destination's Attr, so create/refresh it as a remote
+				// on-demand file here. Previously this fired ONLY when the target was
+				// ALREADY tracked (true for git's HEAD, but NOT for a brand-new pack/
+				// idx/index), so those final clone artifacts intermittently never
+				// propagated → peer ".git/objects" empty → "bad object HEAD".
+				logger.Info("Rename of untracked source: materializing destination",
+					"path", req.Path, "size", req.Attr.Size)
+				_ = kd.FS.Root.AddRemoteFile(logger, req.Path, filepath.Base(req.Path), statFromAttr(req.Attr))
 			}
 		}
 

--- a/pkg/logic/service/service.go
+++ b/pkg/logic/service/service.go
@@ -82,18 +82,6 @@ func (kd *KeibidropServiceImpl) Debug(context.Context, *bindings.DebugRequest) (
 func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRequest) (*bindings.NotifyResponse, error) {
 	logger := kd.Logger.With("method", "notify", "req-type", req.Type)
 
-	// notify-recv: log EVERY received notification (end-to-end trace with sender's
-	// notify-enqueue/notify-send). Lets us grep a path and see if it crossed the wire.
-	{
-		var rsz int64 = -1
-		var rmt uint64
-		if req.Attr != nil {
-			rsz = req.Attr.Size
-			rmt = req.Attr.ModificationTime
-		}
-		logger.Info("notify-recv", "path", req.Path, "type", req.Type, "oldPath", req.OldPath, "size", rsz, "mtime", rmt)
-	}
-
 	// Handle DISCONNECT before FS checks — it doesn't need a mounted filesystem.
 	if req.Type == bindings.NotifyType_DISCONNECT {
 		logger.Info("Peer requested graceful disconnect")

--- a/pkg/logic/service/service.go
+++ b/pkg/logic/service/service.go
@@ -82,6 +82,18 @@ func (kd *KeibidropServiceImpl) Debug(context.Context, *bindings.DebugRequest) (
 func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRequest) (*bindings.NotifyResponse, error) {
 	logger := kd.Logger.With("method", "notify", "req-type", req.Type)
 
+	// notify-recv: log EVERY received notification (end-to-end trace with sender's
+	// notify-enqueue/notify-send). Lets us grep a path and see if it crossed the wire.
+	{
+		var rsz int64 = -1
+		var rmt uint64
+		if req.Attr != nil {
+			rsz = req.Attr.Size
+			rmt = req.Attr.ModificationTime
+		}
+		logger.Info("notify-recv", "path", req.Path, "type", req.Type, "oldPath", req.OldPath, "size", rsz, "mtime", rmt)
+	}
+
 	// Handle DISCONNECT before FS checks — it doesn't need a mounted filesystem.
 	if req.Type == bindings.NotifyType_DISCONNECT {
 		logger.Info("Peer requested graceful disconnect")

--- a/tests/integration_fuse_git_ondemand_test.go
+++ b/tests/integration_fuse_git_ondemand_test.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2026 KeibiSoft S.R.L.
+
+package tests
+
+import (
+	"crypto/md5" //#nosec G501 -- integrity compare, not security
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestFUSEtoFUSE_GitClone_OnDemandIntegrity reproduces the reported corruption:
+// peer A (alice) clones a real repo into her mount; the clone FINISHES; then
+// (after a delay, so every debounced/batched notification has flushed) peer B
+// (bob) reads the repo on-demand and runs the exact command that failed in the
+// field — `git status` — which returned "fatal: Bad object HEAD".
+//
+// The existing TestFUSEtoFUSE_GitClone only runs git log/status/cat-HEAD on a
+// handful of objects; this one verifies EVERY object (git fsck --full) and then
+// byte-compares every file A has against what B serves on-demand, to pinpoint
+// which file (pack/idx/ref/object) came across wrong.
+func TestFUSEtoFUSE_GitClone_OnDemandIntegrity(t *testing.T) {
+	skipIfNoFUSE(t)
+	p := connectFUSEPeers(t, false) // on-demand (prefetch off = current default)
+	req := require.New(t)
+
+	const repoURL = "https://github.com/KeibiSoft/go-fp.git"
+
+	// A clones into her mount: a burst of create/write/rename/remove (pack +
+	// idx temp→rename, refs, HEAD, working tree).
+	resp := p.alice.send(t, "exec . git clone --quiet "+repoURL+" repo", 180*time.Second)
+	req.Truef(strings.HasPrefix(resp, "EXEC:0:"), "alice clone failed: %s", resp)
+	t.Log("alice: clone finished")
+
+	// Wait for the tree to propagate to B, then a fixed delay so the clone is
+	// long done and all notifications have flushed before B reads anything.
+	WaitForFileOnMount(t, filepath.Join(p.bobMount, "repo", ".git", "HEAD"), 30*time.Second)
+	WaitForFileOnMount(t, filepath.Join(p.bobMount, "repo", "go.mod"), 30*time.Second)
+	time.Sleep(8 * time.Second)
+
+	// Pinpoint FIRST, before B runs any git command (git status rewrites
+	// .git/index, which would otherwise show as a false mismatch). This is the
+	// pure synced/on-demand state: every file A has vs what B serves on-demand.
+	mismatches := diffTrees(t, filepath.Join(p.aliceMount, "repo"), filepath.Join(p.bobMount, "repo"))
+	for _, m := range mismatches {
+		t.Logf("MISMATCH: %s", m)
+	}
+
+	// His exact failing command.
+	status := p.bob.send(t, "exec repo git status", 60*time.Second)
+	t.Logf("bob `git status`: %s", status)
+
+	// Full object verification (reads + checks every object on-demand).
+	fsck := p.bob.send(t, "exec repo git fsck --full --strict", 120*time.Second)
+	t.Logf("bob `git fsck`: %s", fsck)
+
+	revparse := p.bob.send(t, "exec repo git rev-parse HEAD", 30*time.Second)
+	t.Logf("bob `git rev-parse HEAD`: %s", revparse)
+
+	// Assertions — any of these failing IS the bug, reproduced.
+	req.Falsef(strings.Contains(status, "Bad object") || strings.Contains(status, "fatal"),
+		"git status reports corruption: %s", status)
+	req.Truef(strings.HasPrefix(status, "EXEC:0:"), "git status nonzero exit: %s", status)
+	req.Truef(strings.HasPrefix(fsck, "EXEC:0:"), "git fsck reports corruption: %s", fsck)
+	req.Emptyf(mismatches, "%d file(s) diverged between A (source) and B (on-demand)", len(mismatches))
+}
+
+// diffTrees walks src, and for every regular file compares its md5 to the same
+// file under dst (read on-demand through B's FUSE mount). Returns a list of
+// "relpath: srcSize vs dstSize (md5 a/b)" for files that differ or are missing.
+func diffTrees(t *testing.T, src, dst string) []string {
+	t.Helper()
+	var out []string
+	_ = filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return nil
+		}
+		rel, _ := filepath.Rel(src, path)
+		a, aerr := os.ReadFile(path) //#nosec G304 -- test paths
+		if aerr != nil {
+			return nil
+		}
+		b, berr := os.ReadFile(filepath.Join(dst, rel)) //#nosec G304 -- test paths
+		if berr != nil {
+			out = append(out, fmt.Sprintf("%s: MISSING on B (%v)", rel, berr))
+			return nil
+		}
+		if md5.Sum(a) != md5.Sum(b) { //#nosec G401
+			out = append(out, fmt.Sprintf("%s: A=%dB md5=%x  B=%dB md5=%x",
+				rel, len(a), md5.Sum(a), len(b), md5.Sum(b)))
+		}
+		return nil
+	})
+	return out
+}


### PR DESCRIPTION
During git clones between peers via relay sometimes index got corrupted. Running race detector
found 4 metadata races between peers.

This PR solves 3 issues:
1. Metadata of files could race between peers.
2. Git atomic renames did not propagate if index was not already tracked
3. There were silent file events notify drops between peers


Because of the above issues, git cloning, git lfs cloning, and runnning postgresql servers on the mounted filesystem, between peers lead to data loss/ corruptions.

Now It Just Works! `d:^D`