### PR TITLE
fix(discovery): self-filter LAN beacons by instance id, not name

### DIFF
--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -33,6 +33,7 @@ type Beacon struct {
 	Name string `json:"n"`           // random two-word name (e.g., "Cosmic Waffle")
 	Port int    `json:"p"`           // TCP listening port for KeibiDrop
 	Ver  int    `json:"v,omitempty"` // protocol version (1)
+	ID   string `json:"i,omitempty"` // random per-session id; self-filter uses this, not Name
 }
 
 // Peer represents a discovered peer on the LAN.
@@ -44,9 +45,10 @@ type Peer struct {
 
 // Service handles both advertising and browsing for KeibiDrop peers.
 type Service struct {
-	name   string
-	port   int
-	logger *slog.Logger
+	name       string
+	instanceID string
+	port       int
+	logger     *slog.Logger
 
 	mu      sync.RWMutex
 	peers   map[string]*Peer // keyed by addr
@@ -57,10 +59,11 @@ type Service struct {
 // New creates a discovery service with a random two-word name.
 func New(port int, logger *slog.Logger) *Service {
 	return &Service{
-		name:   generateName(),
-		port:   port,
-		logger: logger.With("component", "discovery"),
-		peers:  make(map[string]*Peer),
+		name:       generateName(),
+		instanceID: generateInstanceID(),
+		port:       port,
+		logger:     logger.With("component", "discovery"),
+		peers:      make(map[string]*Peer),
 	}
 }
 
@@ -137,6 +140,11 @@ func (s *Service) Peers() []Peer {
 	return result
 }
 
+// beacon returns the advertisement this service broadcasts on the LAN.
+func (s *Service) beacon() Beacon {
+	return Beacon{Name: s.name, Port: s.port, Ver: 1, ID: s.instanceID}
+}
+
 func (s *Service) advertise(ctx context.Context) {
 	addr, err := net.ResolveUDPAddr("udp4", multicastAddr)
 	if err != nil {
@@ -151,8 +159,7 @@ func (s *Service) advertise(ctx context.Context) {
 	}
 	defer conn.Close()
 
-	beacon := Beacon{Name: s.name, Port: s.port, Ver: 1}
-	data, _ := json.Marshal(beacon)
+	data, _ := json.Marshal(s.beacon())
 
 	ticker := time.NewTicker(beaconInterval)
 	defer ticker.Stop()
@@ -168,6 +175,12 @@ func (s *Service) advertise(ctx context.Context) {
 			_, _ = conn.Write(data)
 		}
 	}
+}
+
+// isSelfBeacon reports whether a received beacon came from this service. The ID is
+// a random per-session value, so a same-named peer (different ID) is not self.
+func isSelfBeacon(b Beacon, myID string) bool {
+	return b.ID != "" && b.ID == myID
 }
 
 func (s *Service) listen(ctx context.Context) {
@@ -208,8 +221,9 @@ func (s *Service) listen(ctx context.Context) {
 			continue
 		}
 
-		// Skip our own beacons.
-		if beacon.Name == s.name {
+		// Skip our own beacons (matched by stable per-session id, not name, so a
+		// peer that randomly picked the same name is still discovered).
+		if isSelfBeacon(beacon, s.instanceID) {
 			continue
 		}
 

--- a/pkg/discovery/discovery_test.go
+++ b/pkg/discovery/discovery_test.go
@@ -155,3 +155,49 @@ func TestClearPeers_FreshBeaconsAppear(t *testing.T) {
 		t.Errorf("expected name 'Fresh Otter', got %q", peers[0].Name)
 	}
 }
+
+func TestIsSelfBeacon(t *testing.T) {
+	const myID = "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6"
+	cases := []struct {
+		desc string
+		b    Beacon
+		want bool
+	}{
+		{"own beacon, same id", Beacon{Name: "Cosmic Waffle", ID: myID}, true},
+		// Same display name but a different id is a real peer, not self. This is
+		// the collision the name-only filter used to drop.
+		{"same name, different id", Beacon{Name: "Cosmic Waffle", ID: "ffffffffffffffffffffffffffffffff"}, false},
+		{"legacy peer, no id", Beacon{Name: "Cosmic Waffle", ID: ""}, false},
+		{"different name and id", Beacon{Name: "Swift Penguin", ID: "ffffffffffffffffffffffffffffffff"}, false},
+	}
+	for _, c := range cases {
+		if got := isSelfBeacon(c.b, myID); got != c.want {
+			t.Errorf("%s: isSelfBeacon = %v, want %v", c.desc, got, c.want)
+		}
+	}
+}
+
+func TestGenerateInstanceID(t *testing.T) {
+	id := generateInstanceID()
+	if len(id) != 32 {
+		t.Errorf("len(id) = %d, want 32 hex chars", len(id))
+	}
+	if id == generateInstanceID() {
+		t.Error("two calls returned the same id")
+	}
+}
+
+func TestServiceBeaconCarriesInstanceID(t *testing.T) {
+	s := New(26001, slog.Default())
+	b := s.beacon()
+	if b.Name != s.name || b.Port != s.port {
+		t.Errorf("beacon = %+v, want name=%q port=%d", b, s.name, s.port)
+	}
+	if b.ID == "" || b.ID != s.instanceID {
+		t.Errorf("beacon.ID = %q, want service instanceID %q", b.ID, s.instanceID)
+	}
+	// A second service must advertise a different id so same-named peers differ.
+	if s2 := New(26001, slog.Default()); s2.beacon().ID == b.ID {
+		t.Error("two services share an instance id")
+	}
+}

--- a/pkg/discovery/names.go
+++ b/pkg/discovery/names.go
@@ -51,3 +51,10 @@ func generateName() string {
 	noun := nouns[rand.IntN(len(nouns))]          // #nosec G404
 	return fmt.Sprintf("%s %s", adj, noun)
 }
+
+// generateInstanceID returns a random 128-bit per-session id as 32 hex chars. It
+// only needs to be unique on the LAN, not unpredictable, so it shares the name
+// generator's non-crypto source.
+func generateInstanceID() string {
+	return fmt.Sprintf("%016x%016x", rand.Uint64(), rand.Uint64()) // #nosec G404
+}


### PR DESCRIPTION
Two devices that randomly rolled the same two-word discovery name each
treated the other's beacon as its own and dropped it, so neither showed
up in Nearby devices and local mode could not connect. Affects all
platforms (shared Go core, so the mobile AAR picks this up too).

Fix: add a random per-session instance id to the beacon and self-filter
on it instead of the display name. Backward compatible with older peers.

Verified: full Go suite + integration green; the same-name collision now
discovers on desktop (real multicast) and on Android hardware.
