### PR TITLE
ci(release): sign Windows binaries via SignPath Foundation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ on:
 
 permissions:
   contents: write
+  actions: read       # SignPath pulls the uploaded artifact by id
 
 jobs:
   build:
@@ -43,6 +44,10 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     name: Build ${{ matrix.name }}
+    env:
+      # secrets can't be used in `if:`, so expose presence as a string env var.
+      # Signing is skipped on forks and before the SignPath secret is set.
+      HAS_SIGNPATH: ${{ secrets.SIGNPATH_API_TOKEN != '' }}
 
     steps:
       - uses: actions/checkout@v4
@@ -178,6 +183,43 @@ jobs:
         if: matrix.package == 'zip'
         shell: bash
         run: make package-windows VERSION=${{ steps.version.outputs.version }}
+
+      # Sign the zip in place: after packaging, before the Chocolatey SHA256 and
+      # the release upload, so the signed checksum flows to choco and the Release.
+      - name: Upload unsigned zip for signing (Windows)
+        id: upload-unsigned-windows
+        if: matrix.package == 'zip' && env.HAS_SIGNPATH == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: unsigned-windows-${{ matrix.goarch }}
+          path: dist/keibidrop-${{ steps.version.outputs.version }}-windows-amd64.zip
+          if-no-files-found: error
+
+      # The three slugs below are placeholders; set them to the values from the
+      # SignPath console once the Foundation application is approved.
+      - name: Sign Windows zip with SignPath (Windows)
+        if: matrix.package == 'zip' && env.HAS_SIGNPATH == 'true'
+        uses: signpath/github-action-submit-signing-request@v2
+        with:
+          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          organization-id: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
+          project-slug: keibidrop
+          signing-policy-slug: release-signing
+          artifact-configuration-slug: windows-zip
+          github-artifact-id: ${{ steps.upload-unsigned-windows.outputs.artifact-id }}
+          wait-for-completion: true
+          wait-for-completion-timeout-in-seconds: 600
+          output-artifact-directory: dist/signed
+
+      - name: Replace unsigned zip with signed (Windows)
+        if: matrix.package == 'zip' && env.HAS_SIGNPATH == 'true'
+        shell: bash
+        run: |
+          SIGNED=dist/signed/keibidrop-${{ steps.version.outputs.version }}-windows-amd64.zip
+          test -f "$SIGNED" || { echo "ERROR: signed zip not found at $SIGNED"; ls -R dist/signed; exit 1; }
+          mv -f "$SIGNED" dist/keibidrop-${{ steps.version.outputs.version }}-windows-amd64.zip
+          rm -rf dist/signed
+          echo "Replaced dist zip with SignPath-signed artifact"
 
       - name: Package .deb (Linux)
         if: matrix.package == 'deb'

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at [INSERT CONTACT METHOD]. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -36,7 +36,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at [INSERT CONTACT METHOD]. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at marius@keibisoft.com or andrei@keibisoft.com. All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 

--- a/CODE_SIGNING_POLICY.md
+++ b/CODE_SIGNING_POLICY.md
@@ -1,0 +1,26 @@
+# Code signing policy
+
+KeibiDrop release binaries are signed so you can confirm they come from us and
+have not been altered.
+
+## How releases are cut
+
+Releases are built by
+[`.github/workflows/release.yml`](.github/workflows/release.yml) when a `v*` tag
+is pushed. Only maintainers with push access to this repository can create tags,
+so only they can publish a release.
+
+## What is signed
+
+- Windows (`kd.exe`, `keibidrop-cli.exe`, `keibidrop.exe`): signed during the
+  release build with the SignPath Foundation certificate. SignPath verifies that
+  each request comes from this repository's release workflow (origin
+  verification) before signing. The signing key lives in SignPath's HSM; we
+  never hold it.
+- macOS (`.dmg` and the binaries inside it): signed with our Apple Developer ID
+  certificate and notarized by Apple.
+- Linux (`.deb`, `.tar.gz`): not code-signed. Verify downloads against the
+  `SHA256SUMS` published with each release.
+
+Free code signing provided by [SignPath.io](https://signpath.io), certificate by
+[SignPath Foundation](https://signpath.org).

--- a/README.md
+++ b/README.md
@@ -174,6 +174,14 @@ Full protocol description: [Security.md](./Security.md)
 
 See [TROUBLESHOOTING.md](./TROUBLESHOOTING.md).
 
+## Code signing
+
+KeibiDrop signs its release binaries: Windows via SignPath, macOS via Apple
+Developer ID. See [CODE_SIGNING_POLICY.md](./CODE_SIGNING_POLICY.md).
+
+Free code signing provided by [SignPath.io](https://signpath.io), certificate by
+[SignPath Foundation](https://signpath.org).
+
 ## Contributing
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md).


### PR DESCRIPTION
Free Windows code signing via the SignPath Foundation OSS program. The release
workflow uploads the unsigned Windows zip, SignPath signs it server-side with
the Foundation certificate, and the signed zip replaces the original before the
Chocolatey checksum and the release upload. Gated on the `SIGNPATH_API_TOKEN`
secret, so it skips cleanly on forks and until the account is configured. Safe
to merge early; signing stays inert until the secret is set.

Also adds the program's prerequisites: `CODE_OF_CONDUCT.md` (Contributor
Covenant 2.1), `CODE_SIGNING_POLICY.md`, and the required README attribution.

Maintainer follow-up before signing runs (SignPath console):
- Apply to the SignPath Foundation and get the project approved.
- Set secret `SIGNPATH_API_TOKEN` and variable `SIGNPATH_ORGANIZATION_ID`.
- Replace the placeholder slugs (`project-slug`, `signing-policy-slug`,
  `artifact-configuration-slug`) with the real console values.
- Fill the `[INSERT CONTACT METHOD]` placeholder in `CODE_OF_CONDUCT.md`.
