### PR TITLE
fix(sync): peer REMOVE on create-then-delete, no-FUSE Read lock, ADD guard

### DIFF
--- a/pkg/logic/common/utils.go
+++ b/pkg/logic/common/utils.go
@@ -296,13 +296,12 @@ func isValidIPv6(ipStr string) bool {
 
 //
 
-// refreshAttrFromDisk updates req.Attr's Size/ModTime from the on-disk file
-// before a debounced notification is sent (the size captured when the event was
-// queued may be stale). It returns false only when the file no longer exists,
-// signalling the caller to drop the pending notification.
-func refreshAttrFromDisk(req *bindings.NotifyRequest, downloadFolder string) bool {
+// refreshAttrFromDisk refreshes req.Attr's Size/ModTime from disk before a
+// debounced notify is sent (the queued size may be stale). A file gone at
+// flush time is kept, not dropped (see Option A below).
+func refreshAttrFromDisk(req *bindings.NotifyRequest, downloadFolder string) {
 	if req.Attr == nil {
-		return true
+		return
 	}
 	info, err := os.Lstat(filepath.Join(downloadFolder, req.Path))
 	if err != nil {
@@ -312,11 +311,10 @@ func refreshAttrFromDisk(req *bindings.NotifyRequest, downloadFolder string) boo
 		// dropping here loses REAL files that merely flickered (e.g. files generated
 		// then atomically replaced); a true phantom is harmless because the peer's
 		// on-demand Read returns EOF for a gone remote file (see fuse Read handler).
-		return true
+		return
 	}
 	req.Attr.Size = info.Size()
 	req.Attr.ModificationTime = uint64(info.ModTime().UnixNano())
-	return true
 }
 
 func (kd *KeibiDrop) setupFilesystem(logger *slog.Logger, ready chan struct{}) error {
@@ -431,12 +429,10 @@ func (kd *KeibiDrop) setupFilesystem(logger *slog.Logger, ready chan struct{}) e
 					immediate = append(immediate, req)
 				default:
 					// REMOVE, ADD_DIR, REMOVE_DIR, DISCONNECT — send immediately.
-					// Skip REMOVE if there's a debounced ADD for the same path:
-					// the file was deleted and recreated quickly (e.g., initdb).
+					// create-then-delete in the debounce window: drop the pending
+					// ADD and send the REMOVE so the peer doesn't keep a dead file.
 					if req.Type == bindings.NotifyType_REMOVE_FILE || req.Type == bindings.NotifyType_REMOVE_DIR {
-						if _, hasPending := pending[req.Path]; hasPending {
-							continue
-						}
+						delete(pending, req.Path)
 					}
 					immediate = append(immediate, req)
 				}

--- a/pkg/logic/service/notify_synctracker_test.go
+++ b/pkg/logic/service/notify_synctracker_test.go
@@ -86,6 +86,60 @@ func TestAddFile_FuseMode_WritesSyncTracker(t *testing.T) {
 	assert.Equal(t, uint64(fileSize), got.Size, "Size mismatch")
 }
 
+// TestAddFile_NoFUSE_RejectsStaleSmallerOlder_AcceptsNewerShrink: the non-FUSE
+// ADD path rejects a stale smaller ADD but accepts a newer shrink (git HEAD 25->21).
+func TestAddFile_NoFUSE_RejectsStaleSmallerOlder_AcceptsNewerShrink(t *testing.T) {
+	st := synctracker.NewSyncTracker()
+	const filePath = "HEAD"
+	st.RemoteFilesMu.Lock()
+	st.RemoteFiles[filePath] = &synctracker.File{
+		Name: filePath, RelativePath: filePath, Size: 25, LastEditTime: 1000,
+	}
+	st.RemoteFilesMu.Unlock()
+
+	svc := &KeibidropServiceImpl{
+		Logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+		FS:          nil, // non-FUSE path
+		SyncTracker: st,
+	}
+	sizeOf := func() uint64 {
+		st.RemoteFilesMu.RLock()
+		defer st.RemoteFilesMu.RUnlock()
+		return st.RemoteFiles[filePath].Size
+	}
+
+	// (a) smaller AND older -> rejected, entry unchanged.
+	_, err := svc.Notify(context.Background(), &bindings.NotifyRequest{
+		Type: bindings.NotifyType_ADD_FILE, Path: filePath, Name: filePath,
+		Attr: &bindings.Attr{Size: 21, ModificationTime: 500},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, uint64(25), sizeOf(), "stale smaller+older ADD must be rejected")
+
+	// (b) smaller AND newer (legit shrink) -> accepted, entry updates.
+	_, err = svc.Notify(context.Background(), &bindings.NotifyRequest{
+		Type: bindings.NotifyType_ADD_FILE, Path: filePath, Name: filePath,
+		Attr: &bindings.Attr{Size: 21, ModificationTime: 2000},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, uint64(21), sizeOf(), "legit smaller+newer shrink must be accepted")
+
+	// (c) resume entry has no stored mtime (LastEditTime==0); its size is the
+	// stale one, so a fresh smaller ADD is accepted (else the resume would
+	// target a stale-larger size and stall).
+	st.RemoteFilesMu.Lock()
+	st.RemoteFiles["resume"] = &synctracker.File{Name: "resume", RelativePath: "resume", Size: 25, LastEditTime: 0}
+	st.RemoteFilesMu.Unlock()
+	_, err = svc.Notify(context.Background(), &bindings.NotifyRequest{
+		Type: bindings.NotifyType_ADD_FILE, Path: "resume", Name: "resume",
+		Attr: &bindings.Attr{Size: 21, ModificationTime: 2000},
+	})
+	require.NoError(t, err)
+	st.RemoteFilesMu.RLock()
+	assert.Equal(t, uint64(21), st.RemoteFiles["resume"].Size, "fresh smaller ADD on a resume entry (no stored mtime) must be accepted")
+	st.RemoteFilesMu.RUnlock()
+}
+
 // TestEditFile_FuseMode_UpdatesSyncTracker verifies that when FUSE is active,
 // a NotifyType_EDIT_FILE request updates an existing entry in SyncTracker.RemoteFiles.
 func TestEditFile_FuseMode_UpdatesSyncTracker(t *testing.T) {

--- a/pkg/logic/service/notify_synctracker_test.go
+++ b/pkg/logic/service/notify_synctracker_test.go
@@ -347,3 +347,36 @@ func TestRemoveFile_NoFUSE_ExecutesAfterWindow(t *testing.T) {
 		return !ok
 	}, 5*time.Second, 25*time.Millisecond, "buffered remove must execute after the window")
 }
+
+// TestRemoveFile_NoFUSE_DisconnectCancelsPendingRemoves: a graceful DISCONNECT
+// cancels buffered removes; the tracker outlives the session, so a surviving
+// timer would delete a file re-synced by the next session.
+func TestRemoveFile_NoFUSE_DisconnectCancelsPendingRemoves(t *testing.T) {
+	st := synctracker.NewSyncTracker()
+	const filePath = "h.txt"
+	st.RemoteFilesMu.Lock()
+	st.RemoteFiles[filePath] = &synctracker.File{Name: filePath, RelativePath: filePath, Size: 100}
+	st.RemoteFilesMu.Unlock()
+
+	svc := &KeibidropServiceImpl{
+		Logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+		FS:          nil, // non-FUSE path
+		SyncTracker: st,
+	}
+
+	_, err := svc.Notify(context.Background(), &bindings.NotifyRequest{
+		Type: bindings.NotifyType_REMOVE_FILE, Path: filePath,
+	})
+	require.NoError(t, err)
+
+	_, err = svc.Notify(context.Background(), &bindings.NotifyRequest{
+		Type: bindings.NotifyType_DISCONNECT,
+	})
+	require.NoError(t, err)
+
+	time.Sleep(1200 * time.Millisecond)
+	st.RemoteFilesMu.RLock()
+	_, ok := st.RemoteFiles[filePath]
+	st.RemoteFilesMu.RUnlock()
+	assert.True(t, ok, "DISCONNECT must cancel the buffered remove")
+}

--- a/pkg/logic/service/notify_synctracker_test.go
+++ b/pkg/logic/service/notify_synctracker_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (c) 2025 KeibiSoft S.R.L.
-// ABOUTME: Tests that ADD_FILE and EDIT_FILE via the FUSE path write SyncTracker.RemoteFiles.
-// ABOUTME: Regression for FUSE-mode files being invisible in the UI via KD_GetFileCount/KD_GetFileName.
+// ABOUTME: Tests the desktop Notify handler: FUSE ADD/EDIT writing SyncTracker.RemoteFiles,
+// ABOUTME: the no-FUSE ADD stale-guard, and the receiver-side REMOVE debounce.
 
 //go:build !android
 
@@ -13,6 +13,7 @@ import (
 	"log/slog"
 	"sync"
 	"testing"
+	"time"
 
 	bindings "github.com/KeibiSoft/KeibiDrop/grpc_bindings"
 	"github.com/KeibiSoft/KeibiDrop/pkg/filesystem"
@@ -278,4 +279,71 @@ func TestEditFile_FuseMode_CreatesNewSyncTrackerEntry(t *testing.T) {
 	assert.Equal(t, uint64(fileSize), got.Size, "Size mismatch")
 	assert.Equal(t, fileModTime, got.LastEditTime, "LastEditTime mismatch")
 	assert.Equal(t, fileBirth, got.CreatedTime, "CreatedTime mismatch")
+}
+
+// TestRemoveFile_NoFUSE_BufferedThenCancelledByAdd: REMOVE is buffered for
+// 1000ms, not applied immediately; an ADD within the window cancels it.
+func TestRemoveFile_NoFUSE_BufferedThenCancelledByAdd(t *testing.T) {
+	st := synctracker.NewSyncTracker()
+	const filePath = "f.txt"
+	st.RemoteFilesMu.Lock()
+	st.RemoteFiles[filePath] = &synctracker.File{Name: filePath, RelativePath: filePath, Size: 100}
+	st.RemoteFilesMu.Unlock()
+
+	svc := &KeibidropServiceImpl{
+		Logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+		FS:          nil, // non-FUSE path
+		SyncTracker: st,
+	}
+	tracked := func() bool {
+		st.RemoteFilesMu.RLock()
+		defer st.RemoteFilesMu.RUnlock()
+		_, ok := st.RemoteFiles[filePath]
+		return ok
+	}
+
+	// REMOVE is buffered, not applied immediately.
+	_, err := svc.Notify(context.Background(), &bindings.NotifyRequest{
+		Type: bindings.NotifyType_REMOVE_FILE, Path: filePath,
+	})
+	require.NoError(t, err)
+	assert.True(t, tracked(), "REMOVE should be buffered, file still present")
+
+	// An ADD for the same path within the window cancels the buffered remove.
+	_, err = svc.Notify(context.Background(), &bindings.NotifyRequest{
+		Type: bindings.NotifyType_ADD_FILE, Path: filePath, Name: filePath,
+		Attr: &bindings.Attr{Size: 100, ModificationTime: 1},
+	})
+	require.NoError(t, err)
+	time.Sleep(1200 * time.Millisecond)
+	assert.True(t, tracked(), "ADD within the window must cancel the buffered remove")
+}
+
+// TestRemoveFile_NoFUSE_ExecutesAfterWindow: a buffered REMOVE with no
+// ADD/RENAME within the window executes and drops the tracked entry.
+func TestRemoveFile_NoFUSE_ExecutesAfterWindow(t *testing.T) {
+	st := synctracker.NewSyncTracker()
+	const filePath = "g.txt"
+	st.RemoteFilesMu.Lock()
+	st.RemoteFiles[filePath] = &synctracker.File{Name: filePath, RelativePath: filePath, Size: 100}
+	st.RemoteFilesMu.Unlock()
+
+	svc := &KeibidropServiceImpl{
+		Logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+		FS:          nil, // non-FUSE path
+		SyncTracker: st,
+	}
+
+	_, err := svc.Notify(context.Background(), &bindings.NotifyRequest{
+		Type: bindings.NotifyType_REMOVE_FILE, Path: filePath,
+	})
+	require.NoError(t, err)
+
+	// Poll past the 1000ms window with a deadline so load cannot flake this.
+	require.Eventually(t, func() bool {
+		st.RemoteFilesMu.RLock()
+		defer st.RemoteFilesMu.RUnlock()
+		_, ok := st.RemoteFiles[filePath]
+		return !ok
+	}, 5*time.Second, 25*time.Millisecond, "buffered remove must execute after the window")
 }

--- a/pkg/logic/service/service.go
+++ b/pkg/logic/service/service.go
@@ -156,11 +156,12 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 			defer kd.SyncTracker.RemoteFilesMu.Unlock()
 			existing, ok := kd.SyncTracker.RemoteFiles[req.Path]
 			if ok {
-				// Reject stale ADD_FILE with smaller size — git's debounced
-				// notification for a temp file can arrive AFTER a RENAME
-				// already set the correct (larger) size.
-				if uint64(req.Attr.Size) < existing.Size {
-					logger.Info("Ignoring stale ADD_FILE with smaller size",
+				// A smaller size is usually a stale temp-file ADD arriving after a
+				// rename set the real size; those carry an older mtime, so reject
+				// only when older. A real shrink (git HEAD 25->21) is newer: accept.
+				if uint64(req.Attr.Size) < existing.Size &&
+					req.Attr.ModificationTime < existing.LastEditTime {
+					logger.Info("Ignoring stale ADD_FILE (smaller, older mtime)",
 						"path", req.Path, "staleSize", req.Attr.Size, "currentSize", existing.Size)
 					return &bindings.NotifyResponse{}, nil
 				}
@@ -602,9 +603,6 @@ func (kd *KeibidropServiceImpl) Read(stream bindings.KeibiService_ReadServer) er
 	logger := kd.Logger.With("method", "server-read")
 
 	if (kd.FS == nil || kd.FS.Root == nil) && kd.SyncTracker != nil {
-		kd.SyncTracker.LocalFilesMu.RLock()
-		defer kd.SyncTracker.LocalFilesMu.RUnlock()
-
 		isOpen := false
 
 		var fh *os.File
@@ -637,17 +635,24 @@ func (kd *KeibidropServiceImpl) Read(stream bindings.KeibiService_ReadServer) er
 				// Normalize: FUSE peers send "/filename", no-FUSE uses bare "filename".
 				// LocalFiles keys use bare names (from AddFile's finfo.Name()).
 				lookupPath := strings.TrimPrefix(rec.Path, "/")
+				// Lock only the lookup; copy the path and stream lock-free.
+				kd.SyncTracker.LocalFilesMu.RLock()
 				f, ok := kd.SyncTracker.LocalFiles[lookupPath]
 				if !ok {
 					// Fallback: try original path (e.g. full path stored by PullFile).
 					f, ok = kd.SyncTracker.LocalFiles[rec.Path]
 				}
+				var realPath string
+				if ok {
+					realPath = f.RealPathOfFile
+				}
+				kd.SyncTracker.LocalFilesMu.RUnlock()
 				if !ok {
 					logger.Warn("File not found", "rec", rec)
 					return status.Error(codes.NotFound, "file not found")
 				}
 
-				fh, err = os.Open(f.RealPathOfFile)
+				fh, err = os.Open(realPath)
 				if err != nil {
 					logger.Error("Failed to open real file", "error", err)
 					return status.Error(codes.Internal, "error accessing file")

--- a/pkg/logic/service/service.go
+++ b/pkg/logic/service/service.go
@@ -159,6 +159,7 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 				// A smaller size is usually a stale temp-file ADD arriving after a
 				// rename set the real size; those carry an older mtime, so reject
 				// only when older. A real shrink (git HEAD 25->21) is newer: accept.
+				// Strict <: equal-mtime shrink is accepted; reject only provably stale ADDs.
 				if uint64(req.Attr.Size) < existing.Size &&
 					req.Attr.ModificationTime < existing.LastEditTime {
 					logger.Info("Ignoring stale ADD_FILE (smaller, older mtime)",

--- a/pkg/logic/service/service.go
+++ b/pkg/logic/service/service.go
@@ -85,6 +85,7 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 	// Handle DISCONNECT before FS checks — it doesn't need a mounted filesystem.
 	if req.Type == bindings.NotifyType_DISCONNECT {
 		logger.Info("Peer requested graceful disconnect")
+		kd.cancelAllPendingRemoves()
 		if kd.OnEvent != nil {
 			kd.OnEvent("peer_disconnected:")
 		}
@@ -493,6 +494,18 @@ func (kd *KeibidropServiceImpl) cancelPendingRemove(path string) {
 		delete(kd.pendingRemoves, path)
 		kd.Logger.Info("Cancelled buffered remove (ADD/RENAME arrived)", "path", path)
 	}
+}
+
+// cancelAllPendingRemoves stops every buffered remove (on disconnect). The
+// SyncTracker and FS outlive the session; a timer surviving into the next
+// session would remove a freshly re-synced file.
+func (kd *KeibidropServiceImpl) cancelAllPendingRemoves() {
+	kd.pendingRemovesMu.Lock()
+	defer kd.pendingRemovesMu.Unlock()
+	for _, t := range kd.pendingRemoves {
+		t.Stop()
+	}
+	kd.pendingRemoves = nil
 }
 
 // executeRemove performs the actual REMOVE_FILE logic (previously inline in Notify).


### PR DESCRIPTION
Sync bugs found while reviewing the last batch:

- A file deleted by a git branch switch could stay behind on the other peer (sender now forwards the REMOVE; fixes the known BobMainNoCrossPeerFile e2e failure).
- No-FUSE reads held a lock for the whole transfer, blocking parallel pulls.
- A file that legitimately shrinks (e.g. git HEAD) was ignored on the no-FUSE side.
- Buffered removes are cancelled on graceful disconnect, so a stale timer cannot delete a file re-synced by the next session.

The receiver debounce paths now have tests that run on linux. Android counterpart: #179 (merge this one first).