### PR TITLE
fix(android): match desktop Notify handler (REMOVE debounce + ADD guard)

### DIFF
--- a/pkg/logic/service/service_android.go
+++ b/pkg/logic/service/service_android.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	bindings "github.com/KeibiSoft/KeibiDrop/grpc_bindings"
@@ -47,6 +48,11 @@ type KeibidropServiceImpl struct {
 	SyncTracker  *synctracker.SyncTracker
 	OnEvent      func(string)
 	OnDisconnect func()
+
+	// pendingRemoves buffers REMOVE_FILE for 1000ms; an ADD/EDIT/RENAME for the
+	// same path within that window cancels it (git's atomic .lock->rename dance).
+	pendingRemovesMu sync.Mutex
+	pendingRemoves   map[string]*time.Timer
 }
 
 func (kd *KeibidropServiceImpl) Debug(context.Context, *bindings.DebugRequest) (*bindings.DebugResponse, error) {
@@ -59,6 +65,7 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 
 	if req.Type == bindings.NotifyType_DISCONNECT {
 		logger.Info("Peer requested graceful disconnect")
+		kd.cancelAllPendingRemoves()
 		if kd.OnEvent != nil {
 			kd.OnEvent("peer_disconnected:")
 		}
@@ -84,6 +91,7 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 		logger.Info("Directory notification ignored in SyncTracker mode", "type", req.Type)
 
 	case bindings.NotifyType_ADD_FILE:
+		kd.cancelPendingRemove(req.Path)
 		if req.Attr == nil {
 			logger.Error("Failed to add file, invalid attr", "error", ErrGRPCInvalidArgument)
 			return nil, ErrGRPCInvalidArgument
@@ -119,6 +127,7 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 		logger.Info("Success")
 
 	case bindings.NotifyType_EDIT_FILE:
+		kd.cancelPendingRemove(req.Path)
 		if req.Attr == nil {
 			logger.Error("Failed to edit file, invalid attr", "error", ErrGRPCInvalidArgument)
 			return nil, ErrGRPCFailedPrecondition
@@ -158,13 +167,12 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 		logger.Info("Success")
 
 	case bindings.NotifyType_REMOVE_FILE:
-		logger.Info("Remove file reference", "path", req.Path)
-		kd.SyncTracker.RemoteFilesMu.Lock()
-		delete(kd.SyncTracker.RemoteFiles, req.Path)
-		kd.SyncTracker.RemoteFilesMu.Unlock()
-		logger.Info("Removed file from sync tracker", "path", req.Path)
+		// Buffer the remove; a quick ADD/RENAME for the same path cancels it.
+		kd.bufferRemove(req.Path, logger)
 
 	case bindings.NotifyType_RENAME_FILE:
+		kd.cancelPendingRemove(req.Path)
+		kd.cancelPendingRemove(req.OldPath)
 		logger.Info("Rename file", "oldPath", req.OldPath, "newPath", req.Path)
 		kd.SyncTracker.RemoteFilesMu.Lock()
 		if f, ok := kd.SyncTracker.RemoteFiles[req.OldPath]; ok {
@@ -190,6 +198,55 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 
 	logger.Info("Success")
 	return &bindings.NotifyResponse{}, nil
+}
+
+// bufferRemove delays a REMOVE_FILE by 1000ms; cancelPendingRemove for the same
+// path before it fires discards it.
+func (kd *KeibidropServiceImpl) bufferRemove(path string, logger *slog.Logger) {
+	kd.pendingRemovesMu.Lock()
+	defer kd.pendingRemovesMu.Unlock()
+
+	if kd.pendingRemoves == nil {
+		kd.pendingRemoves = make(map[string]*time.Timer)
+	}
+	if t, ok := kd.pendingRemoves[path]; ok {
+		t.Stop()
+	}
+	kd.pendingRemoves[path] = time.AfterFunc(1000*time.Millisecond, func() {
+		kd.pendingRemovesMu.Lock()
+		delete(kd.pendingRemoves, path)
+		kd.pendingRemovesMu.Unlock()
+		kd.executeRemove(path, logger)
+	})
+}
+
+// cancelPendingRemove discards a buffered REMOVE when an ADD/EDIT/RENAME for the
+// same path arrives (the remove was part of git's atomic .lock->rename dance).
+func (kd *KeibidropServiceImpl) cancelPendingRemove(path string) {
+	kd.pendingRemovesMu.Lock()
+	defer kd.pendingRemovesMu.Unlock()
+	if t, ok := kd.pendingRemoves[path]; ok {
+		t.Stop()
+		delete(kd.pendingRemoves, path)
+	}
+}
+
+// cancelAllPendingRemoves stops every buffered remove (on disconnect).
+func (kd *KeibidropServiceImpl) cancelAllPendingRemoves() {
+	kd.pendingRemovesMu.Lock()
+	defer kd.pendingRemovesMu.Unlock()
+	for _, t := range kd.pendingRemoves {
+		t.Stop()
+	}
+	kd.pendingRemoves = nil
+}
+
+// executeRemove drops the file from the sync tracker (android has no FUSE).
+func (kd *KeibidropServiceImpl) executeRemove(path string, logger *slog.Logger) {
+	kd.SyncTracker.RemoteFilesMu.Lock()
+	delete(kd.SyncTracker.RemoteFiles, path)
+	kd.SyncTracker.RemoteFilesMu.Unlock()
+	logger.Info("Removed file from sync tracker (buffered)", "path", path)
 }
 
 func (kd *KeibidropServiceImpl) BatchNotify(ctx context.Context, req *bindings.BatchNotifyRequest) (*bindings.BatchNotifyResponse, error) {

--- a/pkg/logic/service/service_android.go
+++ b/pkg/logic/service/service_android.go
@@ -102,8 +102,12 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 
 		existing, ok := kd.SyncTracker.RemoteFiles[req.Path]
 		if ok {
-			if uint64(req.Attr.Size) < existing.Size {
-				logger.Info("Ignoring stale ADD_FILE with smaller size",
+			// A smaller size is usually a stale temp-file ADD arriving after a
+			// rename set the real size; those carry an older mtime, so reject
+			// only when older. A real shrink (git HEAD 25->21) is newer: accept.
+			if uint64(req.Attr.Size) < existing.Size &&
+				req.Attr.ModificationTime < existing.LastEditTime {
+				logger.Info("Ignoring stale ADD_FILE (smaller, older mtime)",
 					"path", req.Path, "staleSize", req.Attr.Size, "currentSize", existing.Size)
 				return &bindings.NotifyResponse{}, nil
 			}

--- a/pkg/logic/service/service_android.go
+++ b/pkg/logic/service/service_android.go
@@ -105,6 +105,7 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 			// A smaller size is usually a stale temp-file ADD arriving after a
 			// rename set the real size; those carry an older mtime, so reject
 			// only when older. A real shrink (git HEAD 25->21) is newer: accept.
+			// Strict <: equal-mtime shrink is accepted; reject only provably stale ADDs.
 			if uint64(req.Attr.Size) < existing.Size &&
 				req.Attr.ModificationTime < existing.LastEditTime {
 				logger.Info("Ignoring stale ADD_FILE (smaller, older mtime)",
@@ -172,6 +173,7 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 
 	case bindings.NotifyType_REMOVE_FILE:
 		// Buffer the remove; a quick ADD/RENAME for the same path cancels it.
+		logger.Info("Buffering remove (1000ms)", "path", req.Path)
 		kd.bufferRemove(req.Path, logger)
 
 	case bindings.NotifyType_RENAME_FILE:
@@ -220,6 +222,8 @@ func (kd *KeibidropServiceImpl) bufferRemove(path string, logger *slog.Logger) {
 		kd.pendingRemovesMu.Lock()
 		delete(kd.pendingRemoves, path)
 		kd.pendingRemovesMu.Unlock()
+
+		logger.Info("Executing buffered remove (no ADD/RENAME arrived)", "path", path)
 		kd.executeRemove(path, logger)
 	})
 }
@@ -232,6 +236,7 @@ func (kd *KeibidropServiceImpl) cancelPendingRemove(path string) {
 	if t, ok := kd.pendingRemoves[path]; ok {
 		t.Stop()
 		delete(kd.pendingRemoves, path)
+		kd.Logger.Info("Cancelled buffered remove (ADD/RENAME arrived)", "path", path)
 	}
 }
 
@@ -247,6 +252,9 @@ func (kd *KeibidropServiceImpl) cancelAllPendingRemoves() {
 
 // executeRemove drops the file from the sync tracker (android has no FUSE).
 func (kd *KeibidropServiceImpl) executeRemove(path string, logger *slog.Logger) {
+	if kd.SyncTracker == nil {
+		return
+	}
 	kd.SyncTracker.RemoteFilesMu.Lock()
 	delete(kd.SyncTracker.RemoteFiles, path)
 	kd.SyncTracker.RemoteFilesMu.Unlock()

--- a/pkg/logic/service/service_android_notify_test.go
+++ b/pkg/logic/service/service_android_notify_test.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"log/slog"
 	"testing"
+	"time"
 
 	bindings "github.com/KeibiSoft/KeibiDrop/grpc_bindings"
 	synctracker "github.com/KeibiSoft/KeibiDrop/pkg/sync-tracker"
@@ -82,6 +83,44 @@ func TestNotify_EditFile_UpdatesExistingEntry(t *testing.T) {
 	require.NotNil(t, f)
 	assert.Equal(t, uint64(200), f.Size)
 	assert.Equal(t, uint64(2000), f.LastEditTime)
+}
+
+func TestNotify_Remove_BufferedThenCancelledByAdd(t *testing.T) {
+	svc := newTestService()
+	svc.SyncTracker.RemoteFiles["f.txt"] = &synctracker.File{Name: "f.txt", RelativePath: "f.txt", Size: 100}
+
+	// REMOVE is buffered, not applied immediately.
+	_, err := svc.Notify(context.Background(), &bindings.NotifyRequest{Type: bindings.NotifyType_REMOVE_FILE, Path: "f.txt"})
+	require.NoError(t, err)
+	svc.SyncTracker.RemoteFilesMu.RLock()
+	_, ok := svc.SyncTracker.RemoteFiles["f.txt"]
+	svc.SyncTracker.RemoteFilesMu.RUnlock()
+	assert.True(t, ok, "REMOVE should be buffered, file still present")
+
+	// An ADD for the same path within the window cancels the buffered remove.
+	_, err = svc.Notify(context.Background(), &bindings.NotifyRequest{
+		Type: bindings.NotifyType_ADD_FILE, Path: "f.txt", Name: "f.txt",
+		Attr: &bindings.Attr{Size: 100, ModificationTime: 1},
+	})
+	require.NoError(t, err)
+	time.Sleep(1200 * time.Millisecond)
+	svc.SyncTracker.RemoteFilesMu.RLock()
+	_, ok = svc.SyncTracker.RemoteFiles["f.txt"]
+	svc.SyncTracker.RemoteFilesMu.RUnlock()
+	assert.True(t, ok, "ADD within the window must cancel the buffered remove")
+}
+
+func TestNotify_Remove_ExecutesAfterWindow(t *testing.T) {
+	svc := newTestService()
+	svc.SyncTracker.RemoteFiles["g.txt"] = &synctracker.File{Name: "g.txt", RelativePath: "g.txt", Size: 100}
+
+	_, err := svc.Notify(context.Background(), &bindings.NotifyRequest{Type: bindings.NotifyType_REMOVE_FILE, Path: "g.txt"})
+	require.NoError(t, err)
+	time.Sleep(1200 * time.Millisecond)
+	svc.SyncTracker.RemoteFilesMu.RLock()
+	_, ok := svc.SyncTracker.RemoteFiles["g.txt"]
+	svc.SyncTracker.RemoteFilesMu.RUnlock()
+	assert.False(t, ok, "buffered remove must execute after the window")
 }
 
 func TestNotify_RenameFile_UpdatesSizeFromAttr(t *testing.T) {

--- a/pkg/logic/service/service_android_notify_test.go
+++ b/pkg/logic/service/service_android_notify_test.go
@@ -1,5 +1,5 @@
-// ABOUTME: Tests for Android Notify handler: EDIT create-on-miss, RENAME
-// ABOUTME: resilience (size update + create-on-miss), and OnEvent emission.
+// ABOUTME: Tests for the Android Notify handler: ADD stale-guard, REMOVE
+// ABOUTME: debounce, EDIT/RENAME resilience, and OnEvent emission.
 
 //go:build android
 
@@ -254,4 +254,48 @@ func TestNotify_EditFile_EmitsFileArrivedEvent(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, "file_arrived:doc.txt:200", received)
+}
+
+func TestNotify_AddFile_RejectsStaleSmallerOlder(t *testing.T) {
+	svc := newTestService()
+	svc.SyncTracker.RemoteFiles["f.txt"] = &synctracker.File{
+		Name: "f.txt", RelativePath: "f.txt", Size: 100, LastEditTime: 2000,
+	}
+
+	// A stale temp-file ADD: smaller AND older than what we have. Reject it.
+	_, err := svc.Notify(context.Background(), &bindings.NotifyRequest{
+		Type: bindings.NotifyType_ADD_FILE, Path: "f.txt", Name: "f.txt",
+		Attr: &bindings.Attr{Size: 50, ModificationTime: 1000},
+	})
+	require.NoError(t, err)
+
+	svc.SyncTracker.RemoteFilesMu.RLock()
+	f := svc.SyncTracker.RemoteFiles["f.txt"]
+	svc.SyncTracker.RemoteFilesMu.RUnlock()
+
+	require.NotNil(t, f)
+	assert.Equal(t, uint64(100), f.Size, "stale smaller+older ADD must be ignored")
+	assert.Equal(t, uint64(2000), f.LastEditTime)
+}
+
+func TestNotify_AddFile_AcceptsSmallerNewer(t *testing.T) {
+	svc := newTestService()
+	svc.SyncTracker.RemoteFiles["f.txt"] = &synctracker.File{
+		Name: "f.txt", RelativePath: "f.txt", Size: 100, LastEditTime: 1000,
+	}
+
+	// A real shrink (e.g. git HEAD 100->50) carries a newer mtime. Accept it.
+	_, err := svc.Notify(context.Background(), &bindings.NotifyRequest{
+		Type: bindings.NotifyType_ADD_FILE, Path: "f.txt", Name: "f.txt",
+		Attr: &bindings.Attr{Size: 50, ModificationTime: 2000},
+	})
+	require.NoError(t, err)
+
+	svc.SyncTracker.RemoteFilesMu.RLock()
+	f := svc.SyncTracker.RemoteFiles["f.txt"]
+	svc.SyncTracker.RemoteFilesMu.RUnlock()
+
+	require.NotNil(t, f)
+	assert.Equal(t, uint64(50), f.Size, "real shrink with newer mtime must be accepted")
+	assert.Equal(t, uint64(2000), f.LastEditTime)
 }


### PR DESCRIPTION
Brings the Android Notify handler in line with desktop: peer REMOVE is debounced so a quick create-then-delete (git, initdb) still propagates, a smaller ADD is rejected only when its mtime is also older (a real git shrink is accepted), buffered removes are cancelled on disconnect, and the debounce logs match desktop for field debugging.

Note: the test file here is android-tagged and does not run on linux CI; the same logic is covered by the runnable desktop tests in #177. Verified live on-device (debounce, cancel, and shrink log evidence). Merge after #177.