### PR TITLE
fix(fuse): tighten File sync-state locking under metaMu

### DIFF
--- a/pkg/filesystem/chmod_stat_race_test.go
+++ b/pkg/filesystem/chmod_stat_race_test.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// ABOUTME: Mount-free -race guard: Chmod/Chown write f.stat.Mode under a map lock
+// ABOUTME: while OpenEx reads it (cacheMode) under metaMu on the same *File.
+
+package filesystem
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"syscall"
+	"testing"
+
+	"github.com/KeibiSoft/KeibiDrop/pkg/types"
+	winfuse "github.com/winfsp/cgofuse/fuse"
+)
+
+// TestChmodStatModeRace drives Chmod and Chown (which write f.stat.Mode/.Uid/.Gid
+// on the AllFileMap/RemoteFiles entry) concurrently with OpenEx, which reads
+// fh.stat.Mode (cacheMode) under metaMu, on the SAME *File (the test aliases the
+// AddRemoteFile entry into AllFileMap too). Before the fix Chmod/Chown wrote f.stat
+// under the map lock only, a different lock than the metaMu readers, so -race
+// flagged the .Mode access. Getattr is the control: it holds AfmLock across its
+// whole body, so it is excluded from Chmod/Chown and must never appear in a race
+// report. Mount-free, so it cannot trip the unrelated cgofuse teardown race.
+func TestChmodStatModeRace(t *testing.T) {
+	d := newTestDir(t.TempDir())
+	d.OpenStreamProvider = func() types.FileStreamProvider { return nil }
+	d.OnLocalChange = nil
+	lg := nopLogger()
+
+	const numFiles = 8
+	const iters = 400
+	var wg sync.WaitGroup
+
+	for i := 0; i < numFiles; i++ {
+		path := fmt.Sprintf("/m_%04d", i)
+		name := fmt.Sprintf("m_%04d", i)
+		st := &winfuse.Stat_t{Size: 4096, Mode: 0o644 | winfuse.S_IFREG}
+		st.Mtim.Sec = 1
+		_ = d.AddRemoteFile(lg, path, name, st)
+
+		// Alias the same *File into AllFileMap so Chmod/Chown hit it under AfmLock.
+		d.RemoteFilesLock.RLock()
+		f := d.RemoteFiles[path]
+		d.RemoteFilesLock.RUnlock()
+		if f == nil {
+			t.Fatalf("no remote file for %s", path)
+		}
+		d.AfmLock.Lock()
+		d.AllFileMap[path] = f
+		d.AfmLock.Unlock()
+		_ = os.WriteFile(filepath.Join(d.LocalDownloadFolder, name), make([]byte, 4096), 0644)
+
+		wg.Add(4)
+		go func(p string) { // Chmod: writes f.stat.Mode
+			defer wg.Done()
+			for k := 0; k < iters; k++ {
+				d.Chmod(p, 0o600|uint32(k&7))
+			}
+		}(path)
+		go func(p string) { // Chown: writes f.stat.Uid/.Gid/.Mode
+			defer wg.Done()
+			for k := 0; k < iters; k++ {
+				d.Chown(p, uint32(k&3), uint32(k&3))
+			}
+		}(path)
+		go func(p string) { // OpenEx: reads fh.stat.Mode (cacheMode) under metaMu
+			defer wg.Done()
+			for k := 0; k < iters; k++ {
+				fi := &winfuse.FileInfo_t{Flags: syscall.O_RDONLY}
+				d.OpenEx(p, fi)
+				if fi.Fh != 0 {
+					d.Release(p, fi.Fh)
+				}
+			}
+		}(path)
+		go func(p string) { // Getattr: control (AfmLock-excluded), must stay clean
+			defer wg.Done()
+			for k := 0; k < iters; k++ {
+				var s winfuse.Stat_t
+				d.Getattr(p, &s, 0)
+			}
+		}(path)
+	}
+	wg.Wait()
+}

--- a/pkg/filesystem/fuse_directory.go
+++ b/pkg/filesystem/fuse_directory.go
@@ -138,14 +138,21 @@ func (d *Dir) Chmod(path string, mode uint32) (errCode int) {
 
 	d.AfmLock.Lock()
 	if f, ok := d.AllFileMap[path]; ok && f.stat != nil {
+		// Guard the stat write under metaMu: OpenEx/prefetch read f.stat.Mode on the
+		// same *File via metaMu (a different lock than AfmLock), so a bare write here
+		// races their reads. metaMu is innermost; AfmLock stays held. Take a value
+		// snapshot of the stat under metaMu so the notify below builds its Attr from a
+		// stable copy, without holding either lock across StatToAttr's allocation.
+		f.metaMu.Lock()
 		applyMode(f.stat)
-		stat := f.stat
+		statSnap := *f.stat
+		f.metaMu.Unlock()
 		d.AfmLock.Unlock()
 		if d.OnLocalChange != nil {
 			d.OnLocalChange(types.FileEvent{
 				Path:   path,
 				Action: types.EditFile,
-				Attr:   types.StatToAttr(stat),
+				Attr:   types.StatToAttr(&statSnap),
 			})
 		}
 		return 0
@@ -170,7 +177,9 @@ func (d *Dir) Chmod(path string, mode uint32) (errCode int) {
 
 	d.RemoteFilesLock.Lock()
 	if rf, ok := d.RemoteFiles[path]; ok && rf.stat != nil {
+		rf.metaMu.Lock()
 		applyMode(rf.stat)
+		rf.metaMu.Unlock()
 	}
 	d.RemoteFilesLock.Unlock()
 
@@ -216,7 +225,10 @@ func (d *Dir) Chown(path string, uid uint32, gid uint32) (errCode int) {
 
 	d.AfmLock.Lock()
 	if f, ok := d.AllFileMap[path]; ok && f.stat != nil {
+		// metaMu guards f.stat against the OpenEx/prefetch metaMu readers (see Chmod).
+		f.metaMu.Lock()
 		applyOwner(f.stat)
+		f.metaMu.Unlock()
 	}
 	d.AfmLock.Unlock()
 
@@ -228,7 +240,9 @@ func (d *Dir) Chown(path string, uid uint32, gid uint32) (errCode int) {
 
 	d.RemoteFilesLock.Lock()
 	if rf, ok := d.RemoteFiles[path]; ok && rf.stat != nil {
+		rf.metaMu.Lock()
 		applyOwner(rf.stat)
+		rf.metaMu.Unlock()
 	}
 	d.RemoteFilesLock.Unlock()
 

--- a/pkg/filesystem/fuse_directory.go
+++ b/pkg/filesystem/fuse_directory.go
@@ -401,6 +401,16 @@ func (d *Dir) OpenEx(path string, fi *winfuse.FileInfo_t) (errCode int) {
 	hasCreate := flags&syscall.O_CREAT != 0
 	hasExcl := flags&syscall.O_EXCL != 0
 
+	// Snapshot whether this path is a known remote file BEFORE taking AfmLock.
+	// This check used to run in the !ok branch below while AfmLock was held, which
+	// inverts the codebase lock order (RemoteFilesLock -> Adm -> AfmLock, used by
+	// Getattr and AddRemoteFile) and deadlocks under Go's RWMutex writer-preference
+	// when an AddRemoteFile writer is pending. The value only seeds a new File's
+	// LocalNewer below; a microsecond-stale read self-corrects on the next announce.
+	d.RemoteFilesLock.RLock()
+	_, isRemoteFile := d.RemoteFiles[path]
+	d.RemoteFilesLock.RUnlock()
+
 	d.AfmLock.Lock()
 	fh, ok := d.AllFileMap[path]
 
@@ -419,11 +429,6 @@ func (d *Dir) OpenEx(path string, fi *winfuse.FileInfo_t) (errCode int) {
 			d.AfmLock.Unlock()
 			return -winfuse.EEXIST
 		}
-
-		// Check if this is a remote file (don't mark as LocalNewer if so)
-		d.RemoteFilesLock.RLock()
-		_, isRemoteFile := d.RemoteFiles[path]
-		d.RemoteFilesLock.RUnlock()
 
 		if fileExists || hasCreate {
 			fh = &File{
@@ -515,7 +520,9 @@ func (d *Dir) OpenEx(path string, fi *winfuse.FileInfo_t) (errCode int) {
 	if needsRemark && hasRemote {
 		d.RemoteFilesLock.Lock()
 		if rf, ok := d.RemoteFiles[path]; ok {
+			rf.metaMu.Lock()
 			rf.NotLocalSynced = true
+			rf.metaMu.Unlock()
 		}
 		d.RemoteFilesLock.Unlock()
 	}
@@ -846,14 +853,17 @@ func (d *Dir) Getattr(path string, stat *winfuse.Stat_t, fh uint64) (errCode int
 	if isRemote {
 		remFile, okRemote := d.RemoteFiles[path]
 		if okRemote {
-			// Guard this File's stat under its metaMu for the whole branch: it is
+			// See if the file is also present locally. Do the lstat BEFORE taking
+			// metaMu: the syscall needs nothing from remFile (cleanPath derives from
+			// path only), and holding metaMu across it would stall every other op on
+			// this File (Read/OpenEx/Write/Release) behind a slow lstat.
+			stgo, lstatErr := platLstat(cleanPath)
+			// Guard remFile.stat under its metaMu for the rest of the branch: it is
 			// mutated in place below while Read/OpenEx read it via a DIFFERENT lock
 			// (OpenMapLock). Every path here returns, so the defer releases metaMu
-			// (innermost) before the map locks — deadlock-free.
+			// (innermost) before the map locks, so there is no deadlock.
 			remFile.metaMu.Lock()
 			defer remFile.metaMu.Unlock()
-			// File is on remote, let's see if it is also locally.
-			stgo, lstatErr := platLstat(cleanPath)
 			if lstatErr != nil {
 				// Ok file not locally. Just add it, and download it on Open.
 				copyFusestatFromFusestat(stat, remFile.stat)
@@ -1935,10 +1945,12 @@ func (d *Dir) Read(path string, buff []byte, offset int64, fh uint64) (errCode i
 		fd = entry.FD
 		pool = f.StreamPool
 		cacheFD = f.CacheFD
-		notLocalSynced = f.NotLocalSynced
 		bitmap = f.Bitmap
-		// Read f.stat under metaMu: Getattr mutates the same struct in place.
+		// Read f.NotLocalSynced and f.stat under metaMu: Getattr mutates stat in
+		// place and the notify handlers write NotLocalSynced, both via a different
+		// lock than this one (OpenMapLock).
 		f.metaMu.RLock()
+		notLocalSynced = f.NotLocalSynced
 		if f.stat != nil {
 			remoteFileSize = f.stat.Size
 		}
@@ -2262,7 +2274,14 @@ func (d *Dir) AddRemoteFile(logger *slog.Logger, path string, name string, stat 
 	if existing, ok := d.RemoteFiles[path]; ok {
 		oldSize := existing.stat.Size
 		sizeChanged := oldSize != stat.Size
+		// Snapshot the incoming size now, BEFORE `existing.stat = stat` aliases this
+		// struct into existing.stat: the size-changed branch reads it for os.Truncate
+		// AFTER releasing RemoteFilesLock, where Getattr can mutate existing.stat
+		// (the same struct) in place. The local copy keeps that read race-free.
+		newSize := stat.Size
+		existing.metaMu.Lock()
 		existing.LocalNewer = false // Remote has newer content.
+		existing.metaMu.Unlock()
 
 		// Reject stale ADD_FILE only when the incoming mtime is older than
 		// what we already have. A debounced notification for a temp file can
@@ -2283,7 +2302,9 @@ func (d *Dir) AddRemoteFile(logger *slog.Logger, path string, name string, stat 
 
 		if sizeChanged {
 			// Size changed: cancel old prefetch, reset bitmap, re-download.
+			existing.metaMu.Lock()
 			existing.NotLocalSynced = true
+			existing.metaMu.Unlock()
 			existing.Download.Reset(uint64(stat.Size))
 			if existing.PrefetchCancel != nil {
 				existing.PrefetchCancel()
@@ -2293,10 +2314,12 @@ func (d *Dir) AddRemoteFile(logger *slog.Logger, path string, name string, stat 
 			d.RemoteFilesLock.Unlock()
 
 			// Only truncate if size actually changed — truncating to the same size
-			// zeros out content that a previous prefetch already wrote.
+			// zeros out content that a previous prefetch already wrote. Use the
+			// snapshot, not stat.Size: stat is now aliased to existing.stat, which
+			// Getattr may be mutating now that RemoteFilesLock is released.
 			if existing.RealPathOfFile != "" {
-				if truncErr := os.Truncate(existing.RealPathOfFile, stat.Size); truncErr != nil && !os.IsNotExist(truncErr) {
-					logger.Warn("Failed to truncate cache file to new size", "path", existing.RealPathOfFile, "size", stat.Size, "error", truncErr)
+				if truncErr := os.Truncate(existing.RealPathOfFile, newSize); truncErr != nil && !os.IsNotExist(truncErr) {
+					logger.Warn("Failed to truncate cache file to new size", "path", existing.RealPathOfFile, "size", newSize, "error", truncErr)
 				}
 			}
 
@@ -2315,7 +2338,9 @@ func (d *Dir) AddRemoteFile(logger *slog.Logger, path string, name string, stat 
 			// on-demand, mirroring EditRemoteFile. Without this, a peer that
 			// already fully cached the file keeps serving stale content.
 			if incomingMtime > existingMtime {
+				existing.metaMu.Lock()
 				existing.NotLocalSynced = true
+				existing.metaMu.Unlock()
 				existing.Download.Reset(uint64(stat.Size))
 				if existing.PrefetchCancel != nil {
 					existing.PrefetchCancel()
@@ -2324,7 +2349,9 @@ func (d *Dir) AddRemoteFile(logger *slog.Logger, path string, name string, stat 
 				existing.Bitmap = NewChunkBitmap(stat.Size)
 			} else if existing.Bitmap != nil && !existing.Bitmap.IsComplete() {
 				// Same mtime, still incomplete — keep fetching the rest on-demand.
+				existing.metaMu.Lock()
 				existing.NotLocalSynced = true
+				existing.metaMu.Unlock()
 			}
 			d.RemoteFilesLock.Unlock()
 			d.AfmLock.Lock()
@@ -2390,7 +2417,9 @@ func (d *Dir) startPrefetch(logger *slog.Logger, f *File, path string) {
 
 	if f.Bitmap.IsComplete() {
 		os.Remove(bmPath)
+		f.metaMu.Lock()
 		f.NotLocalSynced = false
+		f.metaMu.Unlock()
 		return
 	}
 
@@ -2401,12 +2430,16 @@ func (d *Dir) startPrefetch(logger *slog.Logger, f *File, path string) {
 		logger.Warn("Prefetch: failed to create dirs", "path", realPath, "error", err)
 	}
 	if _, statErr := os.Stat(realPath); os.IsNotExist(statErr) { // #nosec G304
+		// Snapshot the mode off f.stat under metaMu (Getattr mutates the struct in
+		// place); do NOT hold metaMu across the os.OpenFile below.
 		fileMode := os.FileMode(0644)
+		f.metaMu.RLock()
 		if f.stat != nil {
 			fileMode = os.FileMode(f.stat.Mode & 0o777)
-			if fileMode == 0 {
-				fileMode = 0644
-			}
+		}
+		f.metaMu.RUnlock()
+		if fileMode == 0 {
+			fileMode = 0644
 		}
 		lf, createErr := os.OpenFile(realPath, os.O_CREATE|os.O_WRONLY, fileMode)
 		if createErr != nil {
@@ -2471,12 +2504,16 @@ func (d *Dir) prefetchFile(ctx context.Context, logger *slog.Logger, f *File, pa
 		return
 	}
 
+	// Snapshot the mode off f.stat under metaMu (Getattr mutates the struct in
+	// place); do NOT hold metaMu across the os.OpenFile below.
 	fileMode := os.FileMode(0644)
+	f.metaMu.RLock()
 	if f.stat != nil {
 		fileMode = os.FileMode(f.stat.Mode & 0o777)
-		if fileMode == 0 {
-			fileMode = 0644
-		}
+	}
+	f.metaMu.RUnlock()
+	if fileMode == 0 {
+		fileMode = 0644
 	}
 	lf, err := os.OpenFile(realPath, os.O_CREATE|os.O_WRONLY, fileMode)
 	if err != nil {
@@ -2539,7 +2576,9 @@ func (d *Dir) prefetchFile(ctx context.Context, logger *slog.Logger, f *File, pa
 
 	if bitmap.IsComplete() {
 		// logger.Info("Prefetch complete — all chunks downloaded", "fileSize", bitmap.FileSize())
+		f.metaMu.Lock()
 		f.NotLocalSynced = false
+		f.metaMu.Unlock()
 		os.Remove(BitmapPath(realPath))
 	} else {
 		// logger.Info("Prefetch finished with gaps", "progress", bitmap.Progress())
@@ -2591,13 +2630,15 @@ func (d *Dir) EditRemoteFile(logger *slog.Logger, path string, name string, stat
 	}
 
 	// logger.Info("Remote file edited", "path", path, "mtime", stat.Mtim.Time())
+	// Content changed: mark unsynced and reset bitmap + cancel prefetch so reads
+	// re-fetch on-demand. The field stores go under metaMu (innermost); the
+	// PrefetchCancel/Download/Bitmap resets stay outside it.
 	f.metaMu.Lock()
 	f.stat = stat
-	f.LocalNewer = false // Remote has newer content.
+	f.LocalNewer = false    // Remote has newer content.
+	f.NotLocalSynced = true // Re-fetch the edited bytes on the next read.
 	f.metaMu.Unlock()
 
-	// Content changed: reset bitmap + cancel prefetch so reads re-fetch on-demand.
-	f.NotLocalSynced = true
 	f.Download.Reset(uint64(stat.Size))
 	if f.PrefetchCancel != nil {
 		f.PrefetchCancel()

--- a/pkg/filesystem/getattr_metamu_race_test.go
+++ b/pkg/filesystem/getattr_metamu_race_test.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// ABOUTME: -race guard that Getattr keeps remFile.stat under metaMu after the
+// ABOUTME: lstat was hoisted out of the lock (catches a future metaMu drop).
+
+package filesystem
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"syscall"
+	"testing"
+
+	"github.com/KeibiSoft/KeibiDrop/pkg/types"
+	winfuse "github.com/winfsp/cgofuse/fuse"
+)
+
+// TestGetattrStatMetaMu runs Getattr (which lstats then mutates remFile.stat in
+// place) concurrently with OpenEx (which reads remFile.stat) on the same remote
+// file that also exists on disk, so Getattr takes its size/mtime mutation path.
+// Both must touch remFile.stat under metaMu; if the lstat hoist ever drops that
+// guard, -race flags the stat read/write. The lstat is now outside metaMu; the
+// stat access stays inside it.
+//
+// All files are seeded BEFORE the racing phase on purpose: a concurrent
+// AddRemoteFile (a pending RemoteFilesLock writer) exposes a SEPARATE,
+// pre-existing Getattr/OpenEx lock-order deadlock (Getattr holds
+// RemoteFilesLock.RLock across Adm+AfmLock while OpenEx holds AfmLock and wants
+// RemoteFilesLock.RLock). That is out of scope for this metaMu guard.
+func TestGetattrStatMetaMu(t *testing.T) {
+	saveDir := t.TempDir()
+	d := newTestDir(saveDir)
+	d.OpenStreamProvider = func() types.FileStreamProvider { return nil }
+	lg := nopLogger()
+
+	const numFiles = 12
+	const iters = 200
+
+	paths := make([]string, numFiles)
+	for i := 0; i < numFiles; i++ {
+		path := fmt.Sprintf("/g_%04d", i)
+		name := fmt.Sprintf("g_%04d", i)
+		paths[i] = path
+		// Remote file with an OLD mtime so the on-disk copy looks newer and
+		// Getattr takes the stat-mutation branch.
+		rstat := &winfuse.Stat_t{Size: 64}
+		rstat.Mtim.Sec = 1
+		_ = d.AddRemoteFile(lg, path, name, rstat)
+		// On-disk copy at cleanPath (LocalDownloadFolder/name) so platLstat hits.
+		if err := os.WriteFile(filepath.Join(saveDir, name), make([]byte, 64), 0644); err != nil {
+			t.Fatalf("write local %s: %v", name, err)
+		}
+	}
+
+	var wg sync.WaitGroup
+	for _, path := range paths {
+		wg.Add(2)
+		go func(p string) {
+			defer wg.Done()
+			for k := 0; k < iters; k++ {
+				var gs winfuse.Stat_t
+				d.Getattr(p, &gs, 0)
+			}
+		}(path)
+		go func(p string) {
+			defer wg.Done()
+			for k := 0; k < iters; k++ {
+				fi := &winfuse.FileInfo_t{Flags: syscall.O_RDONLY}
+				d.OpenEx(p, fi)
+				if fi.Fh != 0 {
+					d.Release(p, fi.Fh)
+				}
+			}
+		}(path)
+	}
+	wg.Wait()
+}

--- a/pkg/filesystem/getattr_open_deadlock_test.go
+++ b/pkg/filesystem/getattr_open_deadlock_test.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// ABOUTME: Guards the Getattr/OpenEx/AddRemoteFile lock-order deadlock: OpenEx
+// ABOUTME: must not take RemoteFilesLock while holding AfmLock.
+
+package filesystem
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/KeibiSoft/KeibiDrop/pkg/types"
+	winfuse "github.com/winfsp/cgofuse/fuse"
+)
+
+// TestGetattrOpenAddNoDeadlock hammers Getattr, OpenEx, and AddRemoteFile on the
+// same paths concurrently. Getattr holds RemoteFilesLock.RLock across Adm+AfmLock;
+// OpenEx (not-in-AllFileMap branch) held AfmLock while taking RemoteFilesLock.RLock
+// (inverted order); a pending AddRemoteFile RemoteFilesLock.Lock then closes a
+// 3-way cycle under Go's RWMutex writer-preference. Before the fix this hangs;
+// after OpenEx snapshots the remote-file check before AfmLock, it completes. A
+// watchdog turns a hang into a fast, explicit failure with a goroutine dump.
+func TestGetattrOpenAddNoDeadlock(t *testing.T) {
+	saveDir := t.TempDir()
+	d := newTestDir(saveDir)
+	d.OpenStreamProvider = func() types.FileStreamProvider { return nil }
+	lg := nopLogger()
+
+	const numPaths = 8
+	const iters = 400
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		var wg sync.WaitGroup
+		for i := 0; i < numPaths; i++ {
+			path := fmt.Sprintf("/d_%04d", i)
+			name := fmt.Sprintf("d_%04d", i)
+			// On-disk copy so Getattr lstat hits and OpenEx sees fileExists.
+			_ = os.WriteFile(filepath.Join(saveDir, name), make([]byte, 64), 0644)
+
+			wg.Add(3)
+			go func(p string) { // Getattr storm
+				defer wg.Done()
+				for k := 0; k < iters; k++ {
+					var gs winfuse.Stat_t
+					d.Getattr(p, &gs, 0)
+				}
+			}(path)
+			go func(p string) { // OpenEx (hits the not-in-map branch early)
+				defer wg.Done()
+				for k := 0; k < iters; k++ {
+					fi := &winfuse.FileInfo_t{Flags: syscall.O_RDONLY}
+					d.OpenEx(p, fi)
+					if fi.Fh != 0 {
+						d.Release(p, fi.Fh)
+					}
+				}
+			}(path)
+			go func(p, n string) { // AddRemoteFile: pending RemoteFilesLock writer
+				defer wg.Done()
+				for k := 0; k < iters; k++ {
+					st := &winfuse.Stat_t{Size: int64(64 + k%3)}
+					st.Mtim.Sec = int64(k + 1)
+					_ = d.AddRemoteFile(lg, p, n, st)
+				}
+			}(path, name)
+		}
+		wg.Wait()
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(25 * time.Second):
+		buf := make([]byte, 1<<20)
+		n := runtime.Stack(buf, true)
+		t.Fatalf("DEADLOCK: Getattr/OpenEx/AddRemoteFile did not finish in 25s\n%s", buf[:n])
+	}
+}

--- a/pkg/filesystem/remote_prefetch_race_test.go
+++ b/pkg/filesystem/remote_prefetch_race_test.go
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// ABOUTME: Mount-free -race guard for prefetch/Read/Getattr/AddRemoteFile racing
+// ABOUTME: on one *File's NotLocalSynced and stat (prefetch writes, Read reads).
+
+package filesystem
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"syscall"
+	"testing"
+
+	"github.com/KeibiSoft/KeibiDrop/pkg/types"
+	winfuse "github.com/winfsp/cgofuse/fuse"
+)
+
+// TestRemotePrefetchStateRace drives, on the SAME *File (the one AddRemoteFile
+// publishes into RemoteFiles/AllFileMap), the concurrent access classes that touch
+// its sync-state (NotLocalSynced) and stat through different map locks, so the Go
+// race detector flags every access that is not yet under metaMu. It mounts no FUSE
+// and never calls Dir.Write, isolating these accesses.
+//
+// Two file pools, on purpose, so neither trips the SEPARATE (out-of-scope) Bitmap
+// or PrefetchCancel pointer race (those have their own guards; the os.Truncate
+// stat.Size race lives in getattr_open_deadlock_test.go):
+//
+//	Pool C (single-chunk, prefetch completes): the prefetch goroutine writes
+//	  NotLocalSynced and reads stat.Mode while Read reads NotLocalSynced and
+//	  Getattr mutates stat. AddRemoteFile is not run here, so the Bitmap pointer
+//	  is never replaced.
+//	Pool A (multi-chunk, prefetch never completes): AddRemoteFile holds size AND
+//	  mtime CONSTANT, so it stays on the same-size/incomplete NotLocalSynced-write
+//	  branch and never replaces the Bitmap pointer, racing Read's NotLocalSynced read.
+func TestRemotePrefetchStateRace(t *testing.T) {
+	saveDir := t.TempDir()
+	d := newTestDir(saveDir)
+	provider := &slowStreamProvider{content: make([]byte, 4096)}
+	d.OpenStreamProvider = func() types.FileStreamProvider { return provider }
+	d.PrefetchOnOpen = true
+	d.FsCtx = context.Background()
+	d.PrefetchSem = make(chan struct{}, 8)
+	lg := nopLogger()
+
+	const numFiles = 10
+	const iters = 200
+	// Multi-chunk so the single-shot slow stream sets only chunk 0; the bitmap
+	// stays incomplete and AddRemoteFile's same-size branch keeps writing NotLocalSynced.
+	const bigSize = int64(4*ChunkSize + 7)
+
+	var wg sync.WaitGroup
+
+	// ---- Pool C: prefetch (writes NotLocalSynced/reads stat) vs Read vs Getattr.
+	for i := 0; i < numFiles; i++ {
+		path := fmt.Sprintf("/c_%04d", i)
+		name := fmt.Sprintf("c_%04d", i)
+
+		// Remote file, single chunk (prefetch completes), OLD mtime so Getattr's
+		// on-disk-newer stat-mutation branch fires.
+		seed := &winfuse.Stat_t{Size: 4096, Mode: 0o644 | winfuse.S_IFREG}
+		seed.Mtim.Sec = 1
+		if err := d.AddRemoteFile(lg, path, name, seed); err != nil {
+			t.Fatalf("AddRemoteFile seed C failed: %v", err)
+		}
+		// On-disk copy with a NEWER mtime so Getattr mutates stat in place.
+		if err := os.WriteFile(filepath.Join(saveDir, name), make([]byte, 4096), 0644); err != nil {
+			t.Fatalf("write local C %s: %v", name, err)
+		}
+
+		// (a) prefetchFile directly, sequentially, in ONE goroutine per File: writes
+		// f.NotLocalSynced and reads f.stat.Mode, no PrefetchCancel.
+		wg.Add(1)
+		go func(p, n string) {
+			defer wg.Done()
+			d.RemoteFilesLock.RLock()
+			f := d.RemoteFiles[p]
+			d.RemoteFilesLock.RUnlock()
+			if f == nil {
+				return
+			}
+			realPath := filepath.Join(saveDir, n)
+			for k := 0; k < iters; k++ {
+				d.prefetchFile(context.Background(), lg, f, p, realPath)
+			}
+		}(path, name)
+
+		// (b) Read storm on an open handle: reads f.NotLocalSynced.
+		wg.Add(1)
+		go func(p string) {
+			defer wg.Done()
+			fi := &winfuse.FileInfo_t{Flags: syscall.O_RDONLY}
+			if d.OpenEx(p, fi) != 0 || fi.Fh == 0 {
+				return
+			}
+			defer d.Release(p, fi.Fh)
+			buf := make([]byte, 256)
+			for k := 0; k < iters; k++ {
+				d.Read(p, buf, 0, fi.Fh)
+			}
+		}(path)
+
+		// (c) Getattr storm: mutates remFile.stat in place (on-disk copy newer).
+		wg.Add(1)
+		go func(p string) {
+			defer wg.Done()
+			for k := 0; k < iters; k++ {
+				var gs winfuse.Stat_t
+				d.Getattr(p, &gs, 0)
+			}
+		}(path)
+	}
+
+	// ---- Pool A: AddRemoteFile same-size NotLocalSynced write vs Read's read.
+	for i := 0; i < numFiles; i++ {
+		path := fmt.Sprintf("/a_%04d", i)
+		name := fmt.Sprintf("a_%04d", i)
+
+		seed := &winfuse.Stat_t{Size: bigSize, Mode: 0o644 | winfuse.S_IFREG}
+		seed.Mtim.Sec = 1
+		if err := d.AddRemoteFile(lg, path, name, seed); err != nil {
+			t.Fatalf("AddRemoteFile seed A failed: %v", err)
+		}
+
+		// (b) Read storm: reads f.NotLocalSynced on the open handle.
+		wg.Add(1)
+		go func(p string) {
+			defer wg.Done()
+			fi := &winfuse.FileInfo_t{Flags: syscall.O_RDONLY}
+			if d.OpenEx(p, fi) != 0 || fi.Fh == 0 {
+				return
+			}
+			defer d.Release(p, fi.Fh)
+			buf := make([]byte, 256)
+			for k := 0; k < iters; k++ {
+				d.Read(p, buf, 0, fi.Fh)
+			}
+		}(path)
+
+		// (d) AddRemoteFile storm: CONSTANT size and mtime (equal to the seed) so it
+		// stays on the same-size/incomplete NotLocalSynced-write branch and never
+		// replaces the Bitmap pointer. Races that write against Read's NotLocalSynced read.
+		wg.Add(1)
+		go func(p, n string) {
+			defer wg.Done()
+			for k := 0; k < iters; k++ {
+				st := &winfuse.Stat_t{Size: bigSize, Mode: 0o644 | winfuse.S_IFREG}
+				st.Mtim.Sec = 1
+				_ = d.AddRemoteFile(lg, p, n, st)
+			}
+		}(path, name)
+	}
+
+	wg.Wait()
+}

--- a/pkg/filesystem/remote_sync_state_race_test.go
+++ b/pkg/filesystem/remote_sync_state_race_test.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// ABOUTME: Mount-free -race guard for the remote sync-state race: OpenEx reads
+// ABOUTME: File.LocalNewer under metaMu while AddRemoteFile writes it un-metaMu.
+
+package filesystem
+
+import (
+	"fmt"
+	"sync"
+	"syscall"
+	"testing"
+
+	"github.com/KeibiSoft/KeibiDrop/pkg/types"
+	winfuse "github.com/winfsp/cgofuse/fuse"
+)
+
+// TestRemoteSyncStateRace drives the OpenEx read of a File's sync-state bools
+// (LocalNewer/NotLocalSynced) concurrently with the AddRemoteFile/EditRemoteFile
+// writers, on the SAME *File (which the writers publish into AllFileMap). OpenEx
+// reads under metaMu; AddRemoteFile writes LocalNewer under RemoteFilesLock (not
+// metaMu) -> data race. It mounts no FUSE and never calls Dir.Write, so it cannot
+// trip the Release-path race or the cgofuse teardown race; it isolates this one.
+func TestRemoteSyncStateRace(t *testing.T) {
+	saveDir := t.TempDir()
+	d := newTestDir(saveDir)
+	d.OpenStreamProvider = func() types.FileStreamProvider { return nil }
+	lg := nopLogger()
+
+	const numFiles = 16
+	const iters = 200
+	var wg sync.WaitGroup
+
+	for i := 0; i < numFiles; i++ {
+		path := fmt.Sprintf("/r_%04d", i)
+		name := fmt.Sprintf("r_%04d", i)
+		// Seed: creates the *File in RemoteFiles (and, on re-announce, AllFileMap).
+		seed := &winfuse.Stat_t{Size: 1024}
+		_ = d.AddRemoteFile(lg, path, name, seed)
+
+		wg.Add(2)
+		// Reader: OpenEx reads fh.LocalNewer (metaMu) at the top of the open path.
+		go func(p string) {
+			defer wg.Done()
+			for k := 0; k < iters; k++ {
+				fi := &winfuse.FileInfo_t{Flags: syscall.O_RDONLY}
+				d.OpenEx(p, fi)
+				if fi.Fh != 0 {
+					d.Release(p, fi.Fh)
+				}
+			}
+		}(path)
+		// Writer: AddRemoteFile/EditRemoteFile write LocalNewer/NotLocalSynced and
+		// re-publish the same *File into AllFileMap.
+		go func(p, n string) {
+			defer wg.Done()
+			for k := 0; k < iters; k++ {
+				st := &winfuse.Stat_t{Size: int64(1024 + k%5)}
+				st.Mtim.Sec = int64(k + 1)
+				_ = d.AddRemoteFile(lg, p, n, st)
+				_ = d.EditRemoteFile(lg, p, n, st)
+			}
+		}(path, name)
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
Four related concurrency fixes in pkg/filesystem (a File field mutated
under one lock and read under metaMu via another):

- AddRemoteFile: LocalNewer under metaMu.
- Getattr: hoist platLstat out of metaMu (slow lstat stalled every op).
- OpenEx/Getattr/AddRemoteFile lock-order deadlock: OpenEx snapshots the
  RemoteFiles check before AfmLock.
- Unify NotLocalSynced + File.stat under metaMu (Read, prefetch, etc.).
