### PR TITLE
fix(fuse): guard NotRemoteSynced/HadEdits under metaMu (Release race)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,10 @@ jobs:
       - name: Run tests
         run: go test -v -count=1 -timeout 180s -skip 'BlockSizeSweep|WorkerCountSweep|PullFileProfile|BaselineComparison|FUSEReadOverhead|FUSEWriteThroughput|TransferThroughputNetem|MeasureLatency|OpenCloseLatency|ChunkLatency|PullFileThroughput|EncryptedGRPC|TransferThroughput|SecureConnThroughput|RoundTripFUSETransfer|FUSEtoFUSE_GitClone' ./tests/...
 
+      # Fast deterministic race guards in the SAME job (no extra runner) so CI stays cheap.
+      - name: Concurrency tests under -race
+        run: make test-race
+
   lint:
     runs-on: ubuntu-22.04
     steps:

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,14 @@ cross-macos-dmg: cross-macos $(DIST)
 test:
 	go test -v -count=1 -timeout 180s ./tests/...
 
+# Deterministic concurrency-race guards under the race detector. Scoped to the
+# in-process filesystem unit tests (no FUSE mount) so it is fast (~3s) and cannot
+# trip the unrelated cgofuse mount-teardown race that end-to-end FUSE tests hit
+# under -race. Covers the Release async-notify race plus the handle-reuse and
+# prefetch-rename guards.
+test-race:
+	go test -race -count=1 -timeout 90s ./pkg/filesystem/
+
 lint:
 	golangci-lint run ./...
 
@@ -442,7 +450,7 @@ android-deploy: build-android
 	adb shell am start -n com.keibisoft.keibidrop/.MainActivity
 
 .PHONY: build-cli build-kd build-static-rust-bridge build-rust build-all \
-        test lint sec install-proto protoc rust-bindings slint-preview \
+        test test-race lint sec install-proto protoc rust-bindings slint-preview \
         package-macos package-tar package-deb package-windows package-choco checksums clean-dist clean \
         run-alice run-bob \
         run-cli-alice run-cli-bob \

--- a/pkg/filesystem/fuse_directory.go
+++ b/pkg/filesystem/fuse_directory.go
@@ -609,8 +609,8 @@ func (d *Dir) OpenEx(path string, fi *winfuse.FileInfo_t) (errCode int) {
 		fh.openFileCounter.Open()
 		fh.metaMu.Lock()
 		fh.IsLocalPresent = true
-		fh.metaMu.Unlock()
 		fh.NotRemoteSynced = true
+		fh.metaMu.Unlock()
 		handleID := allocHandleID()
 		fh.CurrentHandleID = handleID
 		d.OpenFileHandlers[handleID] = &HandleEntry{FD: fd, File: fh}
@@ -1273,7 +1273,11 @@ func (d *Dir) Release(path string, fh uint64) (errCode int) {
 		delete(d.OpenFileHandlers, fh)
 
 		// SINGLE notification path: notify peer if file was created OR edited locally
-		needsNotify := (f.NotRemoteSynced || f.HadEdits) && d.OnLocalChange != nil
+		f.metaMu.RLock()
+		notRemoteSynced := f.NotRemoteSynced
+		hadEdits := f.HadEdits
+		f.metaMu.RUnlock()
+		needsNotify := (notRemoteSynced || hadEdits) && d.OnLocalChange != nil
 
 		if needsNotify {
 			cleanPath := filepath.Clean(filepath.Join(d.LocalDownloadFolder, path))
@@ -1285,7 +1289,7 @@ func (d *Dir) Release(path string, fh uint64) (errCode int) {
 
 			// logger.Info("Release lstat result", "path", path, "size", stgo.Size)
 
-			if !f.HadEdits {
+			if !hadEdits {
 				// No FUSE Write calls seen. Data arrived via fcopyfile (Finder
 				// drag-and-drop) which bypasses FUSE Write entirely. The lstat
 				// size may be partial because fcopyfile is still flushing.
@@ -1317,8 +1321,10 @@ func (d *Dir) Release(path string, fh uint64) (errCode int) {
 									Action: types.AddFile,
 									Attr:   types.StatToAttr(&recheckStat),
 								})
+								f.metaMu.Lock()
 								f.NotRemoteSynced = false
 								f.HadEdits = false
+								f.metaMu.Unlock()
 								return
 							}
 						} else {
@@ -1336,8 +1342,10 @@ func (d *Dir) Release(path string, fh uint64) (errCode int) {
 						Action: types.AddFile,
 						Attr:   types.StatToAttr(&finalStat),
 					})
+					f.metaMu.Lock()
 					f.NotRemoteSynced = false
 					f.HadEdits = false
+					f.metaMu.Unlock()
 				}()
 			} else {
 				d.OnLocalChange(types.FileEvent{
@@ -1346,8 +1354,10 @@ func (d *Dir) Release(path string, fh uint64) (errCode int) {
 					Attr:   types.StatToAttr(&stgo),
 				})
 
+				f.metaMu.Lock()
 				f.NotRemoteSynced = false
 				f.HadEdits = false
+				f.metaMu.Unlock()
 			}
 		}
 
@@ -1852,10 +1862,12 @@ func (d *Dir) Write(path string, buff []byte, offset int64, fh uint64) (errCode 
 		return n
 	}
 	f := entry.File
+	f.metaMu.Lock()
 	f.HadEdits = true
 	f.NotLocalSynced = false // Local write makes us authoritative - don't read from remote
 	f.NotRemoteSynced = true // File content changed - notify peer on Release with new size
 	f.LocalNewer = true
+	f.metaMu.Unlock()
 
 	startPwrite := time.Now()
 	n, err := platPwrite(entry.FD, buff, offset)
@@ -1892,8 +1904,12 @@ func (d *Dir) Write(path string, buff []byte, offset int64, fh uint64) (errCode 
 	startRemote := time.Now()
 	d.RemoteFilesLock.Lock()
 	if rf, exists := d.RemoteFiles[path]; exists {
+		// Guard under metaMu: Read/OpenEx read these on the same *File via a
+		// different lock (metaMu). metaMu is innermost; RemoteFilesLock stays held.
+		rf.metaMu.Lock()
 		rf.NotLocalSynced = false
 		rf.LocalNewer = true
+		rf.metaMu.Unlock()
 	}
 	d.RemoteFilesLock.Unlock()
 	remoteTime := time.Since(startRemote)

--- a/pkg/filesystem/release_async_notify_race_test.go
+++ b/pkg/filesystem/release_async_notify_race_test.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// ABOUTME: Mount-free -race guard for the Release async-notify data race.
+// ABOUTME: Drives CreateEx/OpenEx/Release directly so it never mounts FUSE.
+
+package filesystem
+
+import (
+	"fmt"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/KeibiSoft/KeibiDrop/pkg/types"
+	"github.com/stretchr/testify/require"
+	winfuse "github.com/winfsp/cgofuse/fuse"
+)
+
+// TestReleaseAsyncNotifyRace reproduces the data race on a File's
+// NotRemoteSynced/HadEdits sync-state bools. A file created without any FUSE
+// Write takes the size-stabilization branch in Release, which spawns a
+// long-lived goroutine that (pre-fix) cleared those two bools holding no lock.
+// Closing, reopening, and closing the same path again spawns several such
+// goroutines on the SAME *File; they all wake ~1.7s later and write the bools
+// concurrently. The fix brings every access under metaMu (the File's innermost
+// lock), so this is green with the fix and fails under -race without it.
+//
+// It runs entirely in-process (no host.Mount), so it cannot trip the unrelated
+// pre-existing cgofuse teardown race that an end-to-end FUSE test hits under
+// -race. That keeps this guard deterministic and cheap for CI.
+func TestReleaseAsyncNotifyRace(t *testing.T) {
+	saveDir := t.TempDir()
+	d := newTestDir(saveDir)
+	d.OpenStreamProvider = func() types.FileStreamProvider { return nil }
+
+	const numFiles = 16
+	const reopenCycles = 4 // func2 goroutines per file = reopenCycles + 1
+
+	// Count surfaced files so the test waits for the racy window (all func2
+	// reaching the bool write) before returning, and verifies they all notify.
+	var mu sync.Mutex
+	fired := make(map[string]int)
+	d.OnLocalChange = func(ev types.FileEvent) {
+		mu.Lock()
+		fired[ev.Path]++
+		mu.Unlock()
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < numFiles; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			path := fmt.Sprintf("/empty_%04d", idx)
+
+			fi := &winfuse.FileInfo_t{}
+			if rc := d.CreateEx(path, 0644, fi); rc != 0 {
+				t.Errorf("CreateEx %s: %d", path, rc)
+				return
+			}
+			// No Write -> HadEdits stays false -> the func2 branch.
+			d.Release(path, fi.Fh)
+
+			for k := 0; k < reopenCycles; k++ {
+				fo := &winfuse.FileInfo_t{Flags: syscall.O_RDWR}
+				if rc := d.OpenEx(path, fo); rc != 0 {
+					t.Errorf("OpenEx %s: %d", path, rc)
+					return
+				}
+				d.Release(path, fo.Fh)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	// Each file's func2 fires OnLocalChange ~1.7s after Release. Wait until
+	// every file has surfaced at least once (the race, if present, has fired
+	// by then) or fail.
+	deadline := time.Now().Add(30 * time.Second)
+	for {
+		mu.Lock()
+		distinct := len(fired)
+		mu.Unlock()
+		if distinct >= numFiles {
+			break
+		}
+		if time.Now().After(deadline) {
+			require.GreaterOrEqual(t, distinct, numFiles,
+				"only %d/%d empty files surfaced via OnLocalChange", distinct, numFiles)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}

--- a/pkg/filesystem/types.go
+++ b/pkg/filesystem/types.go
@@ -262,9 +262,10 @@ type File struct {
 	// through DIFFERENT map locks (AllFileMap/AfmLock vs OpenFileHandlers/
 	// OpenMapLock) — which therefore do NOT mutually exclude: the *stat struct
 	// (Getattr mutates it in place while Read/OpenEx read Size/Mode) and the
-	// sync-state bools IsLocalPresent/LocalNewer/NotLocalSynced. Confirmed by
-	// the race detector. Always taken INNERMOST: after any map lock, and never
-	// acquire a map lock while holding it (so it cannot deadlock).
+	// sync-state bools IsLocalPresent/LocalNewer/NotLocalSynced/NotRemoteSynced/
+	// HadEdits. Confirmed by the race detector. Always taken INNERMOST: after any
+	// map lock, and never acquire a map lock while holding it (so it cannot
+	// deadlock).
 	metaMu sync.RWMutex
 }
 


### PR DESCRIPTION
Release's size-stabilization goroutine cleared NotRemoteSynced/HadEdits
unlocked; reopening a file runs two such goroutines on one *File and races
the bools. Guard them under metaMu at every site, plus the Write handler's
RemoteFiles-entry NotLocalSynced/LocalNewer writes (found in review).

Pre-existing on main, latent because the suite never ran -race. Adds a
mount-free -race guard + a make test-race CI step. Verified under -race on
Linux and Windows/amd64, no transfer regression.
