### PR TITLE
test(sync): regression guards for initdb + lockfile handoff

### DIFF
--- a/tests/integration_fuse_initdb_test.go
+++ b/tests/integration_fuse_initdb_test.go
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2026 KeibiSoft S.R.L.
+// This file tests that a real initdb run on a FUSE mount syncs every file it
+// leaves on disk to the peer (no live file lost to a transient REMOVE).
+
+package tests
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// findInitdb locates an initdb binary (not on PATH on Debian/Ubuntu).
+func findInitdb() string {
+	if p, err := exec.LookPath("initdb"); err == nil {
+		return p
+	}
+	for _, p := range []string{
+		"/usr/lib/postgresql/16/bin/initdb",
+		"/usr/lib/postgresql/15/bin/initdb",
+		"/usr/local/bin/initdb",
+	} {
+		if exists(p) {
+			return p
+		}
+	}
+	return ""
+}
+
+// TestFUSEtoFUSE_InitdbPeerCompleteness runs a real initdb on Alice's FUSE mount
+// and asserts the peer ends up with every file initdb left on disk. initdb does
+// many create-delete-recreate bursts; the guard is that no transient REMOVE
+// deletes a live file on the peer. Skips where initdb is absent (e.g. CI).
+func TestFUSEtoFUSE_InitdbPeerCompleteness(t *testing.T) {
+	skipIfNoFUSE(t)
+	initdb := findInitdb()
+	if initdb == "" {
+		t.Skip("initdb not found")
+	}
+
+	tp := SetupFUSEPeerPair(t, 180*time.Second)
+	waitForFUSEMount(t, tp.AliceMountDir, 15*time.Second)
+
+	pgdata := filepath.Join(tp.AliceMountDir, "pgdata")
+	out, err := exec.Command(initdb, "-D", pgdata, "--no-locale", "-E", "UTF8").CombinedOutput()
+	require.NoError(t, err, "initdb on the FUSE mount failed: %s", out)
+
+	// The files initdb actually LEFT on disk (final state on Alice's mount).
+	want := map[string]bool{}
+	require.NoError(t, filepath.WalkDir(pgdata, func(p string, d os.DirEntry, e error) error {
+		if e == nil && !d.IsDir() {
+			rel, _ := filepath.Rel(tp.AliceMountDir, p)
+			want["/"+filepath.ToSlash(rel)] = true
+		}
+		return nil
+	}))
+	t.Logf("initdb left %d files on Alice's mount", len(want))
+	require.NotEmpty(t, want, "initdb produced no files; harness problem")
+
+	// All of Bob's RemoteFiles come from this initdb (fresh pair), so the count is
+	// the live-file-loss signal. Poll until it settles or reaches parity.
+	bobCount := func() int {
+		tp.Bob.SyncTracker.RemoteFilesMu.RLock()
+		defer tp.Bob.SyncTracker.RemoteFilesMu.RUnlock()
+		return len(tp.Bob.SyncTracker.RemoteFiles)
+	}
+	var last, stable int
+	for i := 0; i < 45; i++ {
+		time.Sleep(1 * time.Second)
+		c := bobCount()
+		if c >= len(want) {
+			break
+		}
+		if c == last {
+			if stable++; stable >= 6 {
+				break // unchanged for 6s -> settled below parity
+			}
+		} else {
+			stable = 0
+		}
+		last = c
+	}
+
+	got := bobCount()
+	missing := []string{}
+	tp.Bob.SyncTracker.RemoteFilesMu.RLock()
+	for f := range want {
+		_, ok := tp.Bob.SyncTracker.RemoteFiles[f]
+		if !ok {
+			_, ok = tp.Bob.SyncTracker.RemoteFiles[f[1:]] // tolerate a missing leading slash
+		}
+		if !ok && len(missing) < 15 {
+			missing = append(missing, f)
+		}
+	}
+	tp.Bob.SyncTracker.RemoteFilesMu.RUnlock()
+
+	t.Logf("alice_files=%d peer_files=%d shortfall=%d", len(want), got, len(want)-got)
+	if len(missing) > 0 {
+		t.Logf("sample missing (on Alice's disk, absent on peer): %v", missing)
+	}
+	require.GreaterOrEqual(t, got, len(want),
+		"peer is missing files that initdb left on disk: live-file loss")
+}

--- a/tests/integration_fuse_remove_handoff_test.go
+++ b/tests/integration_fuse_remove_handoff_test.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2026 KeibiSoft S.R.L.
+// This file guards the postgres/git handoff pattern over FUSE sync: a file
+// rewritten via delete+recreate, and a lockfile deletion, must not take live
+// files down on the peer (the PR #177 REMOVE-debounce concern).
+
+package tests
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestFUSEtoFUSE_CreateDeleteRecreateKeepsFile rewrites files via the
+// create->delete->recreate burst that initdb and git do, and asserts the peer
+// ends with every recreated file present. The receiver buffers a REMOVE for ~1s;
+// the recreate's ADD must win that race so the file is not left deleted.
+func TestFUSEtoFUSE_CreateDeleteRecreateKeepsFile(t *testing.T) {
+	skipIfNoFUSE(t)
+	tp := SetupFUSEPeerPair(t, 120*time.Second)
+	waitForFUSEMount(t, tp.AliceMountDir, 15*time.Second)
+
+	dir := filepath.Join(tp.AliceMountDir, "db")
+	require.NoError(t, os.MkdirAll(dir, 0o700))
+
+	const n = 30
+	for i := 0; i < n; i++ {
+		p := filepath.Join(dir, fmt.Sprintf("f_%d", i))
+		require.NoError(t, os.WriteFile(p, []byte("v1"), 0o600))
+		require.NoError(t, os.Remove(p))
+		require.NoError(t, os.WriteFile(p, []byte("final"), 0o600))
+	}
+
+	// Settle past the sender debounce (200ms) + receiver REMOVE buffer (~1s).
+	time.Sleep(4 * time.Second)
+
+	missing := []string{}
+	tp.Bob.SyncTracker.RemoteFilesMu.RLock()
+	for i := 0; i < n; i++ {
+		key := fmt.Sprintf("/db/f_%d", i)
+		if _, ok := tp.Bob.SyncTracker.RemoteFiles[key]; !ok {
+			missing = append(missing, key)
+		}
+	}
+	tp.Bob.SyncTracker.RemoteFilesMu.RUnlock()
+	require.Empty(t, missing, "create-delete-recreate left files deleted on the peer: %v", missing)
+}
+
+// TestFUSEtoFUSE_RemoveLockfileKeepsNeighbors mirrors the handoff's lockfile step:
+// with a set of live files plus a postmaster.pid synced to the peer, deleting only
+// the lockfile must remove just the lockfile and leave every live file intact.
+func TestFUSEtoFUSE_RemoveLockfileKeepsNeighbors(t *testing.T) {
+	skipIfNoFUSE(t)
+	tp := SetupFUSEPeerPair(t, 120*time.Second)
+	waitForFUSEMount(t, tp.AliceMountDir, 15*time.Second)
+
+	dir := filepath.Join(tp.AliceMountDir, "pgdata")
+	require.NoError(t, os.MkdirAll(dir, 0o700))
+
+	const n = 40
+	for i := 0; i < n; i++ {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, fmt.Sprintf("rel_%d", i)),
+			[]byte(fmt.Sprintf("data-%d", i)), 0o600))
+	}
+	lock := filepath.Join(dir, "postmaster.pid")
+	require.NoError(t, os.WriteFile(lock, []byte("4242\n/pgdata\n"), 0o600))
+
+	// Wait until the lockfile and the last live file have surfaced on the peer.
+	WaitForRemoteFile(t, tp.Bob.SyncTracker, "/pgdata/postmaster.pid", 30*time.Second)
+	WaitForRemoteFile(t, tp.Bob.SyncTracker, fmt.Sprintf("/pgdata/rel_%d", n-1), 30*time.Second)
+
+	// The handoff step: delete ONLY the lockfile.
+	require.NoError(t, os.Remove(lock))
+
+	// The lockfile must disappear on the peer.
+	WaitForCondition(t, 10*time.Second, 100*time.Millisecond, func() bool {
+		tp.Bob.SyncTracker.RemoteFilesMu.RLock()
+		defer tp.Bob.SyncTracker.RemoteFilesMu.RUnlock()
+		_, ok := tp.Bob.SyncTracker.RemoteFiles["/pgdata/postmaster.pid"]
+		return !ok
+	}, "lockfile removed on peer")
+
+	// Every live file must remain. Give the REMOVE buffer time to wrongly fire.
+	time.Sleep(2 * time.Second)
+	missing := []string{}
+	tp.Bob.SyncTracker.RemoteFilesMu.RLock()
+	for i := 0; i < n; i++ {
+		key := fmt.Sprintf("/pgdata/rel_%d", i)
+		if _, ok := tp.Bob.SyncTracker.RemoteFiles[key]; !ok {
+			missing = append(missing, key)
+		}
+	}
+	tp.Bob.SyncTracker.RemoteFilesMu.RUnlock()
+	require.Empty(t, missing, "deleting the lockfile took down live neighbors on the peer: %v", missing)
+}


### PR DESCRIPTION
Integration guards for the postgres/git sync handoff path, which had no coverage:

- `TestFUSEtoFUSE_InitdbPeerCompleteness`: a real `initdb` on a FUSE mount must sync every file it leaves to the peer (skips where initdb is absent, e.g. CI).
- `TestFUSEtoFUSE_CreateDeleteRecreateKeepsFile`: a create-delete-recreate burst keeps the recreated file on the peer.
- `TestFUSEtoFUSE_RemoveLockfileKeepsNeighbors`: deleting a lockfile removes only the lockfile; live neighbors stay.

All green under `make test`.