### PR TITLE
Add persistent peer link, startup scan, auto-connect and read-only

### DIFF
--- a/cmd/cli/keibidrop-cli.go
+++ b/cmd/cli/keibidrop-cli.go
@@ -36,6 +36,7 @@ var (
 )
 
 func pushEvent(evt string) {
+	printCreditEvent(evt)
 	select {
 	case eventCh <- evt:
 	default:
@@ -44,6 +45,27 @@ func pushEvent(evt string) {
 		default:
 		}
 		eventCh <- evt
+	}
+}
+
+// printCreditEvent surfaces credit and bridge warnings in the REPL as they
+// happen. The core emits each threshold crossing once (latched, re-armed on
+// top-up), so this stays one line per crossing, never a stream. Routine
+// events stay in the poll-event queue.
+func printCreditEvent(evt string) {
+	switch {
+	case strings.HasPrefix(evt, "tokens_low:"):
+		color.Yellow("\n[credit] Relay credit low: %s GB left. Top up with: tokens buy", strings.TrimPrefix(evt, "tokens_low:"))
+	case strings.HasPrefix(evt, "tokens_critical:"):
+		color.Red("\n[credit] Relay credit nearly gone: %s GB. At zero, bridged transfers drop to the free tier (slower when the bridge is busy). Top up with: tokens buy", strings.TrimPrefix(evt, "tokens_critical:"))
+	case strings.HasPrefix(evt, "tokens_exhausted:"):
+		color.Red("\n[credit] Relay credit exhausted. Bridged transfers now ride the free tier (slower when the bridge is busy; direct links unaffected). Top up with: tokens buy")
+	case strings.HasPrefix(evt, "tokens_chain_done:"):
+		color.Yellow("\n[credit] A token chain finished; the next funded chain pays from here.")
+	case strings.HasPrefix(evt, "tokens_added:"):
+		color.Green("\n[credit] Token code added to the wallet.")
+	case strings.HasPrefix(evt, "relay_busy:"):
+		color.Yellow("\n[bridge] %s", strings.TrimPrefix(evt, "relay_busy:"))
 	}
 }
 
@@ -317,10 +339,12 @@ func (c *cliContext) executor(in string) {
 			fmt.Printf("Added %.0f GiB of relay credit.\n", gb)
 			fmt.Println("Keep the code safe: it is like cash - anyone holding it can spend it, and it cannot be recovered if lost.")
 		case "list":
+			printCreditStatus(c.kd.TokensCreditStatus())
 			printTokenSummaries(c.kd.TokensSummaries())
 		case "balance":
 			fmt.Println("Checking balances with the relay...")
 			printTokenSummaries(c.kd.TokensRefreshBalances())
+			printCreditStatus(c.kd.TokensCreditStatus())
 		case "buy":
 			fmt.Println("Buy relay credit (prepaid, anonymous, no account, no expiry):")
 			fmt.Println("  " + c.kd.TokensBuyStart())
@@ -468,6 +492,21 @@ func (c *cliContext) completer(d prompt.Document) []prompt.Suggest {
 		{Text: "exit", Description: "Exit the CLI"},
 	}
 	return prompt.FilterHasPrefix(s, d.GetWordBeforeCursor(), true)
+}
+
+// printCreditStatus shows the credit level once per command, colored by
+// severity. Pull-based: no periodic output, no log lines.
+func printCreditStatus(st common.CreditStatus) {
+	switch st.Level {
+	case "critical", "empty":
+		color.Red("Relay credit: %.1f GB (%s)", st.WalletGB, st.Level)
+		color.Red("  %s", st.Notice)
+	case "low":
+		color.Yellow("Relay credit: %.0f GB (low)", st.WalletGB)
+		color.Yellow("  %s", st.Notice)
+	default:
+		fmt.Printf("Relay credit: %.0f GB\n", st.WalletGB)
+	}
 }
 
 func printTokenSummaries(sums []common.TokenChainSummary) {
@@ -826,6 +865,9 @@ func main() {
 	}
 	kd.AutoCache = cfg.LiveCollab // live_collab sets macFUSE auto_cache for same-size live edits on macOS.
 	kd.PrefetchAutoMB = cfg.PrefetchAutoMB
+	kd.ScanSharedOnStart = cfg.ScanSharedOnStart
+	kd.ShareReadOnly = cfg.ShareReadOnly
+	kd.MountReadOnly = cfg.MountReadOnly
 	// The daemon sets these from config; the CLI used to skip them, leaving it
 	// with no relay fallback at all.
 	kd.BridgeAddr = cfg.BridgeAddr
@@ -848,6 +890,15 @@ func main() {
 
 	kd.OnEvent = pushEvent
 	go kd.Run()
+
+	if cfg.AutoConnectPeer != "" {
+		kd.AutoConnectPeer = cfg.AutoConnectPeer
+		if err := kd.StartAutoConnect(kdctx); err != nil {
+			color.Red("auto_connect_peer: %v", err)
+		} else {
+			fmt.Printf("Auto-connect: %s\n", cfg.AutoConnectPeer)
+		}
+	}
 
 	ctx := &cliContext{kd: kd}
 

--- a/cmd/cli/keibidrop-cli.go
+++ b/cmd/cli/keibidrop-cli.go
@@ -868,6 +868,7 @@ func main() {
 	kd.ScanSharedOnStart = cfg.ScanSharedOnStart
 	kd.ShareReadOnly = cfg.ShareReadOnly
 	kd.MountReadOnly = cfg.MountReadOnly
+	kd.PreserveMetadata = cfg.PreserveMetadata
 	// The daemon sets these from config; the CLI used to skip them, leaving it
 	// with no relay fallback at all.
 	kd.BridgeAddr = cfg.BridgeAddr

--- a/cmd/kd/main.go
+++ b/cmd/kd/main.go
@@ -152,6 +152,9 @@ func runDaemon() {
 	kd.AutoCache = cfg.LiveCollab // live_collab sets macFUSE auto_cache for same-size live edits on macOS.
 	kd.PrefetchAutoMB = cfg.PrefetchAutoMB
 	kd.ReadAheadWindowMB = cfg.ReadAheadWindowMB
+	kd.ScanSharedOnStart = cfg.ScanSharedOnStart
+	kd.ShareReadOnly = cfg.ShareReadOnly
+	kd.MountReadOnly = cfg.MountReadOnly
 	for _, warn := range cfg.Warnings() {
 		logger.Warn("config flag note", "note", warn)
 	}
@@ -186,6 +189,13 @@ func runDaemon() {
 
 	go kd.Run()
 
+	if cfg.AutoConnectPeer != "" {
+		kd.AutoConnectPeer = cfg.AutoConnectPeer
+		if err := kd.StartAutoConnect(ctx); err != nil {
+			fmt.Fprintf(os.Stderr, `{"ok":false,"warning":"auto_connect_peer: %s"}`+"\n", err)
+		}
+	}
+
 	ln, err := net.Listen("unix", sock)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, `{"ok":false,"error":"socket listen: %s"}`+"\n", err)
@@ -199,15 +209,19 @@ func runDaemon() {
 
 	fp, _ := kd.ExportFingerprint()
 	startData := map[string]any{
-		"socket":      sock,
-		"fingerprint": fp,
-		"relay":       cfg.Relay,
-		"ip":          kd.LocalIPv6IP,
-		"fuse":        isFuse,
-		"save_path":   cfg.SavePath,
-		"mount_path":  cfg.MountPath,
-		"log_file":    cfg.LogFile,
-		"config_path": config.ConfigPath(),
+		"socket":               sock,
+		"fingerprint":          fp,
+		"relay":                cfg.Relay,
+		"ip":                   kd.LocalIPv6IP,
+		"fuse":                 isFuse,
+		"save_path":            cfg.SavePath,
+		"mount_path":           cfg.MountPath,
+		"log_file":             cfg.LogFile,
+		"config_path":          config.ConfigPath(),
+		"scan_shared_on_start": cfg.ScanSharedOnStart,
+		"auto_connect_peer":    cfg.AutoConnectPeer,
+		"share_read_only":      cfg.ShareReadOnly,
+		"mount_read_only":      cfg.MountReadOnly,
 	}
 	if isLocal {
 		addr, _ := common.GetLinkLocalAddress(kd.InboundPort())
@@ -574,9 +588,9 @@ func dispatch(kd *common.KeibiDrop, req Request, cancel context.CancelFunc, ln n
 				"warning":  "this code is like cash: anyone holding it can spend it, and it cannot be recovered if lost",
 			})
 		case "balance":
-			return okResponse(map[string]any{"chains": kd.TokensRefreshBalances(), "buy_url": common.TokensBuyURL})
+			return okResponse(map[string]any{"chains": kd.TokensRefreshBalances(), "credit": kd.TokensCreditStatus(), "buy_url": common.TokensBuyURL})
 		case "list":
-			return okResponse(map[string]any{"chains": kd.TokensSummaries(), "buy_url": common.TokensBuyURL})
+			return okResponse(map[string]any{"chains": kd.TokensSummaries(), "credit": kd.TokensCreditStatus(), "buy_url": common.TokensBuyURL})
 		case "buy":
 			return okResponse(map[string]any{
 				"url":  kd.TokensBuyStart(),
@@ -923,6 +937,7 @@ func cmdStatus(kd *common.KeibiDrop) Response {
 		"save_path":         kd.ToSave,
 		"writer_epoch":      kd.WriterEpoch(),
 		"bridge":            kd.BridgeInfo(),
+		"credit":            kd.TokensCreditStatus(),
 	}
 
 	kd.SyncTracker.LocalFilesMu.RLock()

--- a/cmd/kd/main.go
+++ b/cmd/kd/main.go
@@ -155,6 +155,7 @@ func runDaemon() {
 	kd.ScanSharedOnStart = cfg.ScanSharedOnStart
 	kd.ShareReadOnly = cfg.ShareReadOnly
 	kd.MountReadOnly = cfg.MountReadOnly
+	kd.PreserveMetadata = cfg.PreserveMetadata
 	for _, warn := range cfg.Warnings() {
 		logger.Warn("config flag note", "note", warn)
 	}
@@ -222,6 +223,7 @@ func runDaemon() {
 		"auto_connect_peer":    cfg.AutoConnectPeer,
 		"share_read_only":      cfg.ShareReadOnly,
 		"mount_read_only":      cfg.MountReadOnly,
+		"preserve_metadata":    cfg.PreserveMetadata,
 	}
 	if isLocal {
 		addr, _ := common.GetLinkLocalAddress(kd.InboundPort())

--- a/docs/kd-agent-guide.md
+++ b/docs/kd-agent-guide.md
@@ -216,6 +216,19 @@ Returns: `{"ok":true,"data":{"file":"big-video.mp4","size":104857600,"duration":
 - The relay only sees encrypted blobs. It cannot read your files or metadata.
 - Fingerprint exchange is the trust anchor. Send it via a secure channel (Signal, etc.).
 
+## Relay Credit and Throttling (infra deployments)
+
+If you run `kd` as always-on infrastructure behind NAT, bridged transfers spend prepaid relay credit. When credit runs dry nothing breaks and nothing is cut off: bridged transfers fall back to the free tier, which is slower only when the bridge is busy. Direct P2P and LAN connections never spend credit and are never throttled.
+
+How to stay ahead of it:
+
+1. **Poll the level, not the events.** `kd status` and `kd tokens list` both return a `credit` object: `{"wallet_gb": 12.4, "level": "low", "notice": "...", "buy_url": "..."}`. Levels: `ok`, `low` (under 50 GB), `critical` (under 2 GB), `empty`. Alert your operator when it leaves `ok`.
+2. **Edge events, no spam.** The daemon emits `tokens_low:<gb>`, `tokens_critical:<gb>`, and `tokens_exhausted:chain` through `kd poll-event`, once per downward threshold crossing (re-armed by a top-up). Logs are not polluted with periodic warnings.
+3. **Top up non-interactively.** `kd tokens add <code>` pastes a purchased code. `kd tokens buy` returns a payment URL; the code adds itself while the daemon runs and a `tokens_added` event fires.
+4. **Check what a session used.** `kd status` includes `bridge.session_gb`, `bridge.paid`, and `bridge.busy`.
+
+Codes are bearer instruments: anyone holding a code can spend it, and it cannot be recovered if lost.
+
 ## For Agent Developers
 
 When building an agent tool that uses `kd`:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -40,6 +40,7 @@ type Config struct {
 	AutoConnectPeer   string `toml:"auto_connect_peer"`    // Saved contact (name or fingerprint) to connect to on startup, with retry.
 	ShareReadOnly     bool   `toml:"share_read_only"`      // Refuse every peer mutation of this node's data (origin-enforced).
 	MountReadOnly     bool   `toml:"mount_read_only"`      // Local FUSE mount returns EROFS on write ops (receiver courtesy).
+	PreserveMetadata  bool   `toml:"preserve_metadata"`    // Apply the origin's mode and timestamps to files saved on disk.
 }
 
 const DefaultRelay = "https://keibidroprelay.keibisoft.com/"
@@ -208,6 +209,12 @@ no_fuse = %v
 # mount_read_only: local FUSE mount returns EROFS on write ops. Courtesy on
 # the reading side; share_read_only on the origin is the enforced guarantee.
 # mount_read_only = false
+#
+# preserve_metadata: when a received file completes on disk, apply the
+# origin's permission bits and timestamps (mtime, atime) to the saved bytes.
+# For forensics/evidence workflows where original timestamps must survive
+# the transfer. Birth time stays view-only (not settable on most systems).
+# preserve_metadata = false
 `, cfg.Relay, cfg.SavePath, cfg.MountPath, cfg.LogFile,
 		cfg.InboundPort, cfg.OutboundPort, cfg.NoFUSE)
 
@@ -297,10 +304,17 @@ share_read_only = %v
 # Courtesy only; the origin's share_read_only is the enforced guarantee.
 # No effect with no_fuse (there is no mount).
 mount_read_only = %v
+
+# Apply the origin's permission bits and timestamps (mtime, atime) to files
+# saved on disk, once their content completes. For forensics/evidence
+# workflows where original timestamps must survive the transfer. Birth time
+# stays view-only (not settable on most systems). On Windows only the
+# read-only permission bit applies.
+preserve_metadata = %v
 `, cfg.Relay, cfg.SavePath, cfg.MountPath, cfg.LogFile,
 		cfg.InboundPort, cfg.OutboundPort, cfg.BridgeAddr,
 		cfg.NoFUSE, cfg.StrictMode, cfg.Incognito, cfg.PrefetchAutoMB, cfg.PrefetchOnOpen, cfg.ReadAheadWindowMB, cfg.LiveCollab, cfg.ScanSharedOnStart, cfg.AutoConnectPeer,
-		cfg.ShareReadOnly, cfg.MountReadOnly)
+		cfg.ShareReadOnly, cfg.MountReadOnly, cfg.PreserveMetadata)
 
 	return os.WriteFile(path, []byte(content), 0600) // #nosec G306
 }
@@ -373,6 +387,9 @@ func applyEnvOverrides(cfg *Config) {
 	}
 	if b, ok := envBool("KEIBIDROP_MOUNT_READ_ONLY", "KD_MOUNT_READ_ONLY"); ok {
 		cfg.MountReadOnly = b
+	}
+	if b, ok := envBool("KEIBIDROP_PRESERVE_METADATA", "KD_PRESERVE_METADATA"); ok {
+		cfg.PreserveMetadata = b
 	}
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -204,6 +204,8 @@ no_fuse = %v
 #
 # share_read_only: refuse every peer mutation of this node's files, enforced
 # on this node before disk. The share becomes one-way (peer reads only).
+# Serving reads also avoid updating file access times (Linux O_NOATIME,
+# Windows handle sentinel), so evidence atime stays the original.
 # share_read_only = false
 #
 # mount_read_only: local FUSE mount returns EROFS on write ops. Courtesy on
@@ -214,6 +216,10 @@ no_fuse = %v
 # origin's permission bits and timestamps (mtime, atime) to the saved bytes.
 # For forensics/evidence workflows where original timestamps must survive
 # the transfer. Birth time stays view-only (not settable on most systems).
+# Later reads follow the local filesystem's atime policy: for strict work,
+# record stat+hashes right after transfer and keep save_path on a
+# noatime/read-only mount during analysis. The announced origin times also
+# stay recorded in the sync tracker, independent of disk.
 # preserve_metadata = false
 `, cfg.Relay, cfg.SavePath, cfg.MountPath, cfg.LogFile,
 		cfg.InboundPort, cfg.OutboundPort, cfg.NoFUSE)
@@ -297,7 +303,9 @@ auto_connect_peer = %q
 # Refuse every peer mutation of this node's files (add/edit/delete/rename).
 # Enforced on this node, before disk: the real read-only guarantee, and it
 # works in no-FUSE mode too. The share becomes one-way: the peer reads, and
-# their own shares to this node are refused while this is on.
+# their own shares to this node are refused while this is on. Serving reads
+# also avoid updating file access times (Linux O_NOATIME, Windows handle
+# sentinel), so evidence atime stays the original.
 share_read_only = %v
 
 # Present the local FUSE mount read-only: local write ops return EROFS.
@@ -309,7 +317,11 @@ mount_read_only = %v
 # saved on disk, once their content completes. For forensics/evidence
 # workflows where original timestamps must survive the transfer. Birth time
 # stays view-only (not settable on most systems). On Windows only the
-# read-only permission bit applies.
+# read-only permission bit applies. Later reads follow the local
+# filesystem's atime policy: for strict work, record stat+hashes right
+# after transfer and keep save_path on a noatime/read-only mount during
+# analysis. The announced origin times also stay recorded in the sync
+# tracker, independent of disk.
 preserve_metadata = %v
 `, cfg.Relay, cfg.SavePath, cfg.MountPath, cfg.LogFile,
 		cfg.InboundPort, cfg.OutboundPort, cfg.BridgeAddr,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -34,8 +34,12 @@ type Config struct {
 	PrefetchAutoMB    int    `toml:"prefetch_auto_mb"`     // Prefetch files at or above this many MB. Default 0 is off because prefetch saturates slow links and starves seeks.
 	ReadAheadWindowMB int    `toml:"read_ahead_window_mb"` // Cap in MB for sequential read-ahead; prevents stalls at block boundaries on high-RTT links. Self-tunes below the cap. Default 64; 0 disables.
 	PushOnWrite       bool   `toml:"push_on_write"`
-	LiveCollab        bool   `toml:"live_collab"`        // Show peers' same-size in-place edits live (macFUSE auto_cache); risks local mmap-write integrity (git).
-	PassphraseProtect bool   `toml:"passphrase_protect"` // Enable Tier 2 identity at-rest encryption with an Argon2id passphrase.
+	LiveCollab        bool   `toml:"live_collab"`          // Show peers' same-size in-place edits live (macFUSE auto_cache); risks local mmap-write integrity (git).
+	PassphraseProtect bool   `toml:"passphrase_protect"`   // Enable Tier 2 identity at-rest encryption with an Argon2id passphrase.
+	ScanSharedOnStart bool   `toml:"scan_shared_on_start"` // Announce files already in save_path when a session starts.
+	AutoConnectPeer   string `toml:"auto_connect_peer"`    // Saved contact (name or fingerprint) to connect to on startup, with retry.
+	ShareReadOnly     bool   `toml:"share_read_only"`      // Refuse every peer mutation of this node's data (origin-enforced).
+	MountReadOnly     bool   `toml:"mount_read_only"`      // Local FUSE mount returns EROFS on write ops (receiver courtesy).
 }
 
 const DefaultRelay = "https://keibidroprelay.keibisoft.com/"
@@ -186,6 +190,24 @@ no_fuse = %v
 # enable it on machines used for document/code collaboration, not git work.
 # On Linux and Windows both work regardless of this setting.
 # live_collab = false
+#
+# scan_shared_on_start: announce files already in save_path when a session
+# starts, so a pre-populated folder appears on the peer without re-adding
+# each file. Metadata only; content streams on demand.
+# scan_shared_on_start = false
+#
+# auto_connect_peer: connect to this saved contact (name or fingerprint) on
+# startup and keep retrying while the peer is offline. Requires a persistent
+# identity and a saved contact (save-contact / add-contact).
+# auto_connect_peer = ""
+#
+# share_read_only: refuse every peer mutation of this node's files, enforced
+# on this node before disk. The share becomes one-way (peer reads only).
+# share_read_only = false
+#
+# mount_read_only: local FUSE mount returns EROFS on write ops. Courtesy on
+# the reading side; share_read_only on the origin is the enforced guarantee.
+# mount_read_only = false
 `, cfg.Relay, cfg.SavePath, cfg.MountPath, cfg.LogFile,
 		cfg.InboundPort, cfg.OutboundPort, cfg.NoFUSE)
 
@@ -252,9 +274,33 @@ read_ahead_window_mb = %v
 # live, at the risk of corrupting mmap-written files (git). Linux/Windows handle
 # both regardless. Leave false unless this machine is for document/code collab.
 live_collab = %v
+
+# Announce files already in save_path when a session starts. Off by default:
+# only files shared explicitly (or by the folder watcher) reach the peer. Set
+# true to share a pre-populated folder: on connect, every file under save_path
+# is announced to the peer (metadata only; content streams on demand).
+scan_shared_on_start = %v
+
+# Connect to this saved contact (name or fingerprint) on startup and keep
+# retrying with backoff while the peer is offline. Empty = off. Requires a
+# persistent identity (incognito off) and a contact saved via save-contact
+# or add-contact.
+auto_connect_peer = %q
+
+# Refuse every peer mutation of this node's files (add/edit/delete/rename).
+# Enforced on this node, before disk: the real read-only guarantee, and it
+# works in no-FUSE mode too. The share becomes one-way: the peer reads, and
+# their own shares to this node are refused while this is on.
+share_read_only = %v
+
+# Present the local FUSE mount read-only: local write ops return EROFS.
+# Courtesy only; the origin's share_read_only is the enforced guarantee.
+# No effect with no_fuse (there is no mount).
+mount_read_only = %v
 `, cfg.Relay, cfg.SavePath, cfg.MountPath, cfg.LogFile,
 		cfg.InboundPort, cfg.OutboundPort, cfg.BridgeAddr,
-		cfg.NoFUSE, cfg.StrictMode, cfg.Incognito, cfg.PrefetchAutoMB, cfg.PrefetchOnOpen, cfg.ReadAheadWindowMB, cfg.LiveCollab)
+		cfg.NoFUSE, cfg.StrictMode, cfg.Incognito, cfg.PrefetchAutoMB, cfg.PrefetchOnOpen, cfg.ReadAheadWindowMB, cfg.LiveCollab, cfg.ScanSharedOnStart, cfg.AutoConnectPeer,
+		cfg.ShareReadOnly, cfg.MountReadOnly)
 
 	return os.WriteFile(path, []byte(content), 0600) // #nosec G306
 }
@@ -316,6 +362,18 @@ func applyEnvOverrides(cfg *Config) {
 	if b, ok := envBool("KEIBIDROP_LIVE_COLLAB", "LIVE_COLLAB_ENV"); ok {
 		cfg.LiveCollab = b
 	}
+	if b, ok := envBool("KEIBIDROP_SCAN_SHARED_ON_START", "KD_SCAN_SHARED_ON_START"); ok {
+		cfg.ScanSharedOnStart = b
+	}
+	if v := envFirst("KEIBIDROP_AUTO_CONNECT_PEER", "KD_AUTO_CONNECT_PEER"); v != "" {
+		cfg.AutoConnectPeer = v
+	}
+	if b, ok := envBool("KEIBIDROP_SHARE_READ_ONLY", "KD_SHARE_READ_ONLY"); ok {
+		cfg.ShareReadOnly = b
+	}
+	if b, ok := envBool("KEIBIDROP_MOUNT_READ_ONLY", "KD_MOUNT_READ_ONLY"); ok {
+		cfg.MountReadOnly = b
+	}
 }
 
 // envFirst returns the first non-empty value from the given environment variable names.
@@ -353,6 +411,9 @@ func (c Config) Warnings() []string {
 		}
 		if c.LiveCollab {
 			w = append(w, "live_collab has no effect with no_fuse: it tunes the FUSE mount cache, while no_fuse uses the AddFile/PullFile API")
+		}
+		if c.MountReadOnly {
+			w = append(w, "mount_read_only has no effect with no_fuse: there is no mount; share_read_only is the enforced guarantee")
 		}
 	}
 	if c.LiveCollab && runtime.GOOS == "darwin" {

--- a/pkg/filesystem/api.go
+++ b/pkg/filesystem/api.go
@@ -36,6 +36,7 @@ type FS struct {
 	ReadAheadWindowMB int  // MB cap for predictive sequential read-ahead (0=off). Each Dir converts it to blocks.
 	PushOnWrite       bool // If true, Write() pushes deltas to the peer asynchronously.
 	AutoCache         bool // If true (live_collab), add macFUSE auto_cache so a peer's same-size in-place edit shows live. Costs mmap-write integrity (git) on macOS; no-op on Linux/Windows.
+	MountReadOnly     bool // If true, every mutating FUSE op returns EROFS. Peer updates still apply.
 
 	// host and root are published by Mount and cleared by Unmount while other
 	// goroutines (Run, teardown, gRPC handlers) read them, so access is atomic.
@@ -158,6 +159,7 @@ func (fs *FS) Mount(mountPoint string, isSecond bool, downloadPath string) error
 		PrefetchAutoMB:        fs.PrefetchAutoMB,
 		ReadAheadWindowBlocks: readAheadWindowBlocks(fs.ReadAheadWindowMB),
 		PushOnWrite:           fs.PushOnWrite,
+		MountReadOnly:         fs.MountReadOnly,
 
 		RemoteFilesLock: sync.RWMutex{},
 		RemoteFiles:     make(map[string]*File),

--- a/pkg/filesystem/api.go
+++ b/pkg/filesystem/api.go
@@ -37,6 +37,7 @@ type FS struct {
 	PushOnWrite       bool // If true, Write() pushes deltas to the peer asynchronously.
 	AutoCache         bool // If true (live_collab), add macFUSE auto_cache so a peer's same-size in-place edit shows live. Costs mmap-write integrity (git) on macOS; no-op on Linux/Windows.
 	MountReadOnly     bool // If true, every mutating FUSE op returns EROFS. Peer updates still apply.
+	PreserveMetadata  bool // If true, apply the origin's mode and times to files saved on disk when their content completes.
 
 	// host and root are published by Mount and cleared by Unmount while other
 	// goroutines (Run, teardown, gRPC handlers) read them, so access is atomic.
@@ -160,6 +161,7 @@ func (fs *FS) Mount(mountPoint string, isSecond bool, downloadPath string) error
 		ReadAheadWindowBlocks: readAheadWindowBlocks(fs.ReadAheadWindowMB),
 		PushOnWrite:           fs.PushOnWrite,
 		MountReadOnly:         fs.MountReadOnly,
+		PreserveMetadata:      fs.PreserveMetadata,
 
 		RemoteFilesLock: sync.RWMutex{},
 		RemoteFiles:     make(map[string]*File),

--- a/pkg/filesystem/fuse_directory.go
+++ b/pkg/filesystem/fuse_directory.go
@@ -770,6 +770,9 @@ func (d *Dir) OpenEx(path string, fi *winfuse.FileInfo_t) (errCode int) {
 		fh.NotLocalSynced = true
 		fh.StreamPool = pool
 		fh.StreamCancel = streamCancel
+		if cacheFD != nil && fh.CacheFD == nil {
+			fh.beginDiskWriter()
+		}
 		fh.CacheFD = cacheFD
 		fh.Download.Reset(remoteTotalSize)
 
@@ -1493,20 +1496,12 @@ func (d *Dir) Release(path string, fh uint64) (errCode int) {
 		// Reset sync state for future opens. Guard under metaMu (OpenEx reads
 		// IsLocalPresent/NotLocalSynced via AfmLock, a different lock). Release
 		// metaMu before the AfmLock acquisition below to avoid a metaMu->AfmLock cycle.
-		var preserveMetaPath string
 		f.metaMu.Lock()
 		f.IsLocalPresent = true
 		// Mark as synced only when the download is complete.
 		// Use ChunkBitmap (preferred) or BytesDownloaded as fallback.
 		if f.Bitmap != nil {
 			if f.Bitmap.IsComplete() {
-				// Peer content just completed on disk (not a local edit).
-				// Apply the origin metadata below, AFTER cacheFD closes:
-				// Windows stamps its cached LastWriteTime at handle close,
-				// which would overwrite Chtimes.
-				if f.NotLocalSynced && !hadEdits && !localNewer && d.PreserveMeta() {
-					preserveMetaPath = filepath.Clean(filepath.Join(d.LocalDownloadFolder, path))
-				}
 				f.NotLocalSynced = false
 				// logger.Info("Download complete (all chunks verified)", "progress", f.Bitmap.Progress())
 			}
@@ -1567,22 +1562,13 @@ func (d *Dir) Release(path string, fh uint64) (errCode int) {
 				if closeErr := cacheFD.Close(); closeErr != nil {
 					logger.Error("Failed to close cache FD", "error", closeErr)
 				}
-			}
-			if preserveMetaPath != "" {
-				f.metaMu.Lock()
-				applyOriginMetaLocked(f, preserveMetaPath)
-				f.metaMu.Unlock()
+				// This handle's writer is done. The last writer standing
+				// applies the origin metadata (see endDiskWriter): prefetch
+				// can still be landing bytes, and an apply before its final
+				// write would get restamped.
+				f.endDiskWriter(d, filepath.Clean(filepath.Join(d.LocalDownloadFolder, path)))
 			}
 			return 0 // Already unlocked. Return.
-		}
-		if preserveMetaPath != "" {
-			// Same rule as above: no disk I/O under OpenMapLock.
-			d.OpenMapLock.Unlock()
-			unlocked = true
-			f.metaMu.Lock()
-			applyOriginMetaLocked(f, preserveMetaPath)
-			f.metaMu.Unlock()
-			return 0
 		}
 	}
 
@@ -1680,6 +1666,9 @@ func (d *Dir) Rename(oldpath string, newpath string) (errCode int) {
 		if tgt.CacheFD != nil {
 			_ = tgt.CacheFD.Close()
 			tgt.CacheFD = nil
+			// Counter only: no disk apply under OpenMapLock, and the
+			// rename replaces these bytes anyway.
+			tgt.dropDiskWriter()
 		}
 		d.OpenMapLock.Unlock()
 	}
@@ -3616,35 +3605,32 @@ func (d *Dir) prefetchFile(ctx context.Context, logger *slog.Logger, f *File, pa
 		logger.Warn("Prefetch: failed to open local file", "error", err)
 		return
 	}
+	f.beginDiskWriter()
 	// Close and handle rename-on-complete (git .lock -> final path race fix).
 	defer func() {
 		lf.Close()
-		if !bitmap.IsComplete() {
-			return
-		}
-		d.RemoteFilesLock.RLock()
-		currentDiskPath := f.RealPathOfFile
-		d.RemoteFilesLock.RUnlock()
 		finalPath := realPath
-		if currentDiskPath != realPath {
-			if mkErr := os.MkdirAll(filepath.Dir(currentDiskPath), 0o755); mkErr != nil {
-				logger.Warn("Prefetch: failed to create dirs for renamed path",
-					"path", currentDiskPath, "error", mkErr)
-			} else if rnErr := os.Rename(realPath, currentDiskPath); rnErr != nil {
-				logger.Warn("Prefetch: atomic rename failed",
-					"from", realPath, "to", currentDiskPath, "error", rnErr)
-			} else {
-				finalPath = currentDiskPath
+		if bitmap.IsComplete() {
+			d.RemoteFilesLock.RLock()
+			currentDiskPath := f.RealPathOfFile
+			d.RemoteFilesLock.RUnlock()
+			if currentDiskPath != realPath {
+				if mkErr := os.MkdirAll(filepath.Dir(currentDiskPath), 0o755); mkErr != nil {
+					logger.Warn("Prefetch: failed to create dirs for renamed path",
+						"path", currentDiskPath, "error", mkErr)
+				} else if rnErr := os.Rename(realPath, currentDiskPath); rnErr != nil {
+					logger.Warn("Prefetch: atomic rename failed",
+						"from", realPath, "to", currentDiskPath, "error", rnErr)
+				} else {
+					finalPath = currentDiskPath
+				}
 			}
 		}
-		// Apply origin metadata after lf closed and the file reached its final
-		// path: Windows stamps its cached LastWriteTime at handle close, which
-		// would overwrite Chtimes.
-		if d.PreserveMeta() {
-			f.metaMu.Lock()
-			applyOriginMetaLocked(f, finalPath)
-			f.metaMu.Unlock()
-		}
+		// Prefetch's writer is done, lf closed, file at its final path. The
+		// last writer standing applies the origin metadata (endDiskWriter):
+		// the on-demand cacheFD can still be landing bytes, and an apply
+		// before its final write would get restamped.
+		f.endDiskWriter(d, finalPath)
 	}()
 
 	heldStamped := false

--- a/pkg/filesystem/fuse_directory.go
+++ b/pkg/filesystem/fuse_directory.go
@@ -1493,12 +1493,20 @@ func (d *Dir) Release(path string, fh uint64) (errCode int) {
 		// Reset sync state for future opens. Guard under metaMu (OpenEx reads
 		// IsLocalPresent/NotLocalSynced via AfmLock, a different lock). Release
 		// metaMu before the AfmLock acquisition below to avoid a metaMu->AfmLock cycle.
+		var preserveMetaPath string
 		f.metaMu.Lock()
 		f.IsLocalPresent = true
 		// Mark as synced only when the download is complete.
 		// Use ChunkBitmap (preferred) or BytesDownloaded as fallback.
 		if f.Bitmap != nil {
 			if f.Bitmap.IsComplete() {
+				// Peer content just completed on disk (not a local edit).
+				// Apply the origin metadata below, AFTER cacheFD closes:
+				// Windows stamps its cached LastWriteTime at handle close,
+				// which would overwrite Chtimes.
+				if f.NotLocalSynced && !hadEdits && !localNewer && d.PreserveMeta() {
+					preserveMetaPath = filepath.Clean(filepath.Join(d.LocalDownloadFolder, path))
+				}
 				f.NotLocalSynced = false
 				// logger.Info("Download complete (all chunks verified)", "progress", f.Bitmap.Progress())
 			}
@@ -1560,7 +1568,21 @@ func (d *Dir) Release(path string, fh uint64) (errCode int) {
 					logger.Error("Failed to close cache FD", "error", closeErr)
 				}
 			}
+			if preserveMetaPath != "" {
+				f.metaMu.Lock()
+				applyOriginMetaLocked(f, preserveMetaPath)
+				f.metaMu.Unlock()
+			}
 			return 0 // Already unlocked. Return.
+		}
+		if preserveMetaPath != "" {
+			// Same rule as above: no disk I/O under OpenMapLock.
+			d.OpenMapLock.Unlock()
+			unlocked = true
+			f.metaMu.Lock()
+			applyOriginMetaLocked(f, preserveMetaPath)
+			f.metaMu.Unlock()
+			return 0
 		}
 	}
 
@@ -3333,6 +3355,7 @@ func (d *Dir) AddRemoteFileWithBase(logger *slog.Logger, path string, name strin
 
 		existing.metaMu.Lock()
 		existing.stat = stat
+		captureOriginMeta(existing, stat)
 		existing.metaMu.Unlock()
 
 		if sizeChanged {
@@ -3460,6 +3483,7 @@ func (d *Dir) AddRemoteFileWithBase(logger *slog.Logger, path string, name strin
 		Bitmap:          NewChunkBitmap(stat.Size),
 		RemoteMtimeNs:   stat.Mtim.Sec*1e9 + stat.Mtim.Nsec,
 	}
+	captureOriginMeta(f, stat)
 	d.RemoteFiles[path] = f
 	d.RemoteFilesLock.Unlock()
 	// Metadata-only on announce: registered with metadata + bitmap +
@@ -3601,6 +3625,7 @@ func (d *Dir) prefetchFile(ctx context.Context, logger *slog.Logger, f *File, pa
 		d.RemoteFilesLock.RLock()
 		currentDiskPath := f.RealPathOfFile
 		d.RemoteFilesLock.RUnlock()
+		finalPath := realPath
 		if currentDiskPath != realPath {
 			if mkErr := os.MkdirAll(filepath.Dir(currentDiskPath), 0o755); mkErr != nil {
 				logger.Warn("Prefetch: failed to create dirs for renamed path",
@@ -3608,7 +3633,17 @@ func (d *Dir) prefetchFile(ctx context.Context, logger *slog.Logger, f *File, pa
 			} else if rnErr := os.Rename(realPath, currentDiskPath); rnErr != nil {
 				logger.Warn("Prefetch: atomic rename failed",
 					"from", realPath, "to", currentDiskPath, "error", rnErr)
+			} else {
+				finalPath = currentDiskPath
 			}
+		}
+		// Apply origin metadata after lf closed and the file reached its final
+		// path: Windows stamps its cached LastWriteTime at handle close, which
+		// would overwrite Chtimes.
+		if d.PreserveMeta() {
+			f.metaMu.Lock()
+			applyOriginMetaLocked(f, finalPath)
+			f.metaMu.Unlock()
 		}
 	}()
 
@@ -3730,6 +3765,7 @@ func (d *Dir) EditRemoteFileWithBase(logger *slog.Logger, path string, name stri
 			Bitmap:          NewChunkBitmap(stat.Size),
 			RemoteMtimeNs:   stat.Mtim.Sec*1e9 + stat.Mtim.Nsec,
 		}
+		captureOriginMeta(newFile, stat)
 		d.RemoteFiles[path] = newFile
 		d.RemoteFilesLock.Unlock()
 		// Ensure AllFileMap points to the same object so OpenEx sees correct state.
@@ -3807,6 +3843,7 @@ func (d *Dir) EditRemoteFileWithBase(logger *slog.Logger, path string, name stri
 	// PrefetchCancel/Download/Bitmap resets stay outside it.
 	f.metaMu.Lock()
 	f.stat = stat
+	captureOriginMeta(f, stat)
 	f.LocalNewer = false    // Remote has newer content.
 	f.NotLocalSynced = true // Re-fetch the edited bytes on the next read.
 	f.metaMu.Unlock()

--- a/pkg/filesystem/fuse_directory.go
+++ b/pkg/filesystem/fuse_directory.go
@@ -123,6 +123,9 @@ func (d *Dir) Chmod(path string, mode uint32) (errCode int) {
 	if e := checkPath(path); e != 0 {
 		return e
 	}
+	if d.ReadOnlyMount() {
+		return -winfuse.EROFS
+	}
 
 	cleanPath := filepath.Clean(filepath.Join(d.LocalDownloadFolder, path))
 
@@ -338,6 +341,9 @@ func (d *Dir) CreateEx(path string, mode uint32, fi *winfuse.FileInfo_t) (errCod
 	if e := checkPath(path); e != 0 {
 		return e
 	}
+	if d.ReadOnlyMount() {
+		return -winfuse.EROFS
+	}
 	// d.logger.Info("FUSE create", "path", path, "mode", mode)
 	logger := d.logger.With("method", "create-ex", "path", path)
 
@@ -425,6 +431,10 @@ func (d *Dir) OpenEx(path string, fi *winfuse.FileInfo_t) (errCode int) {
 	defer d.recoverPanic("OpenEx", &errCode)
 	if e := checkPath(path); e != 0 {
 		return e
+	}
+	if d.ReadOnlyMount() &&
+		fi.Flags&(winfuse.O_WRONLY|winfuse.O_RDWR|winfuse.O_APPEND|winfuse.O_CREAT|winfuse.O_TRUNC) != 0 {
+		return -winfuse.EROFS
 	}
 	flags := fi.Flags
 	// d.logger.Info("FUSE open", "path", path, "flags", flags)
@@ -1103,6 +1113,9 @@ func (d *Dir) Mkdir(path string, mode uint32) (errCode int) {
 	if e := checkPath(path); e != 0 {
 		return e
 	}
+	if d.ReadOnlyMount() {
+		return -winfuse.EROFS
+	}
 	return d.mkdirInternal(path, mode, true)
 }
 
@@ -1183,6 +1196,9 @@ func (d *Dir) Mknod(path string, mode uint32, dev uint64) (errCode int) {
 	defer d.recoverPanic("Mknod", &errCode)
 	if e := checkPath(path); e != 0 {
 		return e
+	}
+	if d.ReadOnlyMount() {
+		return -winfuse.EROFS
 	}
 	// d.logger.Info("Mknod", "path", path, "inode", d.Inode)
 
@@ -1569,6 +1585,9 @@ func (d *Dir) Releasedir(path string, fh uint64) (errCode int) {
 // requests fall back to a basic rename.
 func (d *Dir) Rename(oldpath string, newpath string) (errCode int) {
 	defer d.recoverPanic("Rename", &errCode)
+	if d.ReadOnlyMount() {
+		return -winfuse.EROFS
+	}
 	if e := checkPath(oldpath); e != 0 {
 		return e
 	}
@@ -1749,6 +1768,9 @@ func (d *Dir) Rmdir(path string) (errCode int) {
 	if e := checkPath(path); e != 0 {
 		return e
 	}
+	if d.ReadOnlyMount() {
+		return -winfuse.EROFS
+	}
 	return d.rmdirInternal(path, true)
 }
 
@@ -1850,6 +1872,9 @@ func (d *Dir) Truncate(path string, size int64, fh uint64) (errCode int) {
 		d.logger.Debug("oplog Truncate", "path", path, "size", size, "fh", fh)
 	}
 	defer d.recoverPanic("Truncate", &errCode)
+	if d.ReadOnlyMount() {
+		return -winfuse.EROFS
+	}
 	if e := checkPath(path); e != 0 {
 		return e
 	}
@@ -1924,6 +1949,9 @@ func (d *Dir) Unlink(path string) (errCode int) {
 	defer d.recoverPanic("Unlink", &errCode)
 	if e := checkPath(path); e != 0 {
 		return e
+	}
+	if d.ReadOnlyMount() {
+		return -winfuse.EROFS
 	}
 	return d.unlinkInternal(path, true)
 }
@@ -2010,6 +2038,9 @@ func (d *Dir) Utimens(path string, tmsp []winfuse.Timespec) (errCode int) {
 		d.logger.Debug("oplog Utimens", "path", path)
 	}
 	defer d.recoverPanic("Utimens", &errCode)
+	if d.ReadOnlyMount() {
+		return -winfuse.EROFS
+	}
 	if e := checkPath(path); e != 0 {
 		return e
 	}
@@ -2059,6 +2090,9 @@ func (ws *WriteStats) record(lockTime, pwriteTime, remoteTime time.Duration, byt
 // The method returns the number of bytes written.
 func (d *Dir) Write(path string, buff []byte, offset int64, fh uint64) (errCode int) {
 	defer d.recoverPanic("Write", &errCode)
+	if d.ReadOnlyMount() {
+		return -winfuse.EROFS
+	}
 	// d.logger.Info("FUSE write", "path", path, "offset", offset, "len", len(buff))
 	logger := d.logger.With("method", "write", "path", path, "fh", fh, "offset", offset)
 
@@ -3049,6 +3083,9 @@ func (d *Dir) Setxattr(path string, name string, value []byte, flags int) (errCo
 	defer d.recoverPanic("Setxattr", &errCode)
 	if e := checkPath(path); e != 0 {
 		return e
+	}
+	if d.ReadOnlyMount() {
+		return -winfuse.EROFS
 	}
 	// Don't log xattr operations - too frequent
 	// I do not support flags for this version.

--- a/pkg/filesystem/preserve_metadata.go
+++ b/pkg/filesystem/preserve_metadata.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package filesystem
+
+import (
+	"io/fs"
+	"os"
+	"time"
+
+	winfuse "github.com/winfsp/cgofuse/fuse"
+)
+
+// captureOriginMeta records the origin's mode and times from an adopted
+// announce stat. Caller must hold f.metaMu or own f exclusively (creation).
+// Getattr later mutates f.stat from the local partial file, so these fields
+// are the only stable source for preserve_metadata.
+func captureOriginMeta(f *File, stat *winfuse.Stat_t) {
+	if stat == nil {
+		return
+	}
+	f.OriginMode = stat.Mode
+	f.OriginAtimeNs = stat.Atim.Sec*1e9 + stat.Atim.Nsec
+	f.OriginMtimeNs = stat.Mtim.Sec*1e9 + stat.Mtim.Nsec
+}
+
+// ApplyOriginMetadata sets the origin's permission bits and times on a fully
+// saved file. mtimeNs 0 means no origin data: do nothing. atimeNs 0 falls
+// back to mtime. Chmod/Chtimes act on the backing file directly, not through
+// FUSE, so no notify loop starts. Birth time is not settable on most
+// filesystems and stays view-only.
+func ApplyOriginMetadata(path string, mode uint32, atimeNs, mtimeNs int64) error {
+	if mtimeNs == 0 {
+		return nil
+	}
+	if perm := fs.FileMode(mode) & fs.ModePerm; perm != 0 {
+		if err := os.Chmod(path, perm); err != nil {
+			return err
+		}
+	}
+	if atimeNs == 0 {
+		atimeNs = mtimeNs
+	}
+	return os.Chtimes(path, time.Unix(0, atimeNs), time.Unix(0, mtimeNs))
+}
+
+// applyOriginMetaLocked applies f's captured origin metadata to realPath and
+// aligns f.stat's view with it, so disk, FUSE view, and announce agree.
+// Caller must hold f.metaMu; the disk apply itself is cheap (two syscalls).
+func applyOriginMetaLocked(f *File, realPath string) {
+	if f.OriginMtimeNs == 0 {
+		return
+	}
+	if err := ApplyOriginMetadata(realPath, f.OriginMode, f.OriginAtimeNs, f.OriginMtimeNs); err != nil {
+		f.logger.Warn("preserve_metadata apply failed", "path", realPath, "error", err)
+		return
+	}
+	if f.stat != nil {
+		atime := f.OriginAtimeNs
+		if atime == 0 {
+			atime = f.OriginMtimeNs
+		}
+		f.stat.Atim = winfuse.NewTimespec(time.Unix(0, atime))
+		f.stat.Mtim = winfuse.NewTimespec(time.Unix(0, f.OriginMtimeNs))
+		if f.OriginMode != 0 {
+			f.stat.Mode = f.OriginMode
+		}
+	}
+}

--- a/pkg/filesystem/preserve_metadata.go
+++ b/pkg/filesystem/preserve_metadata.go
@@ -47,6 +47,45 @@ func ApplyOriginMetadata(path string, mode uint32, atimeNs, mtimeNs int64) error
 	return os.Chtimes(path, time.Unix(0, atimeNs), time.Unix(0, mtimeNs))
 }
 
+// beginDiskWriter registers an open write handle (on-demand cacheFD or
+// prefetch fd) on the saved file.
+func (f *File) beginDiskWriter() {
+	f.metaMu.Lock()
+	f.diskWriters++
+	f.metaMu.Unlock()
+}
+
+// dropDiskWriter unregisters a write handle without the apply check, for
+// teardown sites that hold OpenMapLock and must not touch the disk.
+func (f *File) dropDiskWriter() {
+	f.metaMu.Lock()
+	f.diskWriters--
+	f.metaMu.Unlock()
+}
+
+// endDiskWriter unregisters a write handle. When it was the last one and the
+// download is complete, applies the origin metadata to realPath. The two
+// download paths land bytes concurrently and either can finish last; only
+// the last writer applies, so no later write or handle close (Windows stamps
+// LastWriteTime then) can restamp the restored times. Callers close their
+// write handle first and must not hold OpenMapLock.
+func (f *File) endDiskWriter(d *Dir, realPath string) {
+	f.metaMu.Lock()
+	defer f.metaMu.Unlock()
+	f.diskWriters--
+	if f.diskWriters != 0 || !d.PreserveMeta() {
+		return
+	}
+	if f.Bitmap == nil || !f.Bitmap.IsComplete() {
+		return
+	}
+	if f.HadEdits || f.LocalNewer {
+		// Local edits own the file's times now.
+		return
+	}
+	applyOriginMetaLocked(f, realPath)
+}
+
 // applyOriginMetaLocked applies f's captured origin metadata to realPath and
 // aligns f.stat's view with it, so disk, FUSE view, and announce agree.
 // Caller must hold f.metaMu; the disk apply itself is cheap (two syscalls).

--- a/pkg/filesystem/preserve_metadata_test.go
+++ b/pkg/filesystem/preserve_metadata_test.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// ABOUTME: Tests ApplyOriginMetadata and the origin-capture path: mode and
+// ABOUTME: times land on disk, and captured values survive Getattr pollution.
+
+package filesystem
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	winfuse "github.com/winfsp/cgofuse/fuse"
+)
+
+func TestApplyOriginMetadata_SetsModeAndMtime(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "f.bin")
+	require.NoError(t, os.WriteFile(p, []byte("data"), 0o666))
+
+	origMtime := time.Now().Add(-48 * time.Hour).Truncate(time.Second)
+	origAtime := time.Now().Add(-24 * time.Hour).Truncate(time.Second)
+	require.NoError(t, ApplyOriginMetadata(p, 0o100640, origAtime.UnixNano(), origMtime.UnixNano()))
+
+	info, err := os.Stat(p)
+	require.NoError(t, err)
+	require.WithinDuration(t, origMtime, info.ModTime(), time.Second)
+	if runtime.GOOS != "windows" {
+		require.Equal(t, os.FileMode(0o640), info.Mode().Perm())
+	}
+}
+
+func TestApplyOriginMetadata_ZeroMtimeIsNoop(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "f.bin")
+	require.NoError(t, os.WriteFile(p, []byte("data"), 0o644))
+
+	require.NoError(t, ApplyOriginMetadata(p, 0o400, 0, 0))
+
+	info, err := os.Stat(p)
+	require.NoError(t, err)
+	require.WithinDuration(t, time.Now(), info.ModTime(), time.Minute, "no origin data: times untouched")
+	if runtime.GOOS != "windows" {
+		require.Equal(t, os.FileMode(0o644), info.Mode().Perm(), "no origin data: mode untouched")
+	}
+}
+
+func TestApplyOriginMetadata_ZeroAtimeFallsBackToMtime(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "f.bin")
+	require.NoError(t, os.WriteFile(p, []byte("data"), 0o644))
+
+	origMtime := time.Now().Add(-48 * time.Hour).Truncate(time.Second)
+	require.NoError(t, ApplyOriginMetadata(p, 0, 0, origMtime.UnixNano()))
+
+	info, err := os.Stat(p)
+	require.NoError(t, err)
+	require.WithinDuration(t, origMtime, info.ModTime(), time.Second)
+}
+
+// TestCaptureApplyOriginMeta_SurvivesStatPollution reproduces the download
+// race: Getattr adopts the local partial file's stat mid-download, so f.stat
+// no longer holds the origin's times at completion. The captured origin
+// fields must still drive the apply, and realign the view.
+func TestCaptureApplyOriginMeta_SurvivesStatPollution(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "f.bin")
+	require.NoError(t, os.WriteFile(p, []byte("data"), 0o666))
+
+	origMtime := time.Now().Add(-48 * time.Hour).Truncate(time.Second)
+	origAtime := time.Now().Add(-24 * time.Hour).Truncate(time.Second)
+	announce := &winfuse.Stat_t{
+		Mode: 0o100640,
+		Size: 4,
+		Atim: winfuse.NewTimespec(origAtime),
+		Mtim: winfuse.NewTimespec(origMtime),
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	f := &File{logger: logger, stat: announce}
+	captureOriginMeta(f, announce)
+
+	// Getattr-style pollution: the partial file on disk is newer.
+	f.stat.Mtim = winfuse.NewTimespec(time.Now())
+	f.stat.Atim = winfuse.NewTimespec(time.Now())
+
+	f.metaMu.Lock()
+	applyOriginMetaLocked(f, p)
+	f.metaMu.Unlock()
+
+	info, err := os.Stat(p)
+	require.NoError(t, err)
+	require.WithinDuration(t, origMtime, info.ModTime(), time.Second, "disk gets the origin mtime")
+	if runtime.GOOS != "windows" {
+		require.Equal(t, os.FileMode(0o640), info.Mode().Perm(), "disk gets the origin mode")
+	}
+	require.Equal(t, origMtime.UnixNano(), f.stat.Mtim.Sec*1e9+f.stat.Mtim.Nsec, "view realigned to origin mtime")
+	require.Equal(t, origAtime.UnixNano(), f.stat.Atim.Sec*1e9+f.stat.Atim.Nsec, "view realigned to origin atime")
+}

--- a/pkg/filesystem/preserve_metadata_test.go
+++ b/pkg/filesystem/preserve_metadata_test.go
@@ -59,6 +59,70 @@ func TestApplyOriginMetadata_ZeroAtimeFallsBackToMtime(t *testing.T) {
 	require.WithinDuration(t, origMtime, info.ModTime(), time.Second)
 }
 
+// TestEndDiskWriter_OnlyLastWriterApplies reproduces the two-writer race:
+// prefetch and the on-demand cacheFD land bytes concurrently. An apply on the
+// first writer's end gets restamped by the second writer's late write, so
+// only the last endDiskWriter may apply.
+func TestEndDiskWriter_OnlyLastWriterApplies(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "f.bin")
+	require.NoError(t, os.WriteFile(p, []byte("data"), 0o666))
+
+	origMtime := time.Now().Add(-48 * time.Hour).Truncate(time.Second)
+	announce := &winfuse.Stat_t{
+		Mode: 0o100640,
+		Size: 4,
+		Mtim: winfuse.NewTimespec(origMtime),
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	bm := NewChunkBitmap(4)
+	bm.SetRange(0, 4)
+	require.True(t, bm.IsComplete())
+	f := &File{logger: logger, stat: announce, Bitmap: bm}
+	captureOriginMeta(f, announce)
+	d := &Dir{PreserveMetadata: true}
+
+	f.beginDiskWriter() // prefetch fd
+	f.beginDiskWriter() // on-demand cacheFD
+
+	// First writer ends: no apply, the other writer can still land bytes.
+	f.endDiskWriter(d, p)
+	info, err := os.Stat(p)
+	require.NoError(t, err)
+	require.WithinDuration(t, time.Now(), info.ModTime(), time.Minute,
+		"apply before the last writer would get restamped")
+
+	// The remaining writer's late write, then its end: now the apply runs.
+	require.NoError(t, os.WriteFile(p, []byte("data"), 0o666))
+	f.endDiskWriter(d, p)
+	info, err = os.Stat(p)
+	require.NoError(t, err)
+	require.WithinDuration(t, origMtime, info.ModTime(), time.Second,
+		"last writer applies the origin mtime")
+}
+
+// TestEndDiskWriter_LocalEditsVeto pins the guard: once local edits own the
+// file, the last writer must not stamp origin metadata over them.
+func TestEndDiskWriter_LocalEditsVeto(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "f.bin")
+	require.NoError(t, os.WriteFile(p, []byte("data"), 0o666))
+
+	origMtime := time.Now().Add(-48 * time.Hour).Truncate(time.Second)
+	announce := &winfuse.Stat_t{Mode: 0o100640, Size: 4, Mtim: winfuse.NewTimespec(origMtime)}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	bm := NewChunkBitmap(4)
+	bm.SetRange(0, 4)
+	f := &File{logger: logger, stat: announce, Bitmap: bm, HadEdits: true}
+	captureOriginMeta(f, announce)
+	d := &Dir{PreserveMetadata: true}
+
+	f.beginDiskWriter()
+	f.endDiskWriter(d, p)
+	info, err := os.Stat(p)
+	require.NoError(t, err)
+	require.WithinDuration(t, time.Now(), info.ModTime(), time.Minute,
+		"local edits keep their times")
+}
+
 // TestCaptureApplyOriginMeta_SurvivesStatPollution reproduces the download
 // race: Getattr adopts the local partial file's stat mid-download, so f.stat
 // no longer holds the origin's times at completion. The captured origin

--- a/pkg/filesystem/readonly_mount_test.go
+++ b/pkg/filesystem/readonly_mount_test.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// ABOUTME: Tests mount_read_only: every local mutating FUSE op returns EROFS,
+// ABOUTME: read intent passes the gate, peer-driven updates bypass it.
+
+package filesystem
+
+import (
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	winfuse "github.com/winfsp/cgofuse/fuse"
+)
+
+func newReadOnlyRoot(t *testing.T) *Dir {
+	t.Helper()
+	tmp := t.TempDir()
+	root := &Dir{
+		logger:              slog.New(slog.NewTextHandler(io.Discard, nil)),
+		RemoteFilesLock:     sync.RWMutex{},
+		RemoteFiles:         make(map[string]*File),
+		AfmLock:             sync.RWMutex{},
+		AllFileMap:          make(map[string]*File),
+		OpenMapLock:         sync.RWMutex{},
+		OpenFileHandlers:    make(map[uint64]*HandleEntry),
+		Adm:                 sync.RWMutex{},
+		AllDirMap:           make(map[string]*Dir),
+		RealPathOfFile:      tmp,
+		LocalDownloadFolder: tmp,
+		PrefetchSem:         make(chan struct{}, 8),
+		MountReadOnly:       true,
+	}
+	root.Root = root
+	return root
+}
+
+// TestMountReadOnly_AllWriteOpsReturnEROFS is the receiver-courtesy matrix:
+// every local mutating op fails with EROFS before touching state.
+func TestMountReadOnly_AllWriteOpsReturnEROFS(t *testing.T) {
+	d := newReadOnlyRoot(t)
+
+	require.Equal(t, -winfuse.EROFS, d.Chmod("/f.txt", 0o644), "Chmod")
+	require.Equal(t, -winfuse.EROFS, d.Mkdir("/newdir", 0o755), "Mkdir")
+	require.Equal(t, -winfuse.EROFS, d.Mknod("/dev0", 0o644, 0), "Mknod")
+	require.Equal(t, -winfuse.EROFS, d.Rename("/a.txt", "/b.txt"), "Rename")
+	require.Equal(t, -winfuse.EROFS, d.Rmdir("/somedir"), "Rmdir")
+	require.Equal(t, -winfuse.EROFS, d.Truncate("/f.txt", 0, 0), "Truncate")
+	require.Equal(t, -winfuse.EROFS, d.Unlink("/f.txt"), "Unlink")
+	require.Equal(t, -winfuse.EROFS, d.Utimens("/f.txt", nil), "Utimens")
+	require.Equal(t, -winfuse.EROFS, d.Write("/f.txt", []byte("x"), 0, 0), "Write")
+	require.Equal(t, -winfuse.EROFS, d.Setxattr("/f.txt", "user.k", []byte("v"), 0), "Setxattr")
+
+	errc, _ := d.Create("/new.txt", winfuse.O_CREAT|winfuse.O_RDWR, 0o644)
+	require.Equal(t, -winfuse.EROFS, errc, "Create")
+
+	errc, _ = d.Open("/f.txt", winfuse.O_RDWR)
+	require.Equal(t, -winfuse.EROFS, errc, "Open O_RDWR")
+	errc, _ = d.Open("/f.txt", winfuse.O_WRONLY)
+	require.Equal(t, -winfuse.EROFS, errc, "Open O_WRONLY")
+}
+
+// TestMountReadOnly_ReadIntentPasses: a read-only open passes the gate (the
+// miss then fails with a non-EROFS code, proving reads are not blocked).
+func TestMountReadOnly_ReadIntentPasses(t *testing.T) {
+	d := newReadOnlyRoot(t)
+	errc, _ := d.Open("/absent.txt", 0) // O_RDONLY
+	require.NotEqual(t, -winfuse.EROFS, errc, "read-only open must not hit the EROFS gate")
+}
+
+// TestMountReadOnly_PeerUpdatesBypass: peer-driven tree changes are not local
+// writes; the read-only mount must keep receiving them.
+func TestMountReadOnly_PeerUpdatesBypass(t *testing.T) {
+	d := newReadOnlyRoot(t)
+
+	require.Equal(t, 0, d.MkdirFromPeer("/from-peer", 0o755), "MkdirFromPeer")
+
+	stat := &winfuse.Stat_t{Mode: 0o644 | 0o100000, Size: 42, Nlink: 1}
+	require.NoError(t, d.AddRemoteFileWithBase(nil, "/from-peer/file.bin", "file.bin", stat, 0))
+
+	d.RemoteFilesLock.RLock()
+	_, ok := d.RemoteFiles["/from-peer/file.bin"]
+	d.RemoteFilesLock.RUnlock()
+	require.True(t, ok, "peer-announced file must appear in the tree")
+}
+
+// TestMountReadOnly_OffKeepsWrites: flag off keeps today's behavior.
+func TestMountReadOnly_OffKeepsWrites(t *testing.T) {
+	d := newReadOnlyRoot(t)
+	d.MountReadOnly = false
+
+	require.Equal(t, 0, d.Mkdir("/writable", 0o755), "Mkdir with flag off")
+}

--- a/pkg/filesystem/types.go
+++ b/pkg/filesystem/types.go
@@ -182,6 +182,9 @@ type Dir struct {
 	PrefetchAutoMB int  // Files at or above this many MB prefetch on open (0=off).
 	PushOnWrite    bool // If true, Write() pushes deltas to the peer asynchronously.
 	MountReadOnly  bool // Set on the ROOT dir: local mutating FUSE ops return EROFS.
+	// PreserveMetadata is set on the ROOT dir: when a remote file's content
+	// completes on disk, apply the origin's mode and times to the saved file.
+	PreserveMetadata bool
 
 	// ReadAheadWindowBlocks caps predictive sequential read-ahead. Sequential
 	// reads fetch up to this many ReadAheadBlock-sized blocks ahead of the read
@@ -218,6 +221,16 @@ func (d *Dir) ReadOnlyMount() bool {
 		r = d
 	}
 	return r.MountReadOnly
+}
+
+// PreserveMeta reports the root's preserve-metadata flag. Download-completion
+// paths check it before applying the origin's mode and times to saved files.
+func (d *Dir) PreserveMeta() bool {
+	r := d.Root
+	if r == nil {
+		r = d
+	}
+	return r.PreserveMetadata
 }
 
 // Ctx returns the live FUSE context from the root. Disconnect swaps it, so do
@@ -336,6 +349,13 @@ type File struct {
 	// notifications set it, under RemoteFilesLock. Local ops overwrite
 	// stat.Mtim and must not join the staleness comparison.
 	RemoteMtimeNs int64
+
+	// Origin metadata captured when an announce's stat is adopted, guarded by
+	// metaMu. Getattr mutates f.stat from the local partial file during a
+	// download, so these keep the origin's values for preserve_metadata.
+	OriginMode    uint32
+	OriginAtimeNs int64
+	OriginMtimeNs int64
 
 	// EditBaseMtimeNs is max(HeldMtimeNs, LastAnnouncedMtimeNs), snapshotted
 	// at the first dirtying op of an edit session under metaMu. The announce

--- a/pkg/filesystem/types.go
+++ b/pkg/filesystem/types.go
@@ -181,6 +181,7 @@ type Dir struct {
 	PrefetchOnOpen bool // If true, Open() fetches the whole file and writes it to local disk.
 	PrefetchAutoMB int  // Files at or above this many MB prefetch on open (0=off).
 	PushOnWrite    bool // If true, Write() pushes deltas to the peer asynchronously.
+	MountReadOnly  bool // Set on the ROOT dir: local mutating FUSE ops return EROFS.
 
 	// ReadAheadWindowBlocks caps predictive sequential read-ahead. Sequential
 	// reads fetch up to this many ReadAheadBlock-sized blocks ahead of the read
@@ -207,6 +208,16 @@ type Dir struct {
 	// SetCtx while FUSE threads read it, so access is atomic. FS.Unmount()
 	// cancels it to unblock FUSE handlers stuck on gRPC.
 	fsCtx atomic.Pointer[context.Context]
+}
+
+// ReadOnlyMount reports the root's read-only flag. Mutating FUSE ops check it
+// and return EROFS; peer-driven updates (*FromPeer, remote add) bypass it.
+func (d *Dir) ReadOnlyMount() bool {
+	r := d.Root
+	if r == nil {
+		r = d
+	}
+	return r.MountReadOnly
 }
 
 // Ctx returns the live FUSE context from the root. Disconnect swaps it, so do

--- a/pkg/filesystem/types.go
+++ b/pkg/filesystem/types.go
@@ -357,6 +357,12 @@ type File struct {
 	OriginAtimeNs int64
 	OriginMtimeNs int64
 
+	// diskWriters counts open write handles on the saved file (on-demand
+	// cacheFD, prefetch fd), guarded by metaMu. The two download paths land
+	// bytes concurrently; preserve_metadata applies when the last one ends,
+	// or a late write restamps the restored times (see endDiskWriter).
+	diskWriters int
+
 	// EditBaseMtimeNs is max(HeldMtimeNs, LastAnnouncedMtimeNs), snapshotted
 	// at the first dirtying op of an edit session under metaMu. The announce
 	// carries it so the receiver can prove a concurrent edit: a base below the

--- a/pkg/logic/common/auto_connect.go
+++ b/pkg/logic/common/auto_connect.go
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package common
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/KeibiSoft/KeibiDrop/pkg/session"
+)
+
+// autoConnectTuning holds the watchdog intervals. Tests shrink them.
+type autoConnectTuning struct {
+	poll           time.Duration // liveness poll while connected or deferring
+	initialBackoff time.Duration // first retry delay after a failed dial
+	maxBackoff     time.Duration // backoff cap
+	rearmGrace     time.Duration // continuous downtime before a re-dial after a session existed
+}
+
+// defaultAutoConnectTuning: the rearm grace stays above the ReconnectManager
+// retry window, so the watchdog never dials while reconnect still owns the
+// session.
+var defaultAutoConnectTuning = autoConnectTuning{
+	poll:           5 * time.Second,
+	initialBackoff: 5 * time.Second,
+	maxBackoff:     2 * time.Minute,
+	rearmGrace:     90 * time.Second,
+}
+
+// ResolveContact maps a saved contact name (case-insensitive) or fingerprint
+// to the contact's fingerprint.
+func (kd *KeibiDrop) ResolveContact(nameOrFingerprint string) (string, error) {
+	if kd.AddressBook == nil {
+		return "", fmt.Errorf("no address book: auto_connect_peer needs a persistent identity (incognito off)")
+	}
+	for _, c := range kd.AddressBook.List() {
+		if strings.EqualFold(c.Name, nameOrFingerprint) {
+			return c.Fingerprint, nil
+		}
+	}
+	if c := kd.AddressBook.Lookup(nameOrFingerprint); c != nil {
+		return c.Fingerprint, nil
+	}
+	return "", fmt.Errorf("auto_connect_peer %q is not a saved contact; add it with add-contact or save-contact", nameOrFingerprint)
+}
+
+// StartAutoConnect resolves AutoConnectPeer and arms the connect watchdog.
+// A no-op when the field is empty. Returns an error when the value does not
+// resolve to a saved contact, so frontends can surface a clear message at
+// startup instead of a silent dead loop.
+func (kd *KeibiDrop) StartAutoConnect(ctx context.Context) error {
+	target := kd.AutoConnectPeer
+	if target == "" {
+		return nil
+	}
+	fp, err := kd.ResolveContact(target)
+	if err != nil {
+		kd.logger.Error("Auto-connect disabled", "peer", target, "error", err)
+		return err
+	}
+	logger := kd.logger.With("method", "auto-connect", "peer", target)
+	logger.Info("Auto-connect armed")
+	go kd.autoConnectLoop(ctx, defaultAutoConnectTuning,
+		func() error { return kd.ConnectToContact(fp) },
+		kd.IsRunning,
+		kd.reconnectBusy)
+	return nil
+}
+
+// reconnectBusy reports whether the reconnect machinery currently owns the
+// session: while it retries or waits for the peer, the watchdog must not dial.
+func (kd *KeibiDrop) reconnectBusy() bool {
+	kd.mu.Lock()
+	rm := kd.ReconnectManager
+	kd.mu.Unlock()
+	if rm == nil {
+		return false
+	}
+	switch rm.State() {
+	case session.ReconnectStateReconnecting, session.ReconnectStateWaitingPeer:
+		return true
+	default:
+		return false
+	}
+}
+
+// autoConnectLoop keeps one contact connected: dial with exponential backoff,
+// then sit idle while the session runs. Transient drops belong to the
+// ReconnectManager; the loop re-dials only after the session has been down a
+// full rearm grace with no reconnect in progress (peer-initiated disconnect or
+// reconnect gave up).
+func (kd *KeibiDrop) autoConnectLoop(ctx context.Context, tun autoConnectTuning,
+	dial func() error, isRunning func() bool, busy func() bool) {
+	logger := kd.logger.With("method", "auto-connect")
+	backoff := tun.initialBackoff
+	hadSession := false
+	var idleSince time.Time
+
+	for ctx.Err() == nil {
+		switch {
+		case isRunning():
+			hadSession = true
+			idleSince = time.Time{}
+			backoff = tun.initialBackoff
+			if !sleepCtx(ctx, tun.poll) {
+				return
+			}
+		case busy():
+			idleSince = time.Time{}
+			if !sleepCtx(ctx, tun.poll) {
+				return
+			}
+		case hadSession && idleSince.IsZero():
+			idleSince = time.Now()
+			if !sleepCtx(ctx, tun.poll) {
+				return
+			}
+		case hadSession && time.Since(idleSince) < tun.rearmGrace:
+			if !sleepCtx(ctx, tun.poll) {
+				return
+			}
+		default:
+			logger.Info("Auto-connect dialing")
+			if err := dial(); err != nil {
+				logger.Warn("Auto-connect attempt failed", "error", err, "retry_in", backoff)
+				if !sleepCtx(ctx, backoff) {
+					return
+				}
+				backoff *= 2
+				if backoff > tun.maxBackoff {
+					backoff = tun.maxBackoff
+				}
+				continue
+			}
+			idleSince = time.Time{}
+		}
+	}
+}
+
+// sleepCtx sleeps d or returns false when ctx ends first.
+func sleepCtx(ctx context.Context, d time.Duration) bool {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-t.C:
+		return true
+	}
+}

--- a/pkg/logic/common/auto_connect_test.go
+++ b/pkg/logic/common/auto_connect_test.go
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// ABOUTME: Tests for auto_connect_peer — contact resolution and the connect watchdog.
+// ABOUTME: Covers unknown-contact rejection, backoff retry, and rearm after teardown.
+
+package common
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/KeibiSoft/KeibiDrop/pkg/identity"
+	"github.com/stretchr/testify/require"
+)
+
+func newAutoConnectTestKD(t *testing.T) *KeibiDrop {
+	t.Helper()
+	ab, err := identity.LoadAddressBook(t.TempDir(), nil) // no file yet: empty book
+	require.NoError(t, err)
+	require.NoError(t, ab.Add("dataset-box", "FP-AAAA-BBBB"))
+	return &KeibiDrop{
+		logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+		AddressBook: ab,
+	}
+}
+
+func TestResolveContact_ByNameAndFingerprint(t *testing.T) {
+	kd := newAutoConnectTestKD(t)
+
+	fp, err := kd.ResolveContact("dataset-box")
+	require.NoError(t, err)
+	require.Equal(t, "FP-AAAA-BBBB", fp)
+
+	fp, err = kd.ResolveContact("DATASET-BOX") // case-insensitive name
+	require.NoError(t, err)
+	require.Equal(t, "FP-AAAA-BBBB", fp)
+
+	fp, err = kd.ResolveContact("FP-AAAA-BBBB") // fingerprint form
+	require.NoError(t, err)
+	require.Equal(t, "FP-AAAA-BBBB", fp)
+}
+
+func TestResolveContact_RejectsUnknown(t *testing.T) {
+	kd := newAutoConnectTestKD(t)
+	_, err := kd.ResolveContact("stranger")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not a saved contact")
+}
+
+func TestResolveContact_RejectsIncognito(t *testing.T) {
+	kd := &KeibiDrop{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	_, err := kd.ResolveContact("anyone")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "persistent identity")
+}
+
+func TestStartAutoConnect_EmptyIsNoop(t *testing.T) {
+	kd := &KeibiDrop{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	require.NoError(t, kd.StartAutoConnect(context.Background()))
+}
+
+// fastTuning keeps watchdog tests in milliseconds.
+var fastTuning = autoConnectTuning{
+	poll:           2 * time.Millisecond,
+	initialBackoff: 2 * time.Millisecond,
+	maxBackoff:     10 * time.Millisecond,
+	rearmGrace:     20 * time.Millisecond,
+}
+
+func waitFor(t *testing.T, timeout time.Duration, cond func() bool, msg string) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("timeout: " + msg)
+}
+
+// TestAutoConnectLoop_RetriesUntilPeerAppears is the offline-then-appears case:
+// dials fail while the peer is away, then one succeeds and the loop goes idle.
+func TestAutoConnectLoop_RetriesUntilPeerAppears(t *testing.T) {
+	kd := &KeibiDrop{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var dials atomic.Int32
+	var running atomic.Bool
+	dial := func() error {
+		n := dials.Add(1)
+		if n < 3 {
+			return errors.New("peer offline")
+		}
+		running.Store(true)
+		return nil
+	}
+
+	done := make(chan struct{})
+	go func() {
+		kd.autoConnectLoop(ctx, fastTuning, dial, running.Load, func() bool { return false })
+		close(done)
+	}()
+
+	waitFor(t, 2*time.Second, func() bool { return dials.Load() == 3 && running.Load() }, "three dials then success")
+	// Idle while running: no further dials.
+	time.Sleep(20 * fastTuning.poll)
+	require.Equal(t, int32(3), dials.Load())
+
+	cancel()
+	<-done
+}
+
+// TestAutoConnectLoop_RearmsAfterTeardown: after a session existed and went
+// away with no reconnect in progress, the loop waits the grace and dials again.
+func TestAutoConnectLoop_RearmsAfterTeardown(t *testing.T) {
+	kd := &KeibiDrop{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var dials atomic.Int32
+	var running atomic.Bool
+	dial := func() error {
+		dials.Add(1)
+		running.Store(true)
+		return nil
+	}
+
+	done := make(chan struct{})
+	go func() {
+		kd.autoConnectLoop(ctx, fastTuning, dial, running.Load, func() bool { return false })
+		close(done)
+	}()
+
+	waitFor(t, 2*time.Second, func() bool { return dials.Load() == 1 }, "first dial")
+	waitFor(t, 2*time.Second, running.Load, "session up")
+
+	// Peer disconnects for good: session gone, no reconnect running.
+	running.Store(false)
+	waitFor(t, 2*time.Second, func() bool { return dials.Load() == 2 }, "re-dial after rearm grace")
+
+	cancel()
+	<-done
+}
+
+// TestAutoConnectLoop_DefersToReconnectManager: while reconnect owns the
+// session the watchdog must not dial, even past the rearm grace.
+func TestAutoConnectLoop_DefersToReconnectManager(t *testing.T) {
+	kd := &KeibiDrop{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var dials atomic.Int32
+	var running, reconnecting atomic.Bool
+	dial := func() error {
+		dials.Add(1)
+		running.Store(true)
+		return nil
+	}
+
+	done := make(chan struct{})
+	go func() {
+		kd.autoConnectLoop(ctx, fastTuning, dial, running.Load, reconnecting.Load)
+		close(done)
+	}()
+
+	waitFor(t, 2*time.Second, func() bool { return dials.Load() == 1 }, "first dial")
+
+	// Transient drop: reconnect machinery takes over.
+	reconnecting.Store(true)
+	running.Store(false)
+	time.Sleep(5 * fastTuning.rearmGrace)
+	require.Equal(t, int32(1), dials.Load(), "watchdog must not dial while reconnect is busy")
+
+	// Reconnect finishes the recovery itself.
+	running.Store(true)
+	reconnecting.Store(false)
+	time.Sleep(10 * fastTuning.poll)
+	require.Equal(t, int32(1), dials.Load())
+
+	cancel()
+	<-done
+}

--- a/pkg/logic/common/logic.go
+++ b/pkg/logic/common/logic.go
@@ -56,13 +56,15 @@ func (kd *KeibiDrop) AddFile(path string) error {
 		return syscall.EISDIR
 	}
 
+	atime, btime := statTimes(finfo)
 	file := &synctracker.File{
 		Name:           name,
 		RelativePath:   name,
 		RealPathOfFile: cleanPath,
 		Size:           uint64(finfo.Size()),
 		LastEditTime:   uint64(finfo.ModTime().UnixNano()),
-		CreatedTime:    uint64(finfo.ModTime().UnixNano()),
+		CreatedTime:    btime,
+		Atime:          atime,
 	}
 
 	kd.SyncTracker.LocalFilesMu.Lock()
@@ -77,10 +79,10 @@ func (kd *KeibiDrop) AddFile(path string) error {
 			Ino:              0,
 			Mode:             uint32(finfo.Mode().Perm()) | syscall.S_IFREG,
 			Size:             finfo.Size(),
-			AccessTime:       file.LastEditTime,
+			AccessTime:       atime,
 			ModificationTime: file.LastEditTime,
 			ChangeTime:       file.LastEditTime,
-			BirthTime:        file.LastEditTime,
+			BirthTime:        btime,
 			Flags:            0o444,
 		},
 	})
@@ -156,13 +158,15 @@ func (kd *KeibiDrop) AddFileAs(localPath string, remoteName string) error {
 		return syscall.EISDIR
 	}
 
+	atime, btime := statTimes(finfo)
 	file := &synctracker.File{
 		Name:           filepath.Base(remoteName),
 		RelativePath:   remoteName,
 		RealPathOfFile: cleanPath,
 		Size:           uint64(finfo.Size()),
 		LastEditTime:   uint64(finfo.ModTime().UnixNano()),
-		CreatedTime:    uint64(finfo.ModTime().UnixNano()),
+		CreatedTime:    btime,
+		Atime:          atime,
 	}
 
 	kd.SyncTracker.LocalFilesMu.Lock()
@@ -175,10 +179,10 @@ func (kd *KeibiDrop) AddFileAs(localPath string, remoteName string) error {
 		Attr: &bindings.Attr{
 			Mode:             uint32(finfo.Mode().Perm()) | syscall.S_IFREG,
 			Size:             finfo.Size(),
-			AccessTime:       file.LastEditTime,
+			AccessTime:       atime,
 			ModificationTime: file.LastEditTime,
 			ChangeTime:       file.LastEditTime,
-			BirthTime:        file.LastEditTime,
+			BirthTime:        btime,
 			Flags:            0o444,
 		},
 	})
@@ -321,6 +325,10 @@ func (kd *KeibiDrop) PullFile(remoteName, localPath string) error {
 	}
 
 updateTracker:
+	// Close the write handle before finalizeDownload's metadata apply: Windows
+	// stamps its cached LastWriteTime at handle close, which would overwrite
+	// Chtimes. The deferred Close then returns ErrClosed, ignored.
+	_ = f.Close()
 	kd.finalizeDownload(remoteName, localPath, fileCopy)
 
 	if fi, statErr := os.Stat(localPath); statErr == nil {
@@ -484,6 +492,12 @@ func (kd *KeibiDrop) finalizeDownload(remoteName, localPath string, fileCopy syn
 	kd.SyncTracker.LocalFilesMu.Lock()
 	kd.SyncTracker.LocalFiles[remoteName] = &fileCopy
 	kd.SyncTracker.LocalFilesMu.Unlock()
+	if kd.PreserveMetadata {
+		// #nosec G115 -- unix nanos fit in int64
+		if err := filesystem.ApplyOriginMetadata(localPath, fileCopy.Mode, int64(fileCopy.Atime), int64(fileCopy.LastEditTime)); err != nil {
+			kd.logger.Warn("preserve_metadata apply failed", "path", localPath, "error", err)
+		}
+	}
 }
 
 func (kd *KeibiDrop) registerDownload(name string, cancel context.CancelFunc) {

--- a/pkg/logic/common/logic.go
+++ b/pkg/logic/common/logic.go
@@ -109,6 +109,7 @@ func (kd *KeibiDrop) persistSharedFile(tag [16]byte, file *synctracker.File) {
 		Path:    file.RealPathOfFile,
 		Size:    file.Size,
 		ModTime: file.LastEditTime,
+		Rel:     file.RelativePath,
 	})
 	kd.sharedStore.Save(entries)
 }

--- a/pkg/logic/common/registry.go
+++ b/pkg/logic/common/registry.go
@@ -132,6 +132,9 @@ type sharedEntry struct {
 	Path    string   `json:"p"`
 	Size    uint64   `json:"s"`
 	ModTime uint64   `json:"m"`
+	// Rel is the announce path relative to the save root. Empty in entries
+	// from older builds; restore falls back to the base name.
+	Rel string `json:"r,omitempty"`
 }
 
 func newSharedFilesStore(configDir string, masterKey []byte) *sharedFilesStore {

--- a/pkg/logic/common/resilience.go
+++ b/pkg/logic/common/resilience.go
@@ -143,9 +143,13 @@ func (kd *KeibiDrop) InitConnectionResilience() error {
 				continue
 			}
 			name := filepath.Base(cleanPath)
-			kd.SyncTracker.LocalFiles[name] = &synctracker.File{
+			rel := e.Rel
+			if rel == "" {
+				rel = name // entry from an older build: flat announce
+			}
+			kd.SyncTracker.LocalFiles[rel] = &synctracker.File{
 				Name:           name,
-				RelativePath:   name,
+				RelativePath:   rel,
 				RealPathOfFile: cleanPath,
 				Size:           uint64(info.Size()),
 				LastEditTime:   uint64(info.ModTime().UnixNano()),
@@ -163,6 +167,22 @@ func (kd *KeibiDrop) InitConnectionResilience() error {
 	}
 	kd.lastSharedFiles = nil
 	kd.lastSharedPeerFP = ""
+
+	// Announce files already in the save folder. Runs after the restore block,
+	// so restored files are already tracked and the scan skips them.
+	if kd.ScanSharedOnStart {
+		ctx := kd.ctx
+		go func() {
+			n, err := kd.ScanAndShareSaveDir(ctx)
+			if err != nil {
+				logger.Warn("Save folder scan stopped early", "announced", n, "error", err)
+				return
+			}
+			if n > 0 {
+				logger.Info("Announced pre-existing save folder files", "count", n)
+			}
+		}()
+	}
 
 	logger.Info("Connection resilience initialized")
 	return nil

--- a/pkg/logic/common/resilience.go
+++ b/pkg/logic/common/resilience.go
@@ -454,15 +454,17 @@ func (kd *KeibiDrop) notifyRestoredFiles(logger *slog.Logger) {
 		if err != nil {
 			continue
 		}
+		atime, btime := statTimes(info)
 		_, _ = client.Notify(kd.ctx, &bindings.NotifyRequest{
 			Type: bindings.NotifyType(types.AddFile),
 			Path: file.RelativePath,
 			Attr: &bindings.Attr{
 				Mode:             uint32(info.Mode().Perm()) | 0100000,
 				Size:             info.Size(),
+				AccessTime:       atime,
 				ModificationTime: uint64(info.ModTime().UnixNano()),
 				ChangeTime:       uint64(info.ModTime().UnixNano()),
-				BirthTime:        uint64(info.ModTime().UnixNano()),
+				BirthTime:        btime,
 			},
 		})
 		logger.Info("Re-notified peer about restored file", "path", file.RelativePath)

--- a/pkg/logic/common/scan_shared.go
+++ b/pkg/logic/common/scan_shared.go
@@ -1,0 +1,272 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package common
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	bindings "github.com/KeibiSoft/KeibiDrop/grpc_bindings"
+	"github.com/KeibiSoft/KeibiDrop/pkg/logic/service"
+	synctracker "github.com/KeibiSoft/KeibiDrop/pkg/sync-tracker"
+	"github.com/KeibiSoft/KeibiDrop/pkg/types"
+	"github.com/winfsp/cgofuse/fuse"
+)
+
+// persistFlushBatch bounds how many scanned files wait in memory before a
+// shared-store write. Each flush rewrites the whole store, so the batch
+// trades store rewrites against buffer growth.
+const persistFlushBatch = 512
+
+// announceBatchSize caps notifies per BatchNotify RPC. One RPC per file makes
+// a big scan RTT-bound on WAN; one giant batch stalls the receiver. A capped
+// batch bounds both, and bounds scan memory.
+const announceBatchSize = 256
+
+// ScanAndShareSaveDir walks the save folder breadth-first and announces every
+// regular file that is not yet tracked, over the same announce path AddFile
+// uses: upsert LocalFiles, send ADD_FILE (in capped batches), persist to the
+// shared store. Breadth-first, so the peer sees the top of the tree before
+// deep subtrees. Nested files keep their save-root-relative path. Idempotent:
+// tracked files are skipped, so restore, watcher events, and repeated scans
+// compose. Returns the number of files announced. On a send error the walk
+// stops; the next session's scan announces the rest.
+func (kd *KeibiDrop) ScanAndShareSaveDir(ctx context.Context) (int, error) {
+	logger := kd.logger.With("method", "scan-shared-on-start")
+	kd.mu.Lock()
+	sess := kd.session
+	kd.mu.Unlock()
+	if sess == nil || kd.SyncTracker == nil {
+		return 0, ErrInvalidSession
+	}
+
+	root := filepath.Clean(kd.ToSave)
+	info, err := os.Stat(root)
+	if err != nil {
+		return 0, err
+	}
+	if !info.IsDir() {
+		return 0, syscall.ENOTDIR
+	}
+
+	var announced int
+	var batchSeq uint64
+	batchFiles := make([]*synctracker.File, 0, announceBatchSize)
+	batchReqs := make([]*bindings.NotifyRequest, 0, announceBatchSize)
+	pendingPersist := make([]*synctracker.File, 0, persistFlushBatch)
+
+	flushPersist := func() {
+		kd.persistSharedFilesBatch(pendingPersist)
+		pendingPersist = pendingPersist[:0]
+	}
+	// flushAnnounce sends the accumulated batch. Files count as announced only
+	// after their batch is accepted; a per-item shortfall on the peer is logged
+	// and self-heals on the next session (the files stay tracked locally).
+	flushAnnounce := func() error {
+		if len(batchReqs) == 0 {
+			return nil
+		}
+		batchSeq++
+		resp, err := kd.sendBatchNotify(ctx, &bindings.BatchNotifyRequest{
+			Notifications: batchReqs,
+			Seq:           batchSeq,
+			Timestamp:     uint64(time.Now().UnixNano()),
+		})
+		if err != nil {
+			return err
+		}
+		if resp != nil && int(resp.Processed) < len(batchReqs) {
+			logger.Warn("Peer processed only part of an announce batch",
+				"sent", len(batchReqs), "processed", resp.Processed)
+		}
+		announced += len(batchReqs)
+		pendingPersist = append(pendingPersist, batchFiles...)
+		batchFiles = batchFiles[:0]
+		batchReqs = batchReqs[:0]
+		if len(pendingPersist) >= persistFlushBatch {
+			flushPersist()
+		}
+		return nil
+	}
+
+	queue := []string{root}
+	for len(queue) > 0 {
+		dir := queue[0]
+		queue = queue[1:]
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			logger.Warn("Scan skipping unreadable directory", "path", dir, "error", err)
+			continue
+		}
+		for _, entry := range entries {
+			if ctx.Err() != nil {
+				flushPersist()
+				return announced, ctx.Err()
+			}
+			path := filepath.Join(dir, entry.Name())
+			if entry.IsDir() {
+				queue = append(queue, path)
+				continue
+			}
+			if !entry.Type().IsRegular() {
+				continue
+			}
+			rel, err := filepath.Rel(root, path)
+			if err != nil {
+				continue
+			}
+			rel = filepath.ToSlash(rel)
+			if service.IsInternalPath(rel) {
+				continue
+			}
+
+			// Files the peer announced to us are theirs; do not announce them back.
+			kd.SyncTracker.RemoteFilesMu.RLock()
+			_, isRemote := kd.SyncTracker.RemoteFiles[rel]
+			kd.SyncTracker.RemoteFilesMu.RUnlock()
+			if isRemote {
+				continue
+			}
+
+			finfo, err := entry.Info()
+			if err != nil {
+				continue
+			}
+
+			kd.SyncTracker.LocalFilesMu.Lock()
+			if _, tracked := kd.SyncTracker.LocalFiles[rel]; tracked {
+				kd.SyncTracker.LocalFilesMu.Unlock()
+				continue
+			}
+			file := &synctracker.File{
+				Name:           finfo.Name(),
+				RelativePath:   rel,
+				RealPathOfFile: filepath.Clean(path),
+				Size:           uint64(finfo.Size()),
+				LastEditTime:   uint64(finfo.ModTime().UnixNano()),
+				CreatedTime:    uint64(finfo.ModTime().UnixNano()),
+				Mode:           uint32(finfo.Mode().Perm()) | syscall.S_IFREG,
+			}
+			kd.SyncTracker.LocalFiles[rel] = file // upsert first: a failed announce retries next scan
+			kd.SyncTracker.LocalFilesMu.Unlock()
+
+			batchFiles = append(batchFiles, file)
+			batchReqs = append(batchReqs, &bindings.NotifyRequest{
+				Type: bindings.NotifyType(types.AddFile),
+				Path: rel,
+				Attr: &bindings.Attr{
+					Mode:             file.Mode,
+					Size:             finfo.Size(),
+					AccessTime:       file.LastEditTime,
+					ModificationTime: file.LastEditTime,
+					ChangeTime:       file.LastEditTime,
+					BirthTime:        file.LastEditTime,
+					Flags:            0o444,
+				},
+			})
+			if len(batchReqs) >= announceBatchSize {
+				if err := flushAnnounce(); err != nil {
+					flushPersist()
+					return announced, err
+				}
+			}
+		}
+	}
+	if err := flushAnnounce(); err != nil {
+		flushPersist()
+		return announced, err
+	}
+	flushPersist()
+	return announced, nil
+}
+
+// persistSharedFilesBatch appends the files to the shared store in one write.
+// A per-file persist rewrites the encrypted store once per file, quadratic on
+// large folders.
+func (kd *KeibiDrop) persistSharedFilesBatch(files []*synctracker.File) {
+	if len(files) == 0 || kd.sharedStore == nil || kd.dlRegistry == nil {
+		return
+	}
+	kd.mu.Lock()
+	sess := kd.session
+	kd.mu.Unlock()
+	if sess == nil {
+		return
+	}
+	tag := kd.dlRegistry.peerTag(sess.ExpectedPeerFingerprint, kd.registryKey)
+	entries := kd.sharedStore.Load()
+	for _, f := range files {
+		entries = append(entries, sharedEntry{
+			PeerTag: tag,
+			Path:    f.RealPathOfFile,
+			Size:    f.Size,
+			ModTime: f.LastEditTime,
+			Rel:     f.RelativePath,
+		})
+	}
+	kd.sharedStore.Save(entries)
+}
+
+// BackfillRemoteFilesIntoFS adds tracker-known remote files to the FUSE tree.
+// ADD_FILE notifies that arrive before the first SetFS land only in
+// SyncTracker.RemoteFiles; without this they never appear in the mount. Run
+// calls it right after it publishes the mounted FS. Files already in the tree
+// are left alone.
+func (kd *KeibiDrop) BackfillRemoteFilesIntoFS() {
+	fsRoot := kd.FS
+	if fsRoot == nil || fsRoot.Root() == nil || kd.SyncTracker == nil {
+		return
+	}
+	root := fsRoot.Root()
+
+	kd.SyncTracker.RemoteFilesMu.RLock()
+	files := make([]*synctracker.File, 0, len(kd.SyncTracker.RemoteFiles))
+	for _, f := range kd.SyncTracker.RemoteFiles {
+		files = append(files, f)
+	}
+	kd.SyncTracker.RemoteFilesMu.RUnlock()
+
+	for _, f := range files {
+		treePath := f.RelativePath
+		if len(treePath) == 0 {
+			continue
+		}
+		if treePath[0] != '/' {
+			treePath = "/" + treePath
+		}
+		root.RemoteFilesLock.Lock()
+		_, known := root.RemoteFiles[treePath]
+		root.RemoteFilesLock.Unlock()
+		if known {
+			continue
+		}
+		name := f.Name
+		if name == "" {
+			name = filepath.Base(f.RelativePath)
+		}
+		mode := f.Mode
+		if mode == 0 {
+			mode = uint32(0o644) | syscall.S_IFREG
+		}
+		mtime := time.Unix(0, int64(f.LastEditTime))
+		stat := &fuse.Stat_t{
+			Mode:     mode,
+			Nlink:    1,
+			Uid:      uint32(os.Getuid()),
+			Gid:      uint32(os.Getgid()),
+			Size:     int64(f.Size),
+			Atim:     fuse.NewTimespec(mtime),
+			Mtim:     fuse.NewTimespec(mtime),
+			Ctim:     fuse.NewTimespec(mtime),
+			Birthtim: fuse.NewTimespec(time.Unix(0, int64(f.CreatedTime))),
+		}
+		_ = root.AddRemoteFileWithBase(kd.logger, f.RelativePath, name, stat, 0)
+	}
+}

--- a/pkg/logic/common/scan_shared.go
+++ b/pkg/logic/common/scan_shared.go
@@ -145,13 +145,15 @@ func (kd *KeibiDrop) ScanAndShareSaveDir(ctx context.Context) (int, error) {
 				kd.SyncTracker.LocalFilesMu.Unlock()
 				continue
 			}
+			atime, btime := statTimes(finfo)
 			file := &synctracker.File{
 				Name:           finfo.Name(),
 				RelativePath:   rel,
 				RealPathOfFile: filepath.Clean(path),
 				Size:           uint64(finfo.Size()),
 				LastEditTime:   uint64(finfo.ModTime().UnixNano()),
-				CreatedTime:    uint64(finfo.ModTime().UnixNano()),
+				CreatedTime:    btime,
+				Atime:          atime,
 				Mode:           uint32(finfo.Mode().Perm()) | syscall.S_IFREG,
 			}
 			kd.SyncTracker.LocalFiles[rel] = file // upsert first: a failed announce retries next scan
@@ -164,10 +166,10 @@ func (kd *KeibiDrop) ScanAndShareSaveDir(ctx context.Context) (int, error) {
 				Attr: &bindings.Attr{
 					Mode:             file.Mode,
 					Size:             finfo.Size(),
-					AccessTime:       file.LastEditTime,
+					AccessTime:       atime,
 					ModificationTime: file.LastEditTime,
 					ChangeTime:       file.LastEditTime,
-					BirthTime:        file.LastEditTime,
+					BirthTime:        btime,
 					Flags:            0o444,
 				},
 			})
@@ -256,13 +258,17 @@ func (kd *KeibiDrop) BackfillRemoteFilesIntoFS() {
 			mode = uint32(0o644) | syscall.S_IFREG
 		}
 		mtime := time.Unix(0, int64(f.LastEditTime))
+		atime := mtime
+		if f.Atime != 0 {
+			atime = time.Unix(0, int64(f.Atime))
+		}
 		stat := &fuse.Stat_t{
 			Mode:     mode,
 			Nlink:    1,
 			Uid:      uint32(os.Getuid()),
 			Gid:      uint32(os.Getgid()),
 			Size:     int64(f.Size),
-			Atim:     fuse.NewTimespec(mtime),
+			Atim:     fuse.NewTimespec(atime),
 			Mtim:     fuse.NewTimespec(mtime),
 			Ctim:     fuse.NewTimespec(mtime),
 			Birthtim: fuse.NewTimespec(time.Unix(0, int64(f.CreatedTime))),

--- a/pkg/logic/common/scan_shared_test.go
+++ b/pkg/logic/common/scan_shared_test.go
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// ABOUTME: Tests for ScanAndShareSaveDir — announce pre-existing save dir files.
+// ABOUTME: Covers idempotence, internal-file skip, nested paths, BFS order, remote skip.
+
+package common
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	bindings "github.com/KeibiSoft/KeibiDrop/grpc_bindings"
+	"github.com/KeibiSoft/KeibiDrop/pkg/session"
+	synctracker "github.com/KeibiSoft/KeibiDrop/pkg/sync-tracker"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+// fakeNotifyCli records Notify and BatchNotify requests; other RPCs come from
+// the embedded nil interface and panic if called.
+type fakeNotifyCli struct {
+	bindings.KeibiServiceClient
+	mu      sync.Mutex
+	reqs    []*bindings.NotifyRequest
+	batches int
+}
+
+func (f *fakeNotifyCli) Notify(_ context.Context, req *bindings.NotifyRequest, _ ...grpc.CallOption) (*bindings.NotifyResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.reqs = append(f.reqs, req)
+	return &bindings.NotifyResponse{}, nil
+}
+
+func (f *fakeNotifyCli) BatchNotify(_ context.Context, req *bindings.BatchNotifyRequest, _ ...grpc.CallOption) (*bindings.BatchNotifyResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.batches++
+	f.reqs = append(f.reqs, req.Notifications...)
+	return &bindings.BatchNotifyResponse{Status: "ok", Processed: uint32(len(req.Notifications))}, nil
+}
+
+func (f *fakeNotifyCli) paths() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, 0, len(f.reqs))
+	for _, r := range f.reqs {
+		out = append(out, r.Path)
+	}
+	return out
+}
+
+func (f *fakeNotifyCli) batchCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.batches
+}
+
+func newScanTestKD(t *testing.T, saveDir string) (*KeibiDrop, *fakeNotifyCli) {
+	t.Helper()
+	cli := &fakeNotifyCli{}
+	kd := &KeibiDrop{
+		logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+		SyncTracker: synctracker.NewSyncTracker(),
+		ToSave:      saveDir,
+		session: &session.Session{
+			GRPCClient:              cli,
+			ExpectedPeerFingerprint: "test-peer",
+		},
+	}
+	return kd, cli
+}
+
+func writeFile(t *testing.T, path string, content []byte) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, content, 0o644))
+}
+
+func TestScanAndShareSaveDir_AnnouncesPreExistingFiles(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "a.txt"), []byte("alpha"))
+	writeFile(t, filepath.Join(dir, "b.bin"), []byte("beta"))
+	writeFile(t, filepath.Join(dir, "sub", "c.txt"), []byte("gamma"))
+	writeFile(t, filepath.Join(dir, ".DS_Store"), []byte("junk"))
+	writeFile(t, filepath.Join(dir, "b.bin.kdbitmap"), []byte("sidecar"))
+
+	kd, cli := newScanTestKD(t, dir)
+	n, err := kd.ScanAndShareSaveDir(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 3, n)
+
+	paths := cli.paths()
+	require.ElementsMatch(t, []string{"a.txt", "b.bin", "sub/c.txt"}, paths)
+	// Breadth-first: both top-level files announce before the nested one.
+	require.Equal(t, "sub/c.txt", paths[2])
+
+	for _, req := range cli.reqs {
+		require.Equal(t, bindings.NotifyType_ADD_FILE, req.Type)
+		require.NotNil(t, req.Attr)
+		require.NotZero(t, req.Attr.ModificationTime)
+	}
+
+	kd.SyncTracker.LocalFilesMu.RLock()
+	defer kd.SyncTracker.LocalFilesMu.RUnlock()
+	require.Len(t, kd.SyncTracker.LocalFiles, 3)
+	require.Contains(t, kd.SyncTracker.LocalFiles, "sub/c.txt")
+	require.Equal(t, "sub/c.txt", kd.SyncTracker.LocalFiles["sub/c.txt"].RelativePath)
+	require.NotContains(t, kd.SyncTracker.LocalFiles, ".DS_Store")
+}
+
+func TestScanAndShareSaveDir_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "a.txt"), []byte("alpha"))
+
+	kd, cli := newScanTestKD(t, dir)
+	n, err := kd.ScanAndShareSaveDir(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, n)
+
+	n, err = kd.ScanAndShareSaveDir(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 0, n)
+	require.Len(t, cli.paths(), 1)
+}
+
+func TestScanAndShareSaveDir_SkipsPeerOwnedFiles(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "theirs.txt"), []byte("from peer"))
+	writeFile(t, filepath.Join(dir, "mine.txt"), []byte("mine"))
+
+	kd, cli := newScanTestKD(t, dir)
+	kd.SyncTracker.RemoteFiles["theirs.txt"] = &synctracker.File{
+		Name: "theirs.txt", RelativePath: "theirs.txt",
+	}
+
+	n, err := kd.ScanAndShareSaveDir(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, n)
+	require.Equal(t, []string{"mine.txt"}, cli.paths())
+}
+
+func TestScanAndShareSaveDir_NoSession(t *testing.T) {
+	kd := &KeibiDrop{
+		logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+		SyncTracker: synctracker.NewSyncTracker(),
+		ToSave:      t.TempDir(),
+	}
+	_, err := kd.ScanAndShareSaveDir(context.Background())
+	require.ErrorIs(t, err, ErrInvalidSession)
+}
+
+func TestScanAndShareSaveDir_MissingDir(t *testing.T) {
+	kd, _ := newScanTestKD(t, filepath.Join(t.TempDir(), "gone"))
+	_, err := kd.ScanAndShareSaveDir(context.Background())
+	require.Error(t, err)
+}
+
+func TestScanAndShareSaveDir_CapsAnnounceBatches(t *testing.T) {
+	dir := t.TempDir()
+	count := announceBatchSize + 10
+	for i := 0; i < count; i++ {
+		writeFile(t, filepath.Join(dir, fmt.Sprintf("f%04d.txt", i)), []byte("x"))
+	}
+
+	kd, cli := newScanTestKD(t, dir)
+	n, err := kd.ScanAndShareSaveDir(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, count, n)
+	require.Equal(t, 2, cli.batchCount())
+	require.Len(t, cli.paths(), count)
+}
+
+func TestScanAndShareSaveDir_PersistsRelPaths(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "a.txt"), []byte("alpha"))
+	writeFile(t, filepath.Join(dir, "sub", "c.txt"), []byte("gamma"))
+
+	kd, _ := newScanTestKD(t, dir)
+	key := make([]byte, 32)
+	kd.registryKey = key
+	kd.dlRegistry = newDownloadRegistry(t.TempDir(), key)
+	kd.sharedStore = newSharedFilesStore(t.TempDir(), key)
+
+	n, err := kd.ScanAndShareSaveDir(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 2, n)
+
+	entries := kd.sharedStore.Load()
+	require.Len(t, entries, 2)
+	rels := []string{entries[0].Rel, entries[1].Rel}
+	require.ElementsMatch(t, []string{"a.txt", "sub/c.txt"}, rels)
+}
+
+func TestScanAndShareSaveDir_CancelledContext(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "a.txt"), []byte("alpha"))
+
+	kd, cli := newScanTestKD(t, dir)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := kd.ScanAndShareSaveDir(ctx)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Empty(t, cli.paths())
+}

--- a/pkg/logic/common/stat_times_darwin.go
+++ b/pkg/logic/common/stat_times_darwin.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//go:build darwin
+
+package common
+
+import (
+	"os"
+	"syscall"
+)
+
+// statTimes returns access and birth time in unix nanoseconds for a stat
+// result. Fallback when the platform data is unavailable: both equal mtime.
+func statTimes(info os.FileInfo) (atimeNs, btimeNs uint64) {
+	st, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		m := uint64(info.ModTime().UnixNano())
+		return m, m
+	}
+	atimeNs = uint64(st.Atimespec.Sec)*1e9 + uint64(st.Atimespec.Nsec)
+	btimeNs = uint64(st.Birthtimespec.Sec)*1e9 + uint64(st.Birthtimespec.Nsec)
+	return atimeNs, btimeNs
+}

--- a/pkg/logic/common/stat_times_linux.go
+++ b/pkg/logic/common/stat_times_linux.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//go:build linux
+
+package common
+
+import (
+	"os"
+	"syscall"
+)
+
+// statTimes returns access and birth time in unix nanoseconds for a stat
+// result. Linux syscall.Stat_t has no birth time; it falls back to mtime.
+func statTimes(info os.FileInfo) (atimeNs, btimeNs uint64) {
+	m := uint64(info.ModTime().UnixNano())
+	st, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return m, m
+	}
+	atimeNs = uint64(st.Atim.Sec)*1e9 + uint64(st.Atim.Nsec)
+	return atimeNs, m
+}

--- a/pkg/logic/common/stat_times_test.go
+++ b/pkg/logic/common/stat_times_test.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// ABOUTME: Tests the statTimes platform helper: a Chtimes-set atime round-trips
+// ABOUTME: through the announce path, and btime stays in a sane range.
+
+package common
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStatTimes_RoundTripsChtimes(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "f.txt")
+	require.NoError(t, os.WriteFile(p, []byte("x"), 0o644))
+	atime := time.Now().Add(-24 * time.Hour).Truncate(time.Second)
+	mtime := time.Now().Add(-48 * time.Hour).Truncate(time.Second)
+	require.NoError(t, os.Chtimes(p, atime, mtime))
+
+	info, err := os.Stat(p)
+	require.NoError(t, err)
+	at, bt := statTimes(info)
+	require.WithinDuration(t, atime, time.Unix(0, int64(at)), time.Second,
+		"atime must round-trip through statTimes")
+	// Birth time: real creation time where the platform has one (darwin,
+	// windows); mtime fallback on linux. Either way a sane timestamp.
+	require.NotZero(t, bt)
+	got := time.Unix(0, int64(bt))
+	require.True(t, got.After(time.Now().Add(-49*time.Hour)), "btime below sane range: %v", got)
+	require.True(t, got.Before(time.Now().Add(time.Minute)), "btime in the future: %v", got)
+}

--- a/pkg/logic/common/stat_times_windows.go
+++ b/pkg/logic/common/stat_times_windows.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//go:build windows
+
+package common
+
+import (
+	"os"
+	"syscall"
+)
+
+// statTimes returns access and birth time in unix nanoseconds for a stat
+// result. Fallback when the platform data is unavailable: both equal mtime.
+func statTimes(info os.FileInfo) (atimeNs, btimeNs uint64) {
+	st, ok := info.Sys().(*syscall.Win32FileAttributeData)
+	if !ok {
+		m := uint64(info.ModTime().UnixNano())
+		return m, m
+	}
+	atimeNs = uint64(st.LastAccessTime.Nanoseconds())
+	btimeNs = uint64(st.CreationTime.Nanoseconds())
+	return atimeNs, btimeNs
+}

--- a/pkg/logic/common/tokens.go
+++ b/pkg/logic/common/tokens.go
@@ -378,6 +378,41 @@ func (kd *KeibiDrop) noteCreditLevel() {
 	}
 }
 
+// CreditStatus is the level-readable relay credit state. Events are edges;
+// agents and frontends poll this for the current level.
+type CreditStatus struct {
+	WalletGB float64 `json:"wallet_gb"`
+	Level    string  `json:"level"` // "ok", "low", "critical", "empty"
+	Notice   string  `json:"notice,omitempty"`
+	BuyURL   string  `json:"buy_url"`
+}
+
+// TokensCreditStatus reports remaining relay credit against the same
+// thresholds noteCreditLevel uses. The copy stays honest: dry credit means
+// the free tier on bridged transfers, slower only under contention, never a
+// cutoff, and direct connections are never affected.
+func (kd *KeibiDrop) TokensCreditStatus() CreditStatus {
+	left := kd.Wallet().unitsLeft()
+	st := CreditStatus{
+		WalletGB: float64(left) * float64(TokenUnitBytes) / float64(1<<30),
+		BuyURL:   TokensBuyURL,
+	}
+	switch {
+	case left == 0:
+		st.Level = "empty"
+		st.Notice = "No relay credit: bridged transfers ride the free tier, slower when the bridge is busy. Direct connections are unaffected. Top up to restore paid speed."
+	case left < criticalCreditUnits:
+		st.Level = "critical"
+		st.Notice = fmt.Sprintf("Relay credit nearly gone (%.1f GB). At zero, bridged transfers drop to the free tier, slower when the bridge is busy. Top up now to avoid the slowdown.", st.WalletGB)
+	case left < lowCreditUnits:
+		st.Level = "low"
+		st.Notice = fmt.Sprintf("Relay credit is getting low (%.0f GB left). Top up before it runs out to keep paid bridge speed.", st.WalletGB)
+	default:
+		st.Level = "ok"
+	}
+	return st
+}
+
 // TokensSummaries lists wallet chains for display.
 func (kd *KeibiDrop) TokensSummaries() []TokenChainSummary {
 	return kd.Wallet().Summaries()

--- a/pkg/logic/common/tokens_credit_test.go
+++ b/pkg/logic/common/tokens_credit_test.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// ABOUTME: Tests TokensCreditStatus level mapping against the wallet
+// ABOUTME: thresholds: ok, low, critical, empty, and the honest notices.
+
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTokensCreditStatus_Levels(t *testing.T) {
+	kd := newTokenTestKD(t, "") // isolated wallet, never the real config dir
+
+	st := kd.TokensCreditStatus()
+	require.Equal(t, "empty", st.Level)
+	require.Contains(t, st.Notice, "free tier")
+	require.NotEmpty(t, st.BuyURL)
+
+	c, err := kd.Wallet().Add(encodeTokenCode(testSeed(t), 6000)) // ~58 GB
+	require.NoError(t, err)
+	st = kd.TokensCreditStatus()
+	require.Equal(t, "ok", st.Level)
+	require.Empty(t, st.Notice)
+	require.InDelta(t, 58.6, st.WalletGB, 1.0)
+
+	kd.Wallet().markRevealed(c, 1500, false) // 4500 units, under the 50 GB mark
+	st = kd.TokensCreditStatus()
+	require.Equal(t, "low", st.Level)
+	require.Contains(t, st.Notice, "Top up")
+
+	kd.Wallet().markRevealed(c, 5900, false) // 100 units left, under the 2 GB mark
+	st = kd.TokensCreditStatus()
+	require.Equal(t, "critical", st.Level)
+	require.Contains(t, st.Notice, "free tier")
+
+	kd.Wallet().markRevealed(c, 6000, false) // dry
+	st = kd.TokensCreditStatus()
+	require.Equal(t, "empty", st.Level)
+}

--- a/pkg/logic/common/types.go
+++ b/pkg/logic/common/types.go
@@ -111,6 +111,7 @@ type KeibiDrop struct {
 	AutoConnectPeer   string // Saved contact to connect to on startup, with retry. From config.AutoConnectPeer.
 	ShareReadOnly     bool   // Refuse every inbound peer mutation at the service layer. From config.ShareReadOnly.
 	MountReadOnly     bool   // Local FUSE mount returns EROFS on write ops. From config.MountReadOnly.
+	PreserveMetadata  bool   // Apply the origin's mode and times to files saved on disk. From config.PreserveMetadata.
 
 	// Signals for loop management.
 	signals      chan TaskSignal

--- a/pkg/logic/common/types.go
+++ b/pkg/logic/common/types.go
@@ -105,8 +105,12 @@ type KeibiDrop struct {
 	// AutoCache enables the macFUSE auto_cache mount option, so a peer's same-size
 	// in-place edit shows live. The caller sets it from config.LiveCollab. False = git-safe.
 	AutoCache         bool
-	PrefetchAutoMB    int // Files >= this many MB auto-prefetch on open. From config.PrefetchAutoMB. 0 = off.
-	ReadAheadWindowMB int // Cap in MB for predictive sequential read-ahead. From config.ReadAheadWindowMB. 0 = off.
+	PrefetchAutoMB    int    // Files >= this many MB auto-prefetch on open. From config.PrefetchAutoMB. 0 = off.
+	ReadAheadWindowMB int    // Cap in MB for predictive sequential read-ahead. From config.ReadAheadWindowMB. 0 = off.
+	ScanSharedOnStart bool   // Announce files already in ToSave when a session starts. From config.ScanSharedOnStart.
+	AutoConnectPeer   string // Saved contact to connect to on startup, with retry. From config.AutoConnectPeer.
+	ShareReadOnly     bool   // Refuse every inbound peer mutation at the service layer. From config.ShareReadOnly.
+	MountReadOnly     bool   // Local FUSE mount returns EROFS on write ops. From config.MountReadOnly.
 
 	// Signals for loop management.
 	signals      chan TaskSignal
@@ -431,6 +435,29 @@ type ErrorMapperFunc func(statusCode int, err error) error
 // InboundPort returns the port this instance listens on for incoming connections.
 func (kd *KeibiDrop) InboundPort() int { return kd.inboundPort }
 
+// WireStats sums bytes over the session's two TCP conns plus the QUIC control
+// lanes (on-demand reads ride there when the lane is up). Counters reset on
+// rekey. For tests and benchmarks.
+func (kd *KeibiDrop) WireStats() (bytesSent, bytesRecv uint64) {
+	kd.mu.Lock()
+	sess := kd.session
+	kd.mu.Unlock()
+	if sess == nil {
+		return 0, 0
+	}
+	conns := []*session.SecureConn{sess.InboundConn(), sess.OutboundConn()}
+	conns = append(conns, kd.quicFoldConns()...)
+	for _, c := range conns {
+		if c == nil {
+			continue
+		}
+		bs, br, _, _ := c.GetStats()
+		bytesSent += bs
+		bytesRecv += br
+	}
+	return bytesSent, bytesRecv
+}
+
 // UpgradeListenerDualStack replaces the IPv6-only listener with a dual-stack one.
 // Local mode uses it: LAN discovery needs IPv4 connectivity.
 func (kd *KeibiDrop) UpgradeListenerDualStack() error {
@@ -665,6 +692,9 @@ func (kd *KeibiDrop) Run() {
 				kd.mu.Unlock()
 				if kd.FS != nil && svc != nil {
 					svc.SetFS(kd.FS)
+					// ADD_FILE notifies that raced this publish landed only in
+					// SyncTracker. Fold them into the tree before serving.
+					kd.BackfillRemoteFilesIntoFS()
 					if kd.FS.IsMounted() {
 						logger.Info("FUSE already mounted, waiting for disconnect")
 						<-kd.ctx.Done()

--- a/pkg/logic/common/utils.go
+++ b/pkg/logic/common/utils.go
@@ -381,6 +381,7 @@ func (kd *KeibiDrop) setupFilesystem(logger *slog.Logger, ready chan struct{}) e
 	fs.PrefetchAutoMB = kd.PrefetchAutoMB
 	fs.ReadAheadWindowMB = kd.ReadAheadWindowMB
 	fs.MountReadOnly = kd.MountReadOnly
+	fs.PreserveMetadata = kd.PreserveMetadata
 
 	// The handshake emits OnPeerVerified; the FUSE cache reacts by scoping to that peer. A
 	// different peer drops the prior cache (no cross-peer leak); the same peer reconnecting or

--- a/pkg/logic/common/utils.go
+++ b/pkg/logic/common/utils.go
@@ -380,6 +380,7 @@ func (kd *KeibiDrop) setupFilesystem(logger *slog.Logger, ready chan struct{}) e
 	fs.AutoCache = kd.AutoCache // live_collab → macFUSE auto_cache (set before Mount)
 	fs.PrefetchAutoMB = kd.PrefetchAutoMB
 	fs.ReadAheadWindowMB = kd.ReadAheadWindowMB
+	fs.MountReadOnly = kd.MountReadOnly
 
 	// The handshake emits OnPeerVerified; the FUSE cache reacts by scoping to that peer. A
 	// different peer drops the prior cache (no cross-peer leak); the same peer reconnecting or
@@ -787,11 +788,12 @@ func (kd *KeibiDrop) startGRPCServer() error {
 	ln := NewSingleConnListener(inboundConn)
 
 	svc := &service.KeibidropServiceImpl{
-		Session:      s,
-		Logger:       kd.logger.With("component", "keibidrop-server"),
-		SyncTracker:  kd.SyncTracker,
-		OnEvent:      kd.OnEvent,
-		OnDisconnect: kd.handleNotifyDisconnect,
+		Session:       s,
+		Logger:        kd.logger.With("component", "keibidrop-server"),
+		SyncTracker:   kd.SyncTracker,
+		OnEvent:       kd.OnEvent,
+		OnDisconnect:  kd.handleNotifyDisconnect,
+		ShareReadOnly: kd.ShareReadOnly,
 	}
 	// Re-wire the FUSE tree here: a reconnect rebuilds KDSvc but the post-mount wiring in
 	// Run() is not re-run, so without this a reconnected FUSE peer would never show

--- a/pkg/logic/service/internal_paths.go
+++ b/pkg/logic/service/internal_paths.go
@@ -6,7 +6,10 @@
 
 package service
 
-import "strings"
+import (
+	"os"
+	"strings"
+)
 
 // internalPathMarkers name OS and KeibiDrop internal files that must never sync.
 var internalPathMarkers = []string{
@@ -26,4 +29,15 @@ func IsInternalPath(path string) bool {
 		}
 	}
 	return false
+}
+
+// openServeRead opens a local file to serve peer reads. With share_read_only
+// (forensic posture) the open does not update the file's access time where
+// the platform allows: Linux O_NOATIME, Windows handle sentinel. macOS has
+// no per-handle equivalent; there the source mount's noatime policy decides.
+func (kd *KeibidropServiceImpl) openServeRead(path string) (*os.File, error) {
+	if kd.ShareReadOnly {
+		return openReadNoAtime(path)
+	}
+	return os.Open(path) // #nosec G304
 }

--- a/pkg/logic/service/internal_paths.go
+++ b/pkg/logic/service/internal_paths.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package service
+
+import "strings"
+
+// internalPathMarkers name OS and KeibiDrop internal files that must never sync.
+var internalPathMarkers = []string{
+	".fuse_hidden",
+	".fseventsd",
+	".fseventuuid",
+	".DS_Store",
+	".kdbitmap",
+}
+
+// IsInternalPath reports whether the path names an internal file that must
+// never sync: FUSE hidden renames, macOS metadata, download bitmap sidecars.
+func IsInternalPath(path string) bool {
+	for _, m := range internalPathMarkers {
+		if strings.Contains(path, m) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/logic/service/open_noatime_linux.go
+++ b/pkg/logic/service/open_noatime_linux.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//go:build linux
+
+package service
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// openReadNoAtime opens path read-only without updating its access time.
+// O_NOATIME needs file ownership or CAP_FOWNER; on failure fall back to a
+// plain open so serving still works.
+func openReadNoAtime(path string) (*os.File, error) {
+	f, err := os.OpenFile(path, os.O_RDONLY|unix.O_NOATIME, 0) // #nosec G304
+	if err == nil {
+		return f, nil
+	}
+	return os.Open(path) // #nosec G304
+}

--- a/pkg/logic/service/open_noatime_linux_test.go
+++ b/pkg/logic/service/open_noatime_linux_test.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// ABOUTME: Proves a no-atime serve read leaves the file's access time alone.
+// ABOUTME: atime is set 30h back so relatime would bump it on a plain read.
+
+//go:build linux
+
+package service
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenReadNoAtime_DoesNotBumpAtime(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "evidence.bin")
+	require.NoError(t, os.WriteFile(p, []byte("evidence"), 0o600))
+	old := time.Now().Add(-30 * time.Hour).Truncate(time.Second)
+	require.NoError(t, os.Chtimes(p, old, old))
+
+	f, err := openReadNoAtime(p)
+	require.NoError(t, err)
+	buf := make([]byte, 8)
+	_, err = f.Read(buf)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	info, err := os.Stat(p)
+	require.NoError(t, err)
+	st, ok := info.Sys().(*syscall.Stat_t)
+	require.True(t, ok)
+	got := time.Unix(st.Atim.Sec, st.Atim.Nsec)
+	require.WithinDuration(t, old, got, time.Second, "serve read must not change atime")
+}

--- a/pkg/logic/service/open_noatime_other.go
+++ b/pkg/logic/service/open_noatime_other.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//go:build !linux && !windows
+
+package service
+
+import "os"
+
+// openReadNoAtime: macOS/iOS have no per-handle way to suppress access-time
+// updates. Forensic guidance there: put the source on a noatime/read-only
+// mount. Serving still works with a plain open.
+func openReadNoAtime(path string) (*os.File, error) {
+	return os.Open(path) // #nosec G304
+}

--- a/pkg/logic/service/open_noatime_windows.go
+++ b/pkg/logic/service/open_noatime_windows.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//go:build windows
+
+package service
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// openReadNoAtime opens path read-only and disables access-time updates on
+// the handle (FILETIME -1 sentinel, per SetFileTime docs). Best effort: if
+// the sentinel call fails the handle still serves reads.
+func openReadNoAtime(path string) (*os.File, error) {
+	f, err := os.Open(path) // #nosec G304
+	if err != nil {
+		return nil, err
+	}
+	noUpdate := windows.Filetime{LowDateTime: 0xFFFFFFFF, HighDateTime: 0xFFFFFFFF}
+	_ = windows.SetFileTime(windows.Handle(f.Fd()), nil, &noUpdate, nil)
+	return f, nil
+}

--- a/pkg/logic/service/open_noatime_windows_test.go
+++ b/pkg/logic/service/open_noatime_windows_test.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// ABOUTME: Proves a no-atime serve read leaves the file's access time alone
+// ABOUTME: on Windows (handle sentinel; also holds when the volume disables it).
+
+//go:build windows
+
+package service
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenReadNoAtime_DoesNotBumpAtime(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "evidence.bin")
+	require.NoError(t, os.WriteFile(p, []byte("evidence"), 0o600))
+	old := time.Now().Add(-30 * time.Hour).Truncate(time.Second)
+	require.NoError(t, os.Chtimes(p, old, old))
+
+	f, err := openReadNoAtime(p)
+	require.NoError(t, err)
+	buf := make([]byte, 8)
+	_, err = f.Read(buf)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	info, err := os.Stat(p)
+	require.NoError(t, err)
+	st, ok := info.Sys().(*syscall.Win32FileAttributeData)
+	require.True(t, ok)
+	got := time.Unix(0, st.LastAccessTime.Nanoseconds())
+	require.WithinDuration(t, old, got, time.Second, "serve read must not change atime")
+}

--- a/pkg/logic/service/service.go
+++ b/pkg/logic/service/service.go
@@ -38,6 +38,7 @@ var (
 	ErrGRPCFailedPrecondition = status.Error(codes.FailedPrecondition, "failed precondition")
 	ErrGRPCAlreadyExists      = status.Error(codes.AlreadyExists, "already exists")
 	ErrGRPCNotFound           = status.Error(codes.NotFound, "notFound")
+	ErrGRPCReadOnlyShare      = status.Error(codes.PermissionDenied, "share is read-only")
 )
 
 type KeibidropServiceImpl struct {
@@ -47,6 +48,14 @@ type KeibidropServiceImpl struct {
 	SyncTracker  *synctracker.SyncTracker
 	OnEvent      func(string)
 	OnDisconnect func() // Called (in goroutine) when peer sends DISCONNECT; cancels context to trigger cleanup.
+
+	// ShareReadOnly rejects every inbound mutation (add/edit/remove/rename,
+	// file or dir) before it touches disk or the tracker. The origin-side
+	// guarantee behind the read_only share mode; DISCONNECT still passes.
+	ShareReadOnly bool
+
+	// readOnlyRefusalLogged keeps the refusal log to one line per session.
+	readOnlyRefusalLogged atomic.Bool
 
 	// fs is published while the server is already serving: Run() backfills it
 	// after the first mount, and mount/unmount swap it mid-session. Handlers
@@ -111,8 +120,17 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 		return &bindings.NotifyResponse{Status: "ok"}, nil
 	}
 
+	// Read-only share: refuse every peer mutation before it reaches disk or
+	// the tracker. Log once per session, not once per refused notify.
+	if kd.ShareReadOnly {
+		if kd.readOnlyRefusalLogged.CompareAndSwap(false, true) {
+			logger.Warn("Refusing peer mutation: share is read-only", "first-path", req.Path)
+		}
+		return nil, ErrGRPCReadOnlyShare
+	}
+
 	// Drop macOS/FUSE internal files — ephemeral, never meant to be synced.
-	if strings.Contains(req.Path, ".fuse_hidden") || strings.Contains(req.Path, ".fseventsd") || strings.Contains(req.Path, ".fseventuuid") || strings.Contains(req.Path, ".DS_Store") {
+	if IsInternalPath(req.Path) {
 		// FUSE turns unlink of a still-open file into a rename to
 		// .fuse_hiddenN. Drop the hidden name but keep the effect: the
 		// source left the folder. Apply it as a buffered remove.
@@ -202,6 +220,7 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 				Size:         uint64(req.Attr.Size),
 				LastEditTime: req.Attr.ModificationTime,
 				CreatedTime:  req.Attr.BirthTime,
+				Mode:         req.Attr.Mode,
 			}
 
 			if kd.OnEvent != nil {
@@ -503,6 +522,13 @@ func (kd *KeibidropServiceImpl) BatchNotify(ctx context.Context, req *bindings.B
 	logger := kd.Logger.With("method", "batch-notify", "count", len(req.Notifications), "seq", req.Seq)
 	logger.Info("Processing batch")
 
+	if kd.ShareReadOnly {
+		if kd.readOnlyRefusalLogged.CompareAndSwap(false, true) {
+			logger.Warn("Refusing peer mutation batch: share is read-only")
+		}
+		return nil, ErrGRPCReadOnlyShare
+	}
+
 	var processed uint32
 	for _, n := range req.Notifications {
 		_, err := kd.Notify(ctx, n)
@@ -635,6 +661,7 @@ func (kd *KeibidropServiceImpl) upsertRemoteInTracker(req *bindings.NotifyReques
 		f.Size = uint64(req.Attr.Size)
 		f.LastEditTime = req.Attr.ModificationTime
 		f.CreatedTime = req.Attr.BirthTime
+		f.Mode = req.Attr.Mode
 		return
 	}
 	kd.SyncTracker.RemoteFiles[req.Path] = &synctracker.File{
@@ -643,6 +670,7 @@ func (kd *KeibidropServiceImpl) upsertRemoteInTracker(req *bindings.NotifyReques
 		Size:         uint64(req.Attr.Size),
 		LastEditTime: req.Attr.ModificationTime,
 		CreatedTime:  req.Attr.BirthTime,
+		Mode:         req.Attr.Mode,
 	}
 }
 

--- a/pkg/logic/service/service.go
+++ b/pkg/logic/service/service.go
@@ -210,6 +210,8 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 				// Update existing entry (peer overwrote the file).
 				existing.Size = uint64(req.Attr.Size)
 				existing.LastEditTime = req.Attr.ModificationTime
+				existing.Atime = req.Attr.AccessTime
+				existing.Mode = req.Attr.Mode
 				logger.Info("Updated existing remote file", "path", req.Path, "newSize", req.Attr.Size)
 				return &bindings.NotifyResponse{}, nil
 			}
@@ -220,6 +222,7 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 				Size:         uint64(req.Attr.Size),
 				LastEditTime: req.Attr.ModificationTime,
 				CreatedTime:  req.Attr.BirthTime,
+				Atime:        req.Attr.AccessTime,
 				Mode:         req.Attr.Mode,
 			}
 
@@ -279,6 +282,8 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 					Size:         uint64(req.Attr.Size),
 					LastEditTime: req.Attr.ModificationTime,
 					CreatedTime:  req.Attr.BirthTime,
+					Atime:        req.Attr.AccessTime,
+					Mode:         req.Attr.Mode,
 				}
 			} else {
 				f.Name = req.Name
@@ -286,6 +291,8 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 				f.Size = uint64(req.Attr.Size)
 				f.LastEditTime = req.Attr.ModificationTime
 				f.CreatedTime = req.Attr.BirthTime
+				f.Atime = req.Attr.AccessTime
+				f.Mode = req.Attr.Mode
 			}
 
 			if kd.OnEvent != nil {
@@ -661,6 +668,7 @@ func (kd *KeibidropServiceImpl) upsertRemoteInTracker(req *bindings.NotifyReques
 		f.Size = uint64(req.Attr.Size)
 		f.LastEditTime = req.Attr.ModificationTime
 		f.CreatedTime = req.Attr.BirthTime
+		f.Atime = req.Attr.AccessTime
 		f.Mode = req.Attr.Mode
 		return
 	}
@@ -670,6 +678,7 @@ func (kd *KeibidropServiceImpl) upsertRemoteInTracker(req *bindings.NotifyReques
 		Size:         uint64(req.Attr.Size),
 		LastEditTime: req.Attr.ModificationTime,
 		CreatedTime:  req.Attr.BirthTime,
+		Atime:        req.Attr.AccessTime,
 		Mode:         req.Attr.Mode,
 	}
 }

--- a/pkg/logic/service/service.go
+++ b/pkg/logic/service/service.go
@@ -766,7 +766,7 @@ func (kd *KeibidropServiceImpl) Read(stream bindings.KeibiService_ReadServer) er
 					return status.Error(codes.NotFound, "file not found")
 				}
 
-				fh, err = os.Open(realPath)
+				fh, err = kd.openServeRead(realPath)
 				if err != nil {
 					logger.Error("Failed to open real file", "error", err)
 					return status.Error(codes.Internal, "error accessing file")
@@ -850,7 +850,7 @@ func (kd *KeibidropServiceImpl) Read(stream bindings.KeibiService_ReadServer) er
 				return status.Error(codes.NotFound, "file not found")
 			}
 
-			fh, err = os.Open(realPath) // #nosec G304
+			fh, err = kd.openServeRead(realPath)
 			if err != nil {
 				logger.Error("Failed to open real file", "error", err)
 				return status.Error(codes.Internal, "error accessing file")
@@ -923,7 +923,7 @@ func (kd *KeibidropServiceImpl) StreamFile(req *bindings.StreamFileRequest, stre
 		return status.Error(codes.NotFound, "file not found")
 	}
 
-	fh, err := os.Open(realPath)
+	fh, err := kd.openServeRead(realPath)
 	if err != nil {
 		logger.Error("Failed to open file", "error", err)
 		return status.Error(codes.Internal, "error accessing file")
@@ -1013,7 +1013,7 @@ func (kd *KeibidropServiceImpl) GetChunkHashes(req *bindings.GetChunkHashesReque
 		return status.Error(codes.NotFound, "file not found")
 	}
 
-	fh, err := os.Open(realPath) // #nosec G304
+	fh, err := kd.openServeRead(realPath)
 	if err != nil {
 		logger.Error("Failed to open file", "error", err)
 		return status.Error(codes.Internal, "error accessing file")

--- a/pkg/logic/service/service_android.go
+++ b/pkg/logic/service/service_android.go
@@ -140,6 +140,8 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 			}
 			existing.Size = uint64(req.Attr.Size)
 			existing.LastEditTime = req.Attr.ModificationTime
+			existing.Atime = req.Attr.AccessTime
+			existing.Mode = req.Attr.Mode
 			logger.Info("Updated existing remote file", "path", req.Path, "newSize", req.Attr.Size)
 			return &bindings.NotifyResponse{}, nil
 		}
@@ -150,6 +152,8 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 			Size:         uint64(req.Attr.Size),
 			LastEditTime: req.Attr.ModificationTime,
 			CreatedTime:  req.Attr.BirthTime,
+			Atime:        req.Attr.AccessTime,
+			Mode:         req.Attr.Mode,
 		}
 
 		if kd.OnEvent != nil {
@@ -179,6 +183,8 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 				Size:         uint64(req.Attr.Size),
 				LastEditTime: req.Attr.ModificationTime,
 				CreatedTime:  req.Attr.BirthTime,
+				Atime:        req.Attr.AccessTime,
+				Mode:         req.Attr.Mode,
 			}
 		} else {
 			f.Name = req.Name
@@ -186,6 +192,8 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 			f.Size = uint64(req.Attr.Size)
 			f.LastEditTime = req.Attr.ModificationTime
 			f.CreatedTime = req.Attr.BirthTime
+			f.Atime = req.Attr.AccessTime
+			f.Mode = req.Attr.Mode
 		}
 
 		if kd.OnEvent != nil {

--- a/pkg/logic/service/service_android.go
+++ b/pkg/logic/service/service_android.go
@@ -39,6 +39,7 @@ var (
 	ErrGRPCFailedPrecondition = status.Error(codes.FailedPrecondition, "failed precondition")
 	ErrGRPCAlreadyExists      = status.Error(codes.AlreadyExists, "already exists")
 	ErrGRPCNotFound           = status.Error(codes.NotFound, "notFound")
+	ErrGRPCReadOnlyShare      = status.Error(codes.PermissionDenied, "share is read-only")
 )
 
 type KeibidropServiceImpl struct {
@@ -48,6 +49,13 @@ type KeibidropServiceImpl struct {
 	SyncTracker  *synctracker.SyncTracker
 	OnEvent      func(string)
 	OnDisconnect func()
+
+	// ShareReadOnly rejects every inbound mutation before it touches the
+	// tracker. Mirrors the desktop struct; DISCONNECT still passes.
+	ShareReadOnly bool
+
+	// readOnlyRefusalLogged keeps the refusal log to one line per session.
+	readOnlyRefusalLogged atomic.Bool
 
 	// fs mirrors the desktop struct so the common package compiles unchanged.
 	// Android has no FUSE, so it stays nil.
@@ -83,6 +91,14 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 			go kd.OnDisconnect()
 		}
 		return &bindings.NotifyResponse{Status: "ok"}, nil
+	}
+
+	// Read-only share: refuse every peer mutation before it reaches the tracker.
+	if kd.ShareReadOnly {
+		if kd.readOnlyRefusalLogged.CompareAndSwap(false, true) {
+			logger.Warn("Refusing peer mutation: share is read-only", "first-path", req.Path)
+		}
+		return nil, ErrGRPCReadOnlyShare
 	}
 
 	if kd.SyncTracker == nil {

--- a/pkg/logic/service/service_android.go
+++ b/pkg/logic/service/service_android.go
@@ -360,7 +360,7 @@ func (kd *KeibidropServiceImpl) Read(stream bindings.KeibiService_ReadServer) er
 				return status.Error(codes.NotFound, "file not found")
 			}
 
-			fh, err = os.Open(realPath)
+			fh, err = kd.openServeRead(realPath)
 			if err != nil {
 				logger.Error("Failed to open real file", "error", err)
 				return status.Error(codes.Internal, "error accessing file")
@@ -430,7 +430,7 @@ func (kd *KeibidropServiceImpl) StreamFile(req *bindings.StreamFileRequest, stre
 		return status.Error(codes.NotFound, "file not found")
 	}
 
-	fh, err := os.Open(f.RealPathOfFile)
+	fh, err := kd.openServeRead(f.RealPathOfFile)
 	if err != nil {
 		logger.Error("Failed to open file", "error", err)
 		return status.Error(codes.Internal, "error accessing file")

--- a/pkg/logic/service/service_readonly_test.go
+++ b/pkg/logic/service/service_readonly_test.go
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// ABOUTME: Tests share_read_only origin enforcement: every peer mutation is
+// ABOUTME: refused before disk, bytes and mtime stay intact, DISCONNECT passes.
+
+//go:build !android
+
+package service
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	bindings "github.com/KeibiSoft/KeibiDrop/grpc_bindings"
+	"github.com/KeibiSoft/KeibiDrop/pkg/filesystem"
+	synctracker "github.com/KeibiSoft/KeibiDrop/pkg/sync-tracker"
+	"github.com/stretchr/testify/require"
+)
+
+func newReadOnlyFixture(t *testing.T) (*KeibidropServiceImpl, string) {
+	t.Helper()
+	tmpDir := t.TempDir()
+	root := &filesystem.Dir{
+		RemoteFilesLock:     sync.RWMutex{},
+		RemoteFiles:         make(map[string]*filesystem.File),
+		AfmLock:             sync.RWMutex{},
+		AllFileMap:          make(map[string]*filesystem.File),
+		OpenMapLock:         sync.RWMutex{},
+		OpenFileHandlers:    make(map[uint64]*filesystem.HandleEntry),
+		Adm:                 sync.RWMutex{},
+		AllDirMap:           make(map[string]*filesystem.Dir),
+		RealPathOfFile:      tmpDir,
+		LocalDownloadFolder: tmpDir,
+		PrefetchSem:         make(chan struct{}, 8),
+	}
+	root.Root = root
+
+	svc := &KeibidropServiceImpl{
+		Logger:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		SyncTracker:   synctracker.NewSyncTracker(),
+		ShareReadOnly: true,
+	}
+	fsForSvc := &filesystem.FS{}
+	fsForSvc.SetRoot(root)
+	svc.SetFS(fsForSvc)
+	return svc, tmpDir
+}
+
+func attrFor(size int64) *bindings.Attr {
+	now := uint64(time.Now().UnixNano())
+	return &bindings.Attr{Mode: 0o644, Size: size, ModificationTime: now, ChangeTime: now, BirthTime: now}
+}
+
+// TestShareReadOnly_RefusesEveryMutation: the full mutating notify matrix is
+// refused with PermissionDenied and nothing lands in tracker or tree.
+func TestShareReadOnly_RefusesEveryMutation(t *testing.T) {
+	svc, _ := newReadOnlyFixture(t)
+
+	mutations := []*bindings.NotifyRequest{
+		{Type: bindings.NotifyType_ADD_FILE, Path: "new.txt", Attr: attrFor(4)},
+		{Type: bindings.NotifyType_EDIT_FILE, Path: "victim.txt", Attr: attrFor(9)},
+		{Type: bindings.NotifyType_REMOVE_FILE, Path: "victim.txt"},
+		{Type: bindings.NotifyType_RENAME_FILE, Path: "renamed.txt", OldPath: "victim.txt", Attr: attrFor(4)},
+		{Type: bindings.NotifyType_ADD_DIR, Path: "newdir"},
+		{Type: bindings.NotifyType_REMOVE_DIR, Path: "somedir"},
+	}
+	for _, req := range mutations {
+		_, err := svc.Notify(context.Background(), req)
+		require.ErrorIs(t, err, ErrGRPCReadOnlyShare, "type %v must be refused", req.Type)
+	}
+
+	svc.SyncTracker.RemoteFilesMu.RLock()
+	defer svc.SyncTracker.RemoteFilesMu.RUnlock()
+	require.Empty(t, svc.SyncTracker.RemoteFiles, "refused notifies must not touch the tracker")
+}
+
+// TestShareReadOnly_DiskUntouched: a peer REMOVE/EDIT of a shared file leaves
+// the on-disk bytes and mtime exactly as they were.
+func TestShareReadOnly_DiskUntouched(t *testing.T) {
+	svc, dir := newReadOnlyFixture(t)
+
+	victim := filepath.Join(dir, "victim.txt")
+	content := []byte("evidence bytes")
+	require.NoError(t, os.WriteFile(victim, content, 0o644))
+	before, err := os.Stat(victim)
+	require.NoError(t, err)
+
+	_, err = svc.Notify(context.Background(), &bindings.NotifyRequest{
+		Type: bindings.NotifyType_REMOVE_FILE, Path: "/victim.txt",
+	})
+	require.ErrorIs(t, err, ErrGRPCReadOnlyShare)
+	_, err = svc.Notify(context.Background(), &bindings.NotifyRequest{
+		Type: bindings.NotifyType_EDIT_FILE, Path: "/victim.txt", Attr: attrFor(3),
+	})
+	require.ErrorIs(t, err, ErrGRPCReadOnlyShare)
+
+	// The REMOVE debounce buffers deletes for 1s; outlive it before checking.
+	time.Sleep(1500 * time.Millisecond)
+
+	after, err := os.Stat(victim)
+	require.NoError(t, err, "file must still exist")
+	got, err := os.ReadFile(victim)
+	require.NoError(t, err)
+	require.Equal(t, content, got, "bytes must be unchanged")
+	require.Equal(t, before.ModTime(), after.ModTime(), "mtime must be unchanged")
+}
+
+// TestShareReadOnly_DisconnectStillPasses: the graceful disconnect control
+// message is not a mutation and must keep working.
+func TestShareReadOnly_DisconnectStillPasses(t *testing.T) {
+	svc, _ := newReadOnlyFixture(t)
+	disconnected := make(chan struct{}, 1)
+	svc.OnDisconnect = func() { disconnected <- struct{}{} }
+
+	resp, err := svc.Notify(context.Background(), &bindings.NotifyRequest{
+		Type: bindings.NotifyType_DISCONNECT,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "ok", resp.Status)
+	select {
+	case <-disconnected:
+	case <-time.After(2 * time.Second):
+		t.Fatal("OnDisconnect not called")
+	}
+}
+
+// TestShareReadOnly_BatchRefused: the batch entry point is refused as a whole.
+func TestShareReadOnly_BatchRefused(t *testing.T) {
+	svc, _ := newReadOnlyFixture(t)
+	_, err := svc.BatchNotify(context.Background(), &bindings.BatchNotifyRequest{
+		Notifications: []*bindings.NotifyRequest{
+			{Type: bindings.NotifyType_ADD_FILE, Path: "a.txt", Attr: attrFor(1)},
+		},
+		Seq: 1,
+	})
+	require.ErrorIs(t, err, ErrGRPCReadOnlyShare)
+}
+
+// TestShareReadOnly_OffAllowsMutations: flag off keeps today's behavior.
+func TestShareReadOnly_OffAllowsMutations(t *testing.T) {
+	svc, _ := newReadOnlyFixture(t)
+	svc.ShareReadOnly = false
+
+	_, err := svc.Notify(context.Background(), &bindings.NotifyRequest{
+		Type: bindings.NotifyType_ADD_FILE, Path: "ok.txt", Name: "ok.txt", Attr: attrFor(2),
+	})
+	require.NoError(t, err)
+}

--- a/pkg/sync-tracker/file_tracker.go
+++ b/pkg/sync-tracker/file_tracker.go
@@ -21,6 +21,7 @@ type File struct {
 	CreatedTime  uint64
 
 	Size uint64
+	Mode uint32 // Announced mode bits. 0 means unknown; presenters fall back to 0644.
 }
 
 type SyncTracker struct {

--- a/pkg/sync-tracker/file_tracker.go
+++ b/pkg/sync-tracker/file_tracker.go
@@ -19,6 +19,7 @@ type File struct {
 
 	LastEditTime uint64 // Use time.Now().UnixNano().
 	CreatedTime  uint64
+	Atime        uint64 // Announced access time, unix nanoseconds. 0 means unknown.
 
 	Size uint64
 	Mode uint32 // Announced mode bits. 0 means unknown; presenters fall back to 0644.

--- a/rust/src/bindings.rs
+++ b/rust/src/bindings.rs
@@ -8425,6 +8425,9 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    pub fn KD_SetAutoConnectPeer(peer: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+extern "C" {
     pub fn KD_SanitizeLogs(destPath: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {

--- a/rustbridge/main.go
+++ b/rustbridge/main.go
@@ -179,6 +179,9 @@ func KD_Initialize(relayURL *C.char, inbound, outbound C.int, toMount, toSave *C
 	kd.AutoCache = cfg.LiveCollab // live_collab sets macFUSE auto_cache for same-size live edits on macOS.
 	kd.PrefetchAutoMB = cfg.PrefetchAutoMB
 	kd.ReadAheadWindowMB = cfg.ReadAheadWindowMB
+	kd.ScanSharedOnStart = cfg.ScanSharedOnStart
+	kd.ShareReadOnly = cfg.ShareReadOnly
+	kd.MountReadOnly = cfg.MountReadOnly
 	for _, warn := range cfg.Warnings() {
 		logger.Warn("config flag note", "note", warn)
 	}
@@ -188,6 +191,13 @@ func KD_Initialize(relayURL *C.char, inbound, outbound C.int, toMount, toSave *C
 	}
 
 	go kd.Run()
+
+	if cfg.AutoConnectPeer != "" {
+		kd.AutoConnectPeer = cfg.AutoConnectPeer
+		if err := kd.StartAutoConnect(ctx); err != nil {
+			pushEvent("auto_connect_error:" + err.Error())
+		}
+	}
 	return 0
 }
 
@@ -797,10 +807,11 @@ func KD_GetConfigPath() *C.char {
 func KD_GetConfig() *C.char {
 	cfg, _ := config.Load()
 	return C.CString(fmt.Sprintf(
-		"relay=%s\nsave_path=%s\nmount_path=%s\nlog_file=%s\ninbound_port=%d\noutbound_port=%d\nbridge_addr=%s\nno_fuse=%v\nstrict_mode=%v",
+		"relay=%s\nsave_path=%s\nmount_path=%s\nlog_file=%s\ninbound_port=%d\noutbound_port=%d\nbridge_addr=%s\nno_fuse=%v\nstrict_mode=%v\nscan_shared_on_start=%v\nauto_connect_peer=%s\nshare_read_only=%v\nmount_read_only=%v",
 		cfg.Relay, cfg.SavePath, cfg.MountPath, cfg.LogFile,
 		cfg.InboundPort, cfg.OutboundPort, cfg.BridgeAddr,
-		cfg.NoFUSE, cfg.StrictMode,
+		cfg.NoFUSE, cfg.StrictMode, cfg.ScanSharedOnStart, cfg.AutoConnectPeer,
+		cfg.ShareReadOnly, cfg.MountReadOnly,
 	))
 }
 
@@ -828,10 +839,12 @@ func KD_TokensStatus() *C.char {
 			chains++
 		}
 	}
+	credit := kd.TokensCreditStatus()
 	return C.CString(fmt.Sprintf(
-		"wallet_gb=%.1f\nchains=%d\nvia=%s\npaid=%v\nbusy=%v\nnotice=%s\nbuy_url=%s",
+		"wallet_gb=%.1f\nchains=%d\nvia=%s\npaid=%v\nbusy=%v\nnotice=%s\nbuy_url=%s\ncredit_level=%s\ncredit_notice=%s",
 		bi.WalletGB, chains, bi.Via, bi.Paid, bi.Busy || bi.Contention,
-		strings.ReplaceAll(bi.Notice, "\n", " "), common.TokensBuyURL))
+		strings.ReplaceAll(bi.Notice, "\n", " "), common.TokensBuyURL,
+		credit.Level, strings.ReplaceAll(credit.Notice, "\n", " ")))
 }
 
 // KD_TokensBuyStart returns the buy URL carrying a fresh claim ref and
@@ -861,6 +874,25 @@ func KD_SaveConfig(relay, savePath, mountPath *C.char) C.int {
 	if err := config.Save(cfg); err != nil {
 		setLastError(err)
 		return -1
+	}
+	return 0
+}
+
+// KD_SetAutoConnectPeer persists the connect-at-startup contact (name or
+// fingerprint, empty clears) and applies it to the running instance. The
+// watchdog arms on the next app start; an already-armed watchdog keeps its
+// original target for this session.
+//
+//export KD_SetAutoConnectPeer
+func KD_SetAutoConnectPeer(peer *C.char) C.int {
+	cfg, _ := config.Load()
+	cfg.AutoConnectPeer = C.GoString(peer)
+	if err := config.Save(cfg); err != nil {
+		setLastError(err)
+		return -1
+	}
+	if kd != nil {
+		kd.AutoConnectPeer = cfg.AutoConnectPeer
 	}
 	return 0
 }

--- a/rustbridge/main.go
+++ b/rustbridge/main.go
@@ -182,6 +182,7 @@ func KD_Initialize(relayURL *C.char, inbound, outbound C.int, toMount, toSave *C
 	kd.ScanSharedOnStart = cfg.ScanSharedOnStart
 	kd.ShareReadOnly = cfg.ShareReadOnly
 	kd.MountReadOnly = cfg.MountReadOnly
+	kd.PreserveMetadata = cfg.PreserveMetadata
 	for _, warn := range cfg.Warnings() {
 		logger.Warn("config flag note", "note", warn)
 	}
@@ -807,11 +808,11 @@ func KD_GetConfigPath() *C.char {
 func KD_GetConfig() *C.char {
 	cfg, _ := config.Load()
 	return C.CString(fmt.Sprintf(
-		"relay=%s\nsave_path=%s\nmount_path=%s\nlog_file=%s\ninbound_port=%d\noutbound_port=%d\nbridge_addr=%s\nno_fuse=%v\nstrict_mode=%v\nscan_shared_on_start=%v\nauto_connect_peer=%s\nshare_read_only=%v\nmount_read_only=%v",
+		"relay=%s\nsave_path=%s\nmount_path=%s\nlog_file=%s\ninbound_port=%d\noutbound_port=%d\nbridge_addr=%s\nno_fuse=%v\nstrict_mode=%v\nscan_shared_on_start=%v\nauto_connect_peer=%s\nshare_read_only=%v\nmount_read_only=%v\npreserve_metadata=%v",
 		cfg.Relay, cfg.SavePath, cfg.MountPath, cfg.LogFile,
 		cfg.InboundPort, cfg.OutboundPort, cfg.BridgeAddr,
 		cfg.NoFUSE, cfg.StrictMode, cfg.ScanSharedOnStart, cfg.AutoConnectPeer,
-		cfg.ShareReadOnly, cfg.MountReadOnly,
+		cfg.ShareReadOnly, cfg.MountReadOnly, cfg.PreserveMetadata,
 	))
 }
 

--- a/tests/bench_regiondiff_test.go
+++ b/tests/bench_regiondiff_test.go
@@ -1,0 +1,142 @@
+// ABOUTME: Region-diff verification benchmark — in-place edit of a large cached
+// ABOUTME: file must resync ~the changed region, not the whole file.
+
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package tests
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestRegionDiffEditResync measures bytes-on-wire when a small region of a
+// large, fully cached file changes in place. The edit-reconcile path
+// (GetChunkHashes + bitmap re-mark) must keep the resync near the changed
+// region size. rsync over sshfs moves the whole file on this edit (default
+// whole-file mode on what it sees as local paths). Skipped in short mode.
+func TestRegionDiffEditResync(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping region-diff benchmark in short mode")
+	}
+	skipIfNoFUSE(t)
+	require := require.New(t)
+
+	// Pure on-demand: prefetch-on-open would re-stream the whole file after
+	// the edit reset and mask the reconcile win.
+	t.Setenv("KEIBIDROP_PREFETCH_ON_OPEN", "0")
+	// Same-size in-place edits reach a macOS mount only with auto_cache
+	// (live_collab). Without it the kernel page cache serves the pre-edit
+	// bytes, the documented git-safe default.
+	t.Setenv("KEIBIDROP_LIVE_COLLAB", "1")
+
+	// KD_REGIONDIFF_MB scales the file for manual artefact runs (default 256).
+	fileMB := 256
+	if v, err := strconv.Atoi(os.Getenv("KD_REGIONDIFF_MB")); err == nil && v >= 64 {
+		fileMB = v
+	}
+	var (
+		fileSize = fileMB * 1024 * 1024
+		editSize = 2 * 1024 * 1024
+		editOff  = fileSize/2 + 12345 // unaligned on purpose
+	)
+
+	tp := SetupFUSEPeerPair(t, 600*time.Second)
+	waitForFUSEMount(t, tp.AliceMountDir, 15*time.Second)
+
+	// Bob (origin, no-FUSE) shares a large file.
+	data := make([]byte, fileSize)
+	_, err := rand.Read(data)
+	require.NoError(err)
+	bobPath := filepath.Join(tp.BobSaveDir, "vmimage.bin")
+	require.NoError(os.WriteFile(bobPath, data, 0o644))
+	require.NoError(tp.Bob.AddFile(bobPath))
+
+	alicePath := filepath.Join(tp.AliceMountDir, "vmimage.bin")
+	WaitForCondition(t, 60*time.Second, 200*time.Millisecond, func() bool {
+		info, err := os.Stat(alicePath)
+		return err == nil && info.Size() == int64(fileSize)
+	}, "waiting for vmimage.bin to appear on Alice's mount at full size")
+
+	// Alice caches the whole file through the mount.
+	_, recvBefore := tp.Alice.WireStats()
+	start := time.Now()
+	sumInitial := mountFileSha256(t, alicePath)
+	initialDur := time.Since(start)
+	require.Equal(sha256.Sum256(data), sumInitial, "initial read must be byte-exact")
+	_, recvAfterInitial := tp.Alice.WireStats()
+	initialWire := recvAfterInitial - recvBefore
+
+	// Bob edits a small region IN PLACE (no truncate, no rename) and
+	// re-announces: same size, newer mtime = the in-place edit signal.
+	edit := make([]byte, editSize)
+	_, err = rand.Read(edit)
+	require.NoError(err)
+	copy(data[editOff:editOff+editSize], edit)
+	f, err := os.OpenFile(bobPath, os.O_WRONLY, 0)
+	require.NoError(err)
+	_, err = f.WriteAt(edit, int64(editOff))
+	require.NoError(err)
+	require.NoError(f.Close())
+	require.NoError(tp.Bob.AddFile(bobPath))
+
+	// Wait for the announce + async reconcile traffic to settle.
+	var settled uint64
+	WaitForCondition(t, 60*time.Second, 250*time.Millisecond, func() bool {
+		_, now := tp.Alice.WireStats()
+		if now == settled {
+			return true
+		}
+		settled = now
+		return false
+	}, "waiting for edit announce and reconcile traffic to settle")
+
+	// Alice re-reads the whole file. Unchanged chunks must come from cache.
+	start = time.Now()
+	sumAfter := mountFileSha256(t, alicePath)
+	rereadDur := time.Since(start)
+	require.Equal(sha256.Sum256(data), sumAfter, "post-edit read must be byte-exact")
+
+	_, recvFinal := tp.Alice.WireStats()
+	editWire := recvFinal - recvAfterInitial
+
+	t.Logf("regiondiff_bench file=%dMB edit=%dMB initial_wire=%dMB initial_dur=%s edit_wire_bytes=%d edit_wire_mb=%.2f reread_dur=%s edit_vs_file=%.2f%% edit_vs_region=%.1fx",
+		fileSize/(1024*1024), editSize/(1024*1024),
+		initialWire/(1024*1024), initialDur, editWire,
+		float64(editWire)/(1024*1024), rereadDur,
+		100*float64(editWire)/float64(fileSize),
+		float64(editWire)/float64(editSize))
+
+	// Sanity: the initial sync moved about the whole file.
+	require.Greater(initialWire, uint64(fileSize)*9/10, "initial sync should stream the file")
+	// The claim under test: the resync moves ~the region, not the file.
+	require.Less(editWire, uint64(fileSize)/4,
+		"edit resync moved %.1f%% of the file; region-diff did not fire", 100*float64(editWire)/float64(fileSize))
+}
+
+// mountFileSha256 reads the file through the mount in 4 MiB steps.
+func mountFileSha256(t *testing.T, path string) [32]byte {
+	t.Helper()
+	f, err := os.Open(filepath.Clean(path))
+	require.NoError(t, err)
+	defer f.Close()
+	h := sha256.New()
+	buf := make([]byte, 4*1024*1024)
+	_, err = io.CopyBuffer(h, f, buf)
+	require.NoError(t, err)
+	var out [32]byte
+	copy(out[:], h.Sum(nil))
+	return out
+}

--- a/tests/bench_scan_shared_test.go
+++ b/tests/bench_scan_shared_test.go
@@ -1,0 +1,86 @@
+// ABOUTME: Macro benchmark for ScanAndShareSaveDir — 1k and 10k pre-existing files.
+// ABOUTME: Records wall-clock and bytes-on-wire; proves announce is metadata-only.
+
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package tests
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestScanShareBenchmark measures the populated-folder startup scan: wall-clock
+// to announce N pre-existing files and bytes-on-wire for the announce burst.
+// The content must NOT move (metadata only), so wire bytes stay far below the
+// seeded content size. Skipped in short mode.
+func TestScanShareBenchmark(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping scan benchmark in short mode")
+	}
+
+	const fileSize = 4096
+
+	for _, count := range []int{1000, 10000} {
+		count := count
+		t.Run(fmt.Sprintf("%dfiles", count), func(t *testing.T) {
+			require := require.New(t)
+			tp := SetupPeerPairWithTimeout(t, false, 600*time.Second)
+
+			// Seed AFTER connect with the flag off, then invoke the scan
+			// directly: same code path the flag runs, but the timer excludes
+			// pairing. Spread across subdirs to exercise the BFS walk.
+			payload := make([]byte, fileSize)
+			_, err := rand.Read(payload)
+			require.NoError(err)
+			perDir := 100
+			for i := 0; i < count; i++ {
+				dir := filepath.Join(tp.BobSaveDir, fmt.Sprintf("d%03d", i/perDir))
+				if i%perDir == 0 {
+					require.NoError(os.MkdirAll(dir, 0o755))
+				}
+				require.NoError(os.WriteFile(filepath.Join(dir, fmt.Sprintf("f%05d.bin", i)), payload, 0o644))
+			}
+
+			sentBefore, _ := tp.Bob.WireStats()
+
+			start := time.Now()
+			n, err := tp.Bob.ScanAndShareSaveDir(context.Background())
+			scanDur := time.Since(start)
+			require.NoError(err)
+			require.Equal(count, n)
+
+			// Until the peer tracks every file (includes peer-side processing).
+			WaitForCondition(t, 300*time.Second, 100*time.Millisecond, func() bool {
+				tp.Alice.SyncTracker.RemoteFilesMu.RLock()
+				defer tp.Alice.SyncTracker.RemoteFilesMu.RUnlock()
+				return len(tp.Alice.SyncTracker.RemoteFiles) >= count
+			}, "waiting for peer to track all announced files")
+			e2eDur := time.Since(start)
+
+			sentAfter, _ := tp.Bob.WireStats()
+			wireBytes := sentAfter - sentBefore
+			contentBytes := uint64(count) * fileSize
+
+			t.Logf("scan_share_bench files=%d file_size=%d scan_wall=%s e2e_wall=%s files_per_sec=%.0f wire_bytes=%d wire_per_file=%d content_bytes=%d wire_vs_content=%.1f%%",
+				count, fileSize, scanDur, e2eDur,
+				float64(count)/e2eDur.Seconds(), wireBytes, wireBytes/uint64(count),
+				contentBytes, 100*float64(wireBytes)/float64(contentBytes))
+
+			// Metadata-only claim: the announce burst must not move content.
+			require.Less(wireBytes, contentBytes/2,
+				"announce moved too many bytes; content should stream on demand only")
+		})
+	}
+}

--- a/tests/harness_test.go
+++ b/tests/harness_test.go
@@ -42,6 +42,10 @@ type TestPair struct {
 	runWg *sync.WaitGroup // tracks Run() goroutines for clean shutdown
 }
 
+// PreConnectFunc runs after both peers are constructed, before Run and the
+// room handshake. Tests use it to seed save dirs and set pre-connect flags.
+type PreConnectFunc func(alice, bob *common.KeibiDrop, aliceSave, bobSave string)
+
 // SetupPeerPair creates two KeibiDrop instances connected through a mock relay.
 // Uses t.TempDir() for all directories, dynamic ports in the 26100-26999 range,
 // and ::1 for IPv6 loopback. Returns a fully connected pair ready for file operations.
@@ -53,16 +57,21 @@ func SetupPeerPair(t *testing.T, isFuse bool) *TestPair {
 // This avoids the cgofuse limitation where two concurrent mounts in the same
 // process race on signal handler registration.
 func SetupFUSEPeerPair(t *testing.T, timeout time.Duration) *TestPair {
-	return setupPeerPairImpl(t, true, false, timeout)
+	return setupPeerPairImpl(t, true, false, timeout, nil)
+}
+
+// SetupFUSEPeerPairPreConnect is SetupFUSEPeerPair with a pre-connect hook.
+func SetupFUSEPeerPairPreConnect(t *testing.T, timeout time.Duration, pre PreConnectFunc) *TestPair {
+	return setupPeerPairImpl(t, true, false, timeout, pre)
 }
 
 // SetupPeerPairWithTimeout is like SetupPeerPair but with a custom timeout.
 func SetupPeerPairWithTimeout(t *testing.T, isFuse bool, timeout time.Duration) *TestPair {
-	return setupPeerPairImpl(t, isFuse, isFuse, timeout)
+	return setupPeerPairImpl(t, isFuse, isFuse, timeout, nil)
 }
 
 // setupPeerPairImpl is the shared implementation for all peer pair constructors.
-func setupPeerPairImpl(t *testing.T, aliceFuse bool, bobFuse bool, timeout time.Duration) *TestPair {
+func setupPeerPairImpl(t *testing.T, aliceFuse bool, bobFuse bool, timeout time.Duration, pre PreConnectFunc) *TestPair {
 	t.Helper()
 	require := require.New(t)
 
@@ -134,6 +143,10 @@ func setupPeerPairImpl(t *testing.T, aliceFuse bool, bobFuse bool, timeout time.
 
 	require.NoError(kdAlice.AddPeerFingerprint(bobFp))
 	require.NoError(kdBob.AddPeerFingerprint(aliceFp))
+
+	if pre != nil {
+		pre(kdAlice, kdBob, aliceSave, bobSave)
+	}
 
 	// Start Run() loops (tracked via WaitGroup for clean teardown)
 	var runWg sync.WaitGroup

--- a/tests/integration_auto_connect_test.go
+++ b/tests/integration_auto_connect_test.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// ABOUTME: Integration test for auto_connect_peer — two peers with saved
+// ABOUTME: contacts establish a session on their own, no manual room calls.
+
+package tests
+
+import (
+	"context"
+	"log/slog"
+	"net/url"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/KeibiSoft/KeibiDrop/pkg/logic/common"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAutoConnect_BothSidesEstablishSession is the permanent-link demo: both
+// peers boot with auto_connect_peer set to a saved contact and nothing else.
+// The watchdogs pick roles by fingerprint tiebreak, survive the joiner racing
+// the creator's relay registration, and end in a running session.
+func TestAutoConnect_BothSidesEstablishSession(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping auto-connect integration test in short mode")
+	}
+	require := require.New(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	relay := NewMockRelay()
+	relayURL, err := url.Parse(relay.URL())
+	require.NoError(err)
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	aIn := getFreePortInRange(t, 26100, 26249)
+	aOut := getFreePortInRange(t, 26250, 26399)
+	bIn := getFreePortInRange(t, 26400, 26549)
+	bOut := getFreePortInRange(t, 26550, 26699)
+
+	alice, err := common.NewKeibiDropWithIP(ctx, logger.With("peer", "alice"),
+		false, relayURL, aIn, aOut, t.TempDir(), t.TempDir(), false, true, "::1")
+	require.NoError(err)
+	bob, err := common.NewKeibiDropWithIP(ctx, logger.With("peer", "bob"),
+		false, relayURL, bIn, bOut, t.TempDir(), t.TempDir(), false, true, "::1")
+	require.NoError(err)
+
+	require.NoError(alice.EnablePersistentIdentity(t.TempDir(), common.EnableOpts{}))
+	require.NoError(bob.EnablePersistentIdentity(t.TempDir(), common.EnableOpts{}))
+
+	aliceFP, err := alice.ExportFingerprint()
+	require.NoError(err)
+	bobFP, err := bob.ExportFingerprint()
+	require.NoError(err)
+
+	require.NoError(alice.AddressBook.Add("bob", bobFP))
+	require.NoError(bob.AddressBook.Add("alice", aliceFP))
+
+	var runWg sync.WaitGroup
+	runWg.Add(2)
+	go func() { defer runWg.Done(); alice.Run() }()
+	go func() { defer runWg.Done(); bob.Run() }()
+
+	alice.AutoConnectPeer = "bob"
+	bob.AutoConnectPeer = "alice"
+	require.NoError(alice.StartAutoConnect(ctx))
+	require.NoError(bob.StartAutoConnect(ctx))
+
+	WaitForCondition(t, 90*time.Second, 250*time.Millisecond, func() bool {
+		return alice.IsRunning() && bob.IsRunning()
+	}, "waiting for auto-connect to establish the session on both sides")
+
+	// Unknown contact still fails clearly even while a session runs.
+	bob.AutoConnectPeer = "nobody-saved"
+	require.Error(bob.StartAutoConnect(ctx))
+
+	cancel()
+	alice.StopConnectionResilience()
+	bob.StopConnectionResilience()
+	alice.Shutdown()
+	bob.Shutdown()
+
+	done := make(chan struct{})
+	go func() { runWg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+	}
+}

--- a/tests/integration_forensic_topology_test.go
+++ b/tests/integration_forensic_topology_test.go
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// ABOUTME: Pins the forensic deployment: compromised machine serves evidence
+// ABOUTME: read-only and untampered; the analyst gets bytes + origin metadata.
+
+package tests
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/KeibiSoft/KeibiDrop/pkg/logic/common"
+	"github.com/stretchr/testify/require"
+)
+
+// TestForensicTopology_ReadOnlySourcePreservingAnalyst is the DFIR deployment
+// as one test. Machine A (compromised, no FUSE needed): evidence in save_path,
+// scan_shared_on_start announces it, share_read_only refuses every peer
+// mutation. Machine B (analyst): FUSE mount with mount_read_only so local
+// writes get EROFS, preserve_metadata so saved bytes keep origin timestamps.
+// Invariants: B reads everything byte-exact with origin metadata; nothing on
+// A changes (bytes, mtime, file set).
+func TestForensicTopology_ReadOnlySourcePreservingAnalyst(t *testing.T) {
+	skipIfNoFUSE(t)
+	require := require.New(t)
+
+	origMtime := time.Now().Add(-72 * time.Hour).Truncate(time.Second)
+	origAtime := time.Now().Add(-24 * time.Hour).Truncate(time.Second)
+	evidence := map[string][]byte{
+		"dump/memory.raw": []byte("raw memory dump bytes"),
+		"logs/auth.log":   []byte("sshd: accepted password for root"),
+	}
+
+	tp := SetupFUSEPeerPairPreConnect(t, 120*time.Second,
+		func(alice, bob *common.KeibiDrop, aliceSave, bobSave string) {
+			// Machine A: evidence collected into save_path before pairing.
+			for rel, content := range evidence {
+				p := filepath.Join(bobSave, filepath.FromSlash(rel))
+				require.NoError(os.MkdirAll(filepath.Dir(p), 0o755))
+				require.NoError(os.WriteFile(p, content, 0o644))
+				require.NoError(os.Chmod(p, 0o640))
+				require.NoError(os.Chtimes(p, origAtime, origMtime))
+			}
+			bob.ScanSharedOnStart = true
+			bob.ShareReadOnly = true
+			// Machine B: analyst.
+			alice.MountReadOnly = true
+			alice.PreserveMetadata = true
+		})
+	waitForFUSEMount(t, tp.AliceMountDir, 15*time.Second)
+
+	// B gets every evidence file, byte-exact, through the mount.
+	for rel, content := range evidence {
+		rel, content := rel, content
+		mountPath := filepath.Join(tp.AliceMountDir, filepath.FromSlash(rel))
+		WaitForCondition(t, 30*time.Second, 200*time.Millisecond, func() bool {
+			info, err := os.Stat(mountPath)
+			return err == nil && info.Size() == int64(len(content))
+		}, "waiting for "+rel+" on the analyst mount")
+		got, err := os.ReadFile(mountPath)
+		require.NoError(err, rel)
+		require.Equal(content, got, "byte mismatch: %s", rel)
+	}
+
+	// B cannot contaminate the tree: local writes through the mount get EROFS.
+	err := os.WriteFile(filepath.Join(tp.AliceMountDir, "dump", "note.txt"), []byte("x"), 0o644)
+	require.Error(err, "analyst writes must be refused by the read-only mount")
+
+	// B cannot push anything to A: the origin refuses every peer mutation.
+	plant := filepath.Join(t.TempDir(), "plant.txt")
+	require.NoError(os.WriteFile(plant, []byte("planted"), 0o644))
+	require.Error(tp.Alice.AddFile(plant), "read-only origin must refuse the share")
+
+	// B's saved bytes carry the origin metadata once complete.
+	diskPath := filepath.Join(tp.AliceSaveDir, "dump", "memory.raw")
+	WaitForCondition(t, 15*time.Second, 200*time.Millisecond, func() bool {
+		info, err := os.Stat(diskPath)
+		if err != nil {
+			return false
+		}
+		d := info.ModTime().Sub(origMtime)
+		if d < 0 {
+			d = -d
+		}
+		return d <= time.Second
+	}, "waiting for origin mtime on the analyst's saved bytes")
+	info, err := os.Stat(diskPath)
+	require.NoError(err)
+	require.WithinDuration(origMtime, info.ModTime(), time.Second)
+	if runtime.GOOS != "windows" {
+		require.Equal(os.FileMode(0o640), info.Mode().Perm())
+	}
+	root := tp.Alice.FS.Root()
+	root.RemoteFilesLock.RLock()
+	f := root.RemoteFiles["/dump/memory.raw"]
+	root.RemoteFilesLock.RUnlock()
+	require.NotNil(f)
+	require.Equal(origAtime.UnixNano(), f.OriginAtimeNs, "origin atime recorded on the analyst side")
+
+	// A is untampered: same bytes, same mtime, same file set. Serving is
+	// read-only (os.Open) and share_read_only blocked the plant upstream.
+	seen := map[string]bool{}
+	err = filepath.Walk(tp.BobSaveDir, func(p string, fi os.FileInfo, err error) error {
+		if err != nil || fi.IsDir() || fi.Name() == ".DS_Store" {
+			return err
+		}
+		rel, rerr := filepath.Rel(tp.BobSaveDir, p)
+		if rerr != nil {
+			return rerr
+		}
+		seen[filepath.ToSlash(rel)] = true
+		return nil
+	})
+	require.NoError(err)
+	require.Len(seen, len(evidence), "no files may appear or vanish on the evidence machine: %v", seen)
+	for rel, content := range evidence {
+		require.True(seen[rel], "evidence file missing on A: %s", rel)
+		p := filepath.Join(tp.BobSaveDir, filepath.FromSlash(rel))
+		got, rerr := os.ReadFile(p)
+		require.NoError(rerr)
+		require.Equal(content, got, "evidence bytes changed on A: %s", rel)
+		sinfo, serr := os.Stat(p)
+		require.NoError(serr)
+		require.WithinDuration(origMtime, sinfo.ModTime(), time.Second, "evidence mtime changed on A: %s", rel)
+	}
+}

--- a/tests/integration_preserve_metadata_test.go
+++ b/tests/integration_preserve_metadata_test.go
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// ABOUTME: Integration tests for preserve_metadata — a file's original
+// ABOUTME: mtime, atime and mode survive the transfer onto the receiver's disk.
+
+package tests
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/KeibiSoft/KeibiDrop/pkg/logic/common"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPreserveMetadata_FUSEReceiverAppliesOriginTimes is the DFIR scenario:
+// evidence collected days ago moves to an analyst's machine, and the bytes
+// saved on the analyst's disk keep the original mtime and mode. Exercises the
+// FUSE Release completion path (read-through download).
+func TestPreserveMetadata_FUSEReceiverAppliesOriginTimes(t *testing.T) {
+	skipIfNoFUSE(t)
+	require := require.New(t)
+
+	origMtime := time.Now().Add(-48 * time.Hour).Truncate(time.Second)
+	origAtime := time.Now().Add(-24 * time.Hour).Truncate(time.Second)
+	content := []byte("evidence: original timestamps must survive the transfer")
+
+	tp := SetupFUSEPeerPairPreConnect(t, 120*time.Second,
+		func(alice, bob *common.KeibiDrop, aliceSave, bobSave string) {
+			p := filepath.Join(bobSave, "evidence.bin")
+			require.NoError(os.WriteFile(p, content, 0o644))
+			require.NoError(os.Chmod(p, 0o640))
+			require.NoError(os.Chtimes(p, origAtime, origMtime))
+			bob.ScanSharedOnStart = true
+			alice.PreserveMetadata = true
+		})
+	waitForFUSEMount(t, tp.AliceMountDir, 15*time.Second)
+
+	mountPath := filepath.Join(tp.AliceMountDir, "evidence.bin")
+	WaitForCondition(t, 30*time.Second, 200*time.Millisecond, func() bool {
+		info, err := os.Stat(mountPath)
+		return err == nil && info.Size() == int64(len(content))
+	}, "waiting for evidence.bin on Alice's mount")
+
+	// Full read: the bitmap completes and Release applies the origin metadata.
+	got, err := os.ReadFile(mountPath)
+	require.NoError(err)
+	require.Equal(content, got)
+
+	diskPath := filepath.Join(tp.AliceSaveDir, "evidence.bin")
+	WaitForCondition(t, 15*time.Second, 200*time.Millisecond, func() bool {
+		info, err := os.Stat(diskPath)
+		if err != nil {
+			return false
+		}
+		d := info.ModTime().Sub(origMtime)
+		if d < 0 {
+			d = -d
+		}
+		return d <= time.Second
+	}, "waiting for the origin mtime on Alice's saved bytes")
+
+	info, err := os.Stat(diskPath)
+	require.NoError(err)
+	require.WithinDuration(origMtime, info.ModTime(), time.Second, "disk mtime must be the origin's")
+	if runtime.GOOS != "windows" {
+		require.Equal(os.FileMode(0o640), info.Mode().Perm(), "disk mode must be the origin's")
+	}
+
+	// The origin's real atime crossed the wire and fed the apply (one Chtimes
+	// call sets atime and mtime together; the mtime assert above proves it ran).
+	root := tp.Alice.FS.Root()
+	root.RemoteFilesLock.RLock()
+	f := root.RemoteFiles["/evidence.bin"]
+	root.RemoteFilesLock.RUnlock()
+	require.NotNil(f)
+	require.Equal(origAtime.UnixNano(), f.OriginAtimeNs, "announce must carry the real atime")
+}
+
+// TestPreserveMetadata_PullFileAppliesOriginTimes covers the no-FUSE receiver:
+// PullFile lands the bytes, finalizeDownload applies the origin metadata.
+// Also the control: with the flag off, the pulled copy keeps fresh local times.
+func TestPreserveMetadata_PullFileAppliesOriginTimes(t *testing.T) {
+	require := require.New(t)
+	tp := SetupPeerPairWithTimeout(t, false, 60*time.Second)
+
+	origMtime := time.Now().Add(-48 * time.Hour).Truncate(time.Second)
+	origAtime := time.Now().Add(-24 * time.Hour).Truncate(time.Second)
+	content := []byte("pulled evidence with original metadata")
+	src := filepath.Join(tp.AliceSaveDir, "evidence.bin")
+	require.NoError(os.WriteFile(src, content, 0o644))
+	require.NoError(os.Chmod(src, 0o640))
+	require.NoError(os.Chtimes(src, origAtime, origMtime))
+	require.NoError(tp.Alice.AddFile(src))
+
+	WaitForRemoteFile(t, tp.Bob.SyncTracker, "evidence.bin", 5*time.Second)
+
+	// The announce carried the real atime, not an mtime copy.
+	tp.Bob.SyncTracker.RemoteFilesMu.RLock()
+	rf := tp.Bob.SyncTracker.RemoteFiles["evidence.bin"]
+	tp.Bob.SyncTracker.RemoteFilesMu.RUnlock()
+	require.NotNil(rf)
+	require.Equal(uint64(origAtime.UnixNano()), rf.Atime, "tracker must hold the announced atime")
+
+	tp.Bob.PreserveMetadata = true
+	dest := filepath.Join(t.TempDir(), "evidence.bin")
+	require.NoError(tp.Bob.PullFile("evidence.bin", dest))
+
+	pulled, err := os.ReadFile(dest)
+	require.NoError(err)
+	require.Equal(content, pulled)
+	info, err := os.Stat(dest)
+	require.NoError(err)
+	require.WithinDuration(origMtime, info.ModTime(), time.Second, "pulled file keeps the origin mtime")
+	if runtime.GOOS != "windows" {
+		require.Equal(os.FileMode(0o640), info.Mode().Perm(), "pulled file keeps the origin mode")
+	}
+
+	// Control: flag off, the local write time stays.
+	tp.Bob.PreserveMetadata = false
+	dest2 := filepath.Join(t.TempDir(), "evidence2.bin")
+	require.NoError(tp.Bob.PullFile("evidence.bin", dest2))
+	info2, err := os.Stat(dest2)
+	require.NoError(err)
+	require.WithinDuration(time.Now(), info2.ModTime(), time.Minute, "flag off: pulled file keeps local times")
+}

--- a/tests/integration_readonly_test.go
+++ b/tests/integration_readonly_test.go
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// ABOUTME: End-to-end read-only tests: a writer peer cannot alter a
+// ABOUTME: share_read_only origin, and a mount_read_only mount returns EROFS.
+
+package tests
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/KeibiSoft/KeibiDrop/pkg/logic/common"
+	"github.com/stretchr/testify/require"
+)
+
+// TestShareReadOnly_WriterCannotAlterOrigin: Bob shares a file with
+// share_read_only. Alice reads it through her mount, then tries to write and
+// delete it. Bob's disk must stay byte-identical with the original mtime.
+func TestShareReadOnly_WriterCannotAlterOrigin(t *testing.T) {
+	skipIfNoFUSE(t)
+	require := require.New(t)
+
+	content := []byte("read-only origin bytes")
+	tp := SetupFUSEPeerPairPreConnect(t, 120*time.Second,
+		func(alice, bob *common.KeibiDrop, aliceSave, bobSave string) {
+			require.NoError(os.WriteFile(filepath.Join(bobSave, "evidence.txt"), content, 0o644))
+			bob.ScanSharedOnStart = true
+			bob.ShareReadOnly = true
+		})
+	waitForFUSEMount(t, tp.AliceMountDir, 15*time.Second)
+
+	bobPath := filepath.Join(tp.BobSaveDir, "evidence.txt")
+	before, err := os.Stat(bobPath)
+	require.NoError(err)
+
+	alicePath := filepath.Join(tp.AliceMountDir, "evidence.txt")
+	WaitForCondition(t, 30*time.Second, 200*time.Millisecond, func() bool {
+		info, err := os.Stat(alicePath)
+		return err == nil && info.Size() == int64(len(content))
+	}, "waiting for evidence.txt on Alice's mount")
+
+	got, err := os.ReadFile(alicePath)
+	require.NoError(err)
+	require.Equal(content, got, "read must work on a read-only share")
+
+	// Alice attacks: overwrite, then delete, then create a new file. Local
+	// FUSE ops may succeed in her view; the origin must refuse them all.
+	_ = os.WriteFile(alicePath, []byte("tampered"), 0o644)
+	_ = os.Remove(filepath.Join(tp.AliceMountDir, "evidence.txt"))
+	_ = os.WriteFile(filepath.Join(tp.AliceMountDir, "planted.txt"), []byte("plant"), 0o644)
+
+	// Outlive the watcher debounce (200ms) plus the notify round trip.
+	time.Sleep(3 * time.Second)
+
+	after, err := os.Stat(bobPath)
+	require.NoError(err, "origin file must still exist")
+	bobBytes, err := os.ReadFile(bobPath)
+	require.NoError(err)
+	require.Equal(content, bobBytes, "origin bytes must be unchanged")
+	require.Equal(before.ModTime(), after.ModTime(), "origin mtime must be unchanged")
+
+	_, err = os.Stat(filepath.Join(tp.BobSaveDir, "planted.txt"))
+	require.True(os.IsNotExist(err), "planted file must not reach the origin")
+}
+
+// TestMountReadOnly_EROFSOnRealMount: with mount_read_only on the FUSE side,
+// create/write/remove/rename/mkdir on the mount fail, and reads still work.
+func TestMountReadOnly_EROFSOnRealMount(t *testing.T) {
+	skipIfNoFUSE(t)
+	require := require.New(t)
+
+	content := []byte("look but do not touch")
+	tp := SetupFUSEPeerPairPreConnect(t, 120*time.Second,
+		func(alice, bob *common.KeibiDrop, aliceSave, bobSave string) {
+			require.NoError(os.WriteFile(filepath.Join(bobSave, "shared.txt"), content, 0o644))
+			bob.ScanSharedOnStart = true
+			alice.MountReadOnly = true
+		})
+	waitForFUSEMount(t, tp.AliceMountDir, 15*time.Second)
+
+	alicePath := filepath.Join(tp.AliceMountDir, "shared.txt")
+	WaitForCondition(t, 30*time.Second, 200*time.Millisecond, func() bool {
+		info, err := os.Stat(alicePath)
+		return err == nil && info.Size() == int64(len(content))
+	}, "waiting for shared.txt on Alice's read-only mount")
+
+	got, err := os.ReadFile(alicePath)
+	require.NoError(err, "reads must work on a read-only mount")
+	require.Equal(content, got)
+
+	require.Error(os.WriteFile(filepath.Join(tp.AliceMountDir, "new.txt"), []byte("x"), 0o644), "create must fail")
+	f, err := os.OpenFile(alicePath, os.O_WRONLY, 0)
+	if err == nil {
+		f.Close()
+		t.Fatal("write-open must fail on a read-only mount")
+	}
+	require.Error(os.Remove(alicePath), "unlink must fail")
+	require.Error(os.Rename(alicePath, filepath.Join(tp.AliceMountDir, "renamed.txt")), "rename must fail")
+	require.Error(os.Mkdir(filepath.Join(tp.AliceMountDir, "newdir"), 0o755), "mkdir must fail")
+
+	// The file is still there and intact after the refused ops.
+	got, err = os.ReadFile(alicePath)
+	require.NoError(err)
+	require.Equal(content, got)
+}

--- a/tests/integration_scan_shared_test.go
+++ b/tests/integration_scan_shared_test.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// ABOUTME: Integration test for scan_shared_on_start — a save dir populated
+// ABOUTME: BEFORE pairing appears on the peer's mount, byte-exact, junk excluded.
+
+package tests
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/KeibiSoft/KeibiDrop/pkg/logic/common"
+	"github.com/stretchr/testify/require"
+)
+
+// TestScanSharedOnStart_PopulatedFolderAppears is the sshfs-parity demo:
+// Bob (no-FUSE) points his save dir at a folder that already has files and
+// sets scan_shared_on_start. After pairing, the whole tree appears in
+// Alice's FUSE mount and reads byte-exact, without any per-file add.
+func TestScanSharedOnStart_PopulatedFolderAppears(t *testing.T) {
+	skipIfNoFUSE(t)
+	require := require.New(t)
+
+	big := make([]byte, 512*1024)
+	_, err := rand.Read(big)
+	require.NoError(err)
+
+	seed := map[string][]byte{
+		"report.txt":          []byte("top level file"),
+		"data.bin":            big,
+		"models/weights.dat":  append([]byte("w"), big[:128*1024]...),
+		"models/cfg/net.json": []byte(`{"layers":3}`),
+	}
+
+	tp := SetupFUSEPeerPairPreConnect(t, 120*time.Second,
+		func(alice, bob *common.KeibiDrop, aliceSave, bobSave string) {
+			for rel, content := range seed {
+				p := filepath.Join(bobSave, filepath.FromSlash(rel))
+				require.NoError(os.MkdirAll(filepath.Dir(p), 0o755))
+				require.NoError(os.WriteFile(p, content, 0o644))
+			}
+			require.NoError(os.WriteFile(filepath.Join(bobSave, ".DS_Store"), []byte("junk"), 0o644))
+			bob.ScanSharedOnStart = true
+		})
+	waitForFUSEMount(t, tp.AliceMountDir, 15*time.Second)
+
+	for rel, content := range seed {
+		rel, content := rel, content
+		mountPath := filepath.Join(tp.AliceMountDir, filepath.FromSlash(rel))
+		WaitForCondition(t, 30*time.Second, 200*time.Millisecond, func() bool {
+			info, err := os.Stat(mountPath)
+			return err == nil && info.Size() == int64(len(content))
+		}, "waiting for "+rel+" to appear in Alice's mount")
+
+		got, err := os.ReadFile(mountPath)
+		require.NoError(err, rel)
+		require.Equal(sha256.Sum256(content), sha256.Sum256(got), "content mismatch: %s", rel)
+	}
+
+	// Internal files never sync.
+	_, err = os.Stat(filepath.Join(tp.AliceMountDir, ".DS_Store"))
+	require.True(os.IsNotExist(err), ".DS_Store must not appear on the peer")
+
+	// The mount presents the origin's mtime (metadata contract).
+	src, err := os.Stat(filepath.Join(tp.BobSaveDir, "report.txt"))
+	require.NoError(err)
+	dst, err := os.Stat(filepath.Join(tp.AliceMountDir, "report.txt"))
+	require.NoError(err)
+	require.WithinDuration(src.ModTime(), dst.ModTime(), time.Second,
+		"peer mount must show the origin mtime")
+}


### PR DESCRIPTION
The defaults for this config-first features is off.

- scan_shared_on_start: announces the save_path to the peer
- auto_connect_peer: connect to a saved contact on startup
- share_read_only: refuse any inbound peer mutations at service layer

Added also relay credit alerts for infra deployments.

Expanded tests to verify regressions for:

- region-diff: it fires byte exact as expected
- WireStats also counts QUIC lanes
- synctracker.File carries Mode
- test harness gains a pre-connect hook