### PR TITLE
docs: add Android install and mobile app licensing

### DIFF
--- a/DUAL-LICENSE.md
+++ b/DUAL-LICENSE.md
@@ -12,6 +12,10 @@ The Rust UI (`rust/`) and FFI bridge (`rustbridge/`) are **proprietary software*
 
 The [Slint](https://slint.dev) UI framework is used under the **Slint Royalty-Free Desktop, Mobile, and Web Applications License** - not GPLv3. Attribution to Slint is provided in the application.
 
+## Android and iOS Apps - Proprietary
+
+The **KEIBI**DROP mobile apps are **proprietary software** owned by **KEIBI**SOFT SRL, distributed as binaries through our F-Droid repository and the app stores. They embed the MPL-2.0 Go engine through the mobile bindings above; that does not place the apps themselves under MPL-2.0.
+
 ## Brand Assets - Proprietary, All Rights Reserved
 
 **The following are the exclusive property of **KEIBI**SOFT SRL and are NOT covered by any open source license:**

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Another computer's files show up as a folder on yours. Open and edit them in you
 - End-to-end encrypted (post-quantum). No cloud, and the relay never reads your files.
 - Same network: one click. Over the internet: swap a code once, then save the contact.
 - Their files become a real folder on your machine. Open, edit, `git clone`, anything.
-- macOS, Linux, Windows. iOS and Android coming soon. Open source (MPL-2.0).
+- macOS, Linux, Windows, Android. iOS coming soon. Open source engine (MPL-2.0).
 
 <p align="center">
   <img src="demo-photos/initial-screen.png" alt="KeibiDrop connection screen" width="700">
@@ -67,6 +67,12 @@ choco install keibidrop
 ```
 
 Or download from [GitHub Releases](https://github.com/KeibiSoft/KeibiDrop/releases).
+
+### Android
+
+We host our own F-Droid repository. Open [fdroid.keibisoft.com](https://fdroid.keibisoft.com) on your phone, scan the code, and check the fingerprint before you add it.
+
+To add it by hand, use `https://fdroid.keibisoft.com/fdroid/repo` in F-Droid under Settings, Repositories. The fingerprint to check is on the same page.
 
 ### Build from source
 
@@ -191,7 +197,7 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 Go engine, CLI, and mobile bindings: [Mozilla Public License 2.0](./LICENSE) (per-file copyleft)
 
-Rust UI and brand assets: Proprietary - see [DUAL-LICENSE.md](./DUAL-LICENSE.md)
+Rust UI, mobile apps, and brand assets: Proprietary - see [DUAL-LICENSE.md](./DUAL-LICENSE.md)
 
 Desktop UI built with [Slint](https://slint.dev)
 


### PR DESCRIPTION
The Android app ships through our own F-Droid repository now, so the README says so instead of "coming soon". It points at the repo page rather than repeating the URL and fingerprint, so there is one place to keep correct.

Also records that the mobile apps are proprietary binaries. DUAL-LICENSE.md covered the Go engine and the Rust UI, but not the apps.