### PR TITLE
fix(security): 0.4.2 engine hardening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,9 @@ libkeibidrop-*.a
 libkeibidrop-*.h
 mount-fuse
 *sanitized*
+
+# SDD subagent workspace + local build outputs (scratch, never committed)
+.superpowers/
+/task-*/
+/keibidrop.aar
+kd_bridge.log

--- a/Makefile
+++ b/Makefile
@@ -85,13 +85,14 @@ test:
 	go test -v -count=1 -timeout 600s -skip '$(TEST_SKIP)' ./tests/...
 
 # Deterministic concurrency-race guards under the race detector. Scoped to the
-# in-process unit tests (no FUSE mount) across pkg/filesystem, pkg/session and
-# pkg/logic/common so it stays fast and cannot trip the unrelated cgofuse
-# mount-teardown race that end-to-end FUSE tests hit under -race. Covers the
-# Release async-notify race, the handle-reuse and prefetch-rename guards, the
-# SecureConn double-close race, and the onRekeyNeeded session-nil race.
+# in-process unit tests (no FUSE mount) across pkg/filesystem, pkg/session,
+# pkg/logic/common and pkg/logic/service so it stays fast and cannot trip the
+# unrelated cgofuse mount-teardown race that end-to-end FUSE tests hit under
+# -race. Covers the Release async-notify race, the handle-reuse and
+# prefetch-rename guards, the SecureConn double-close race, the
+# onRekeyNeeded session-nil race, and the peer-path/read-size input guards.
 test-race:
-	go test -race -count=1 -timeout 180s ./pkg/filesystem/ ./pkg/session/ ./pkg/logic/common/
+	go test -race -count=1 -timeout 180s ./pkg/filesystem/ ./pkg/session/ ./pkg/logic/common/ ./pkg/logic/service/
 
 # Unit suites outside ./tests that no other lane runs (identity, service,
 # crypto, discovery, config, CLI, mobile bindings). Keychain suites
@@ -263,7 +264,7 @@ MOBILE_REPO ?= ../KeibiDropMobile
 # go.mod transiently (restored after) so the committed go.mod stays in sync with origin.
 GO_MOD_VERSION := $(shell awk '/^go /{print $$2; exit}' go.mod)
 MOBILE_GOTOOLCHAIN ?= go$(GO_MOD_VERSION)
-MOBILE_PREP = cp go.mod go.mod.bak && cp go.sum go.sum.bak && trap '[ -f go.mod.bak ] && mv -f go.mod.bak go.mod; [ -f go.sum.bak ] && mv -f go.sum.bak go.sum; :' EXIT INT TERM && GOTOOLCHAIN=$(MOBILE_GOTOOLCHAIN) go mod edit -tool=golang.org/x/mobile/cmd/gobind
+MOBILE_PREP = cp go.mod go.mod.bak && cp go.sum go.sum.bak && trap '[ -f go.mod.bak ] && mv -f go.mod.bak go.mod; [ -f go.sum.bak ] && mv -f go.sum.bak go.sum; :' EXIT INT TERM && GOTOOLCHAIN=$(MOBILE_GOTOOLCHAIN) go get -tool golang.org/x/mobile/cmd/gobind@$(MOBILE_PKG_VERSION)
 
 # Install gomobile + gobind (run once, or when 'gomobile version' says it's out of date).
 # x/mobile has no semver tags, so @latest drifts; pin the pseudo-version instead.
@@ -294,8 +295,8 @@ build-android:
 	ANDROID_HOME=$(ANDROID_HOME) ANDROID_NDK_HOME=$(ANDROID_NDK_HOME) \
 	GOTOOLCHAIN=$(MOBILE_GOTOOLCHAIN) GOFLAGS="-mod=mod" \
 	PATH="$$PATH:$$(go env GOPATH)/bin" \
-	gomobile bind -target=android -androidapi 28 \
-	  -ldflags "-X github.com/KeibiSoft/KeibiDrop/pkg/logic/common.Version=$(VERSION) -X github.com/KeibiSoft/KeibiDrop/pkg/logic/common.CommitHash=$(COMMIT) -extldflags '-Wl,-z,max-page-size=16384'" \
+	gomobile bind -target=android -androidapi 28 -trimpath \
+	  -ldflags "-s -w -X github.com/KeibiSoft/KeibiDrop/pkg/logic/common.Version=$(VERSION) -X github.com/KeibiSoft/KeibiDrop/pkg/logic/common.CommitHash=$(COMMIT) -extldflags '-Wl,-z,max-page-size=16384'" \
 	  -o keibidrop.aar ./mobile
 
 # Sync mobile app source + frameworks to the private KeibiDropMobile repo.
@@ -308,7 +309,7 @@ sync-mobile:
 		rsync -av --delete KeibiDrop.xcframework/ $(MOBILE_REPO)/ios/KeibiDrop/KeibiDrop.xcframework/; \
 	fi
 	@if [ -f keibidrop.aar ]; then \
-		cp keibidrop.aar $(MOBILE_REPO)/android/keibidrop.aar; \
+		cp keibidrop.aar $(MOBILE_REPO)/keibidrop.aar; \
 	fi
 	@echo "Done. cd $(MOBILE_REPO) && git add -A && git commit"
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/KeibiSoft/KeibiDrop
 
-go 1.25.0
+go 1.25.14
 
 require (
 	github.com/BurntSushi/toml v1.6.0

--- a/mobile/mobile.go
+++ b/mobile/mobile.go
@@ -402,6 +402,13 @@ func (api *API) SaveFile(remoteName string) (string, error) {
 	}
 	localPath := filepath.Join(api.savePath, remoteName)
 
+	// Defense in depth: refuse a name that escapes the save folder. Ingest already
+	// rejects "..", this guards any other caller into this download sink.
+	if rel, relErr := filepath.Rel(api.savePath, localPath); relErr != nil ||
+		rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("refusing path outside the save folder: %q", remoteName)
+	}
+
 	// Check if already downloaded at correct size.
 	api.kd.SyncTracker.RemoteFilesMu.RLock()
 	rf, ok := api.kd.SyncTracker.RemoteFiles[remoteName]

--- a/pkg/logic/common/handshake_bound.go
+++ b/pkg/logic/common/handshake_bound.go
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// ABOUTME: Runs an inbound handshake and closes the connection when it fails, so a
+// ABOUTME: rejected peer cannot leak the accepted conn.
+
+package common
+
+import (
+	"net"
+
+	"github.com/KeibiSoft/KeibiDrop/pkg/session"
+)
+
+// Indirection so tests can stub the handshake.
+var performInboundHandshake = session.PerformInboundHandshake
+
+// handshakeOrClose closes the connection when the handshake fails. A failed handshake
+// never reaches the session (the fingerprint check gates that), so closing here is safe.
+// The read bound itself lives inside session.PerformInboundHandshake, where no call site
+// can forget it.
+func handshakeOrClose(s *session.Session, c net.Conn) error {
+	if err := performInboundHandshake(s, c); err != nil {
+		c.Close()
+		return err
+	}
+	return nil
+}

--- a/pkg/logic/common/handshake_bound_test.go
+++ b/pkg/logic/common/handshake_bound_test.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// ABOUTME: Tests that a failed inbound handshake closes the accepted connection
+// ABOUTME: and a successful one leaves it open to become the session transport.
+
+package common
+
+import (
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/KeibiSoft/KeibiDrop/pkg/session"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recorderConn counts closes. Only Close is exercised, so the embedded nil Conn
+// is never touched.
+type recorderConn struct {
+	net.Conn
+	closes int
+}
+
+func (c *recorderConn) Close() error {
+	c.closes++
+	return nil
+}
+
+// stubHandshake swaps the handshake for the duration of one test.
+func stubHandshake(t *testing.T, err error) {
+	t.Helper()
+	orig := performInboundHandshake
+	performInboundHandshake = func(*session.Session, net.Conn) error { return err }
+	t.Cleanup(func() { performInboundHandshake = orig })
+}
+
+// A failed handshake must not leak the accepted connection.
+func TestHandshakeOrCloseClosesConnOnFailure(t *testing.T) {
+	wantErr := errors.New("fingerprint mismatch")
+	stubHandshake(t, wantErr)
+	c := &recorderConn{}
+
+	err := handshakeOrClose(nil, c)
+
+	assert.ErrorIs(t, err, wantErr)
+	assert.Equal(t, 1, c.closes, "failed handshake must close the conn")
+}
+
+func TestHandshakeOrCloseKeepsConnOnSuccess(t *testing.T) {
+	stubHandshake(t, nil)
+	c := &recorderConn{}
+
+	require.NoError(t, handshakeOrClose(nil, c))
+	assert.Zero(t, c.closes, "a successful conn becomes the transport, keep it open")
+}

--- a/pkg/logic/common/logic.go
+++ b/pkg/logic/common/logic.go
@@ -37,6 +37,17 @@ const Timeout = 10*60 - 5
 // direct accept window, so a round is the same length whichever path it takes.
 const bridgeRoundWait = 15 * time.Second
 
+// dropOutboundConn closes a completed outbound conn and forgets it. Every LAN bail-out
+// needs this: the outbound handshake has already succeeded by then, and ResetOutboundCrypto
+// only wipes the keys, so without it the conn is stranded when we fall through to
+// direct or bridge.
+func (kd *KeibiDrop) dropOutboundConn() {
+	if c := kd.session.OutboundConn(); c != nil {
+		c.Close()
+		kd.session.SetOutboundConn(nil)
+	}
+}
+
 // Add a file to be tracked.
 func (kd *KeibiDrop) AddFile(path string) error {
 	logger := kd.logger.With("method", "add-file")
@@ -820,10 +831,7 @@ func (kd *KeibiDrop) JoinRoom() error {
 					logger.Warn("Listener not open for LAN inbound accept")
 					// Outbound handshake already succeeded; close it so we don't
 					// strand the conn and stale crypto state on this bail-out.
-					if c := kd.session.OutboundConn(); c != nil {
-						c.Close()
-						kd.session.SetOutboundConn(nil)
-					}
+					kd.dropOutboundConn()
 					kd.session.ResetOutboundCrypto()
 					return ErrListenerNotOpen
 				}
@@ -835,16 +843,16 @@ func (kd *KeibiDrop) JoinRoom() error {
 				if err != nil {
 					logger.Warn("LAN inbound accept failed", "error", err)
 					// Close outbound, fall through to direct/bridge.
-					if c := kd.session.OutboundConn(); c != nil {
-						c.Close()
-						kd.session.SetOutboundConn(nil)
-					}
+					kd.dropOutboundConn()
 					kd.session.ResetOutboundCrypto()
 					lanConnected = false
 					break
 				}
-				if err := session.PerformInboundHandshake(kd.session, inConn); err != nil {
+				if err := handshakeOrClose(kd.session, inConn); err != nil {
 					logger.Warn("LAN inbound handshake failed", "error", err)
+					// The outbound leg already handshaked, so drop it too rather than
+					// strand it when we fall through to direct or bridge.
+					kd.dropOutboundConn()
 					lanConnected = false
 				}
 				break
@@ -895,10 +903,7 @@ func (kd *KeibiDrop) JoinRoom() error {
 					logger.Warn("Listener not open for direct P2P inbound accept")
 					// Outbound handshake already succeeded; close it so we don't
 					// strand the conn and stale crypto state on this bail-out.
-					if c := kd.session.OutboundConn(); c != nil {
-						c.Close()
-						kd.session.SetOutboundConn(nil)
-					}
+					kd.dropOutboundConn()
 					kd.session.ResetOutboundCrypto()
 					return ErrListenerNotOpen
 				}
@@ -913,16 +918,10 @@ func (kd *KeibiDrop) JoinRoom() error {
 					if acceptErr != nil {
 						break
 					}
-					// A connect-and-hold must not pin the accept slot past
-					// the window: bound the handshake read, then clear the
-					// deadline because this conn becomes the session transport.
-					_ = inConn.SetDeadline(time.Now().Add(15 * time.Second))
-					if hsErr := session.PerformInboundHandshake(kd.session, inConn); hsErr != nil {
+					if hsErr := handshakeOrClose(kd.session, inConn); hsErr != nil {
 						logger.Warn("Inbound handshake failed, accepting again", "error", hsErr)
-						inConn.Close()
 						continue
 					}
-					_ = inConn.SetDeadline(time.Time{})
 					break
 				}
 				_ = ln.(*net.TCPListener).SetDeadline(time.Time{})
@@ -981,8 +980,7 @@ func (kd *KeibiDrop) JoinRoom() error {
 			if err != nil {
 				return fmt.Errorf("bridge dial (inbound): %w", err)
 			}
-			if err := session.PerformInboundHandshake(kd.session, inConn); err != nil {
-				inConn.Close()
+			if err := handshakeOrClose(kd.session, inConn); err != nil {
 				return fmt.Errorf("bridge inbound handshake: %w", err)
 			}
 			kd.ConnectionMode = "bridge"
@@ -1209,16 +1207,10 @@ func (kd *KeibiDrop) createRendezvousRound(logger *slog.Logger, round int) (bool
 				if acceptErr != nil {
 					break
 				}
-				// A connect-and-hold must not pin the accept slot past the
-				// window: bound the handshake read, then clear the deadline
-				// because this conn becomes the session transport.
-				_ = conn.SetDeadline(time.Now().Add(15 * time.Second))
-				if hsErr := session.PerformInboundHandshake(kd.session, conn); hsErr != nil {
+				if hsErr := handshakeOrClose(kd.session, conn); hsErr != nil {
 					logger.Warn("Inbound handshake failed, accepting again", "error", hsErr)
-					conn.Close()
 					continue
 				}
-				_ = conn.SetDeadline(time.Time{})
 				break
 			}
 			_ = kd.listener.(*net.TCPListener).SetDeadline(time.Time{})
@@ -1303,17 +1295,16 @@ func (kd *KeibiDrop) createRendezvousRound(logger *slog.Logger, round int) (bool
 				logger.Warn("Bridge dial (inbound) failed this round", "error", err)
 				return false, nil
 			}
-			// Bound the wait for the joiner. Without a deadline this blocks until the
-			// REMOTE bridge closes the unpaired room, which is what produced the +38s
-			// EOF and made the round length a property of the bridge, not of us.
-			_ = inConn.SetReadDeadline(time.Now().Add(bridgeRoundWait))
-			if err := session.PerformInboundHandshake(kd.session, inConn); err != nil {
+			// Bound the wait for the joiner to the round. Without a deadline this blocks
+			// until the REMOTE bridge closes the unpaired room, which is what produced the
+			// +38s EOF and made the round length a property of the bridge, not of us. The
+			// handshake clears the deadline itself once the conn becomes the transport.
+			if err := session.PerformInboundHandshakeWait(kd.session, inConn, bridgeRoundWait); err != nil {
 				inConn.Close()
 				kd.session.ResetInboundCrypto()
 				logger.Info("No joiner on the bridge this round", "error", err)
 				return false, nil
 			}
-			_ = inConn.SetReadDeadline(time.Time{}) // This conn is now the session transport.
 
 			outConn, err := kd.dialBridgeDir("pair2", logger)
 			if err != nil {

--- a/pkg/logic/service/notify_rename_disksink_test.go
+++ b/pkg/logic/service/notify_rename_disksink_test.go
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// ABOUTME: Tests the RENAME_FILE disk sink (os.MkdirAll/RenameShared/os.Remove
+// ABOUTME: in Notify) directly, mount-free, including the T3 path-safety guard.
+
+//go:build !android
+
+package service
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	bindings "github.com/KeibiSoft/KeibiDrop/grpc_bindings"
+	"github.com/KeibiSoft/KeibiDrop/internal/testkit"
+	"github.com/KeibiSoft/KeibiDrop/pkg/filesystem"
+	synctracker "github.com/KeibiSoft/KeibiDrop/pkg/sync-tracker"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newRenameDiskSinkTestService builds a KeibidropServiceImpl whose FS root
+// points at a real temp dir, without mounting FUSE: SetRoot wires a
+// hand-built tree, matching the pattern notify_synctracker_test.go uses.
+func newRenameDiskSinkTestService(realRoot string) *KeibidropServiceImpl {
+	root := &filesystem.Dir{
+		RemoteFilesLock:     sync.RWMutex{},
+		RemoteFiles:         make(map[string]*filesystem.File),
+		AfmLock:             sync.RWMutex{},
+		AllFileMap:          make(map[string]*filesystem.File),
+		OpenMapLock:         sync.RWMutex{},
+		OpenFileHandlers:    make(map[uint64]*filesystem.HandleEntry),
+		Adm:                 sync.RWMutex{},
+		AllDirMap:           make(map[string]*filesystem.Dir),
+		RealPathOfFile:      realRoot,
+		LocalDownloadFolder: realRoot,
+		PrefetchSem:         make(chan struct{}, 8),
+	}
+	root.Root = root
+
+	svc := &KeibidropServiceImpl{
+		Logger:      testkit.DiscardLogger(),
+		SyncTracker: synctracker.NewSyncTracker(),
+	}
+	fsForSvc := &filesystem.FS{}
+	fsForSvc.SetRoot(root)
+	svc.SetFS(fsForSvc)
+	return svc
+}
+
+// TestNotify_RenameFile_MovesRealFileWithinRoot drives a legit RENAME_FILE
+// Notify through the real disk sink (service.go's RENAME_FILE branch) and
+// asserts the file actually moves on disk, under the temp root.
+func TestNotify_RenameFile_MovesRealFileWithinRoot(t *testing.T) {
+	tmpDir := t.TempDir()
+	svc := newRenameDiskSinkTestService(tmpDir)
+
+	const (
+		oldPath = "/src/doc.txt"
+		newPath = "/dst/renamed.txt"
+	)
+	oldDisk := filepath.Join(tmpDir, oldPath)
+	newDisk := filepath.Join(tmpDir, newPath)
+	const payload = "legit rename payload"
+
+	require.NoError(t, os.MkdirAll(filepath.Dir(oldDisk), 0o755))
+	require.NoError(t, os.WriteFile(oldDisk, []byte(payload), 0o644))
+
+	_, err := svc.Notify(context.Background(), &bindings.NotifyRequest{
+		Type:    bindings.NotifyType_RENAME_FILE,
+		OldPath: oldPath,
+		Path:    newPath,
+	})
+	require.NoError(t, err)
+
+	_, statErr := os.Stat(oldDisk)
+	assert.True(t, os.IsNotExist(statErr), "source must no longer exist after rename")
+
+	got, err := os.ReadFile(newDisk)
+	require.NoError(t, err, "renamed file must exist at the new real path")
+	assert.Equal(t, payload, string(got))
+}
+
+// TestNotify_RenameFile_RefusesUnsafePath_NoDiskEscape drives a RENAME_FILE
+// Notify carrying ".." in Path or OldPath and asserts (T3) it is refused
+// with ErrGRPCUnsafePath before any disk I/O, leaving the outside path
+// untouched and the legit source file exactly where it was.
+func TestNotify_RenameFile_RefusesUnsafePath_NoDiskEscape(t *testing.T) {
+	tmpDir := t.TempDir()
+	svc := newRenameDiskSinkTestService(tmpDir)
+
+	const legitPath = "/source.txt"
+	const payload = "must stay put"
+	legitDisk := filepath.Join(tmpDir, legitPath)
+	require.NoError(t, os.WriteFile(legitDisk, []byte(payload), 0o644))
+
+	// What the disk path would have been had the guard not fired:
+	// Clean(Join(tmpDir, "../escaped.txt")) climbs one level above the root.
+	outsideTarget := filepath.Join(filepath.Dir(tmpDir), "escaped.txt")
+	defer os.Remove(outsideTarget) // safety net; must be a no-op if the guard holds
+
+	// Path carries "..": refused before any disk I/O.
+	_, err := svc.Notify(context.Background(), &bindings.NotifyRequest{
+		Type:    bindings.NotifyType_RENAME_FILE,
+		OldPath: legitPath,
+		Path:    "../escaped.txt",
+	})
+	require.ErrorIs(t, err, ErrGRPCUnsafePath)
+
+	// OldPath carries "..": also refused before any disk I/O.
+	_, err = svc.Notify(context.Background(), &bindings.NotifyRequest{
+		Type:    bindings.NotifyType_RENAME_FILE,
+		OldPath: "../escaped.txt",
+		Path:    "/renamed.txt",
+	})
+	require.ErrorIs(t, err, ErrGRPCUnsafePath)
+
+	_, statErr := os.Stat(outsideTarget)
+	assert.True(t, os.IsNotExist(statErr), "unsafe rename must not write outside the save root")
+
+	got, err := os.ReadFile(legitDisk)
+	require.NoError(t, err, "legit source file must be untouched by the refused attempts")
+	assert.Equal(t, payload, string(got))
+}
+
+// A rename whose OldPath resolves to the save root must never reach the disk sink:
+// on an empty root os.Remove(root) would succeed and delete the user's save folder.
+func TestNotify_RenameFile_RefusesRootAsOldPath(t *testing.T) {
+	for _, oldPath := range []string{"", "/", ".", "./", "/. ", " "} {
+		t.Run("oldPath="+oldPath, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			root := filepath.Join(tmpDir, "root")
+			require.NoError(t, os.Mkdir(root, 0o755))
+			svc := newRenameDiskSinkTestService(root)
+
+			_, err := svc.Notify(context.Background(), &bindings.NotifyRequest{
+				Type:    bindings.NotifyType_RENAME_FILE,
+				OldPath: oldPath,
+				Path:    "moved.txt",
+			})
+
+			require.ErrorIs(t, err, ErrGRPCUnsafePath, "a rename off the save root must be refused")
+			info, statErr := os.Stat(root)
+			require.NoError(t, statErr, "the save root must still exist")
+			assert.True(t, info.IsDir(), "the save root must still be a directory")
+		})
+	}
+}

--- a/pkg/logic/service/pathsafety.go
+++ b/pkg/logic/service/pathsafety.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// ABOUTME: Rejects a peer-supplied NotifyRequest path that could escape the
+// ABOUTME: save root. No build tag: both Notify build variants share it.
+
+package service
+
+import (
+	"runtime"
+	"strings"
+
+	bindings "github.com/KeibiSoft/KeibiDrop/grpc_bindings"
+)
+
+// isUnsafeRemotePath reports whether a peer-supplied path could write outside the
+// save root, or onto the root itself. KeibiDrop paths are mount-absolute and
+// filepath.Join keeps a leading separator under the save root, so the ways out are
+// a ".." component, a component Windows normalizes into one or strips to nothing,
+// a Windows alias of a sibling name, or a path that names no entry at all and so
+// resolves to the root. Split on both "/" and "\" before checking components,
+// since a Windows peer sends "\".
+//
+// This validates the raw peer path at the ingest boundary, uniformly on both
+// builds. It is the sibling of filesystem.isInsideRoot, which does resolved-path
+// containment at the FUSE mkdir sites; the service disk sinks have no such guard.
+func isUnsafeRemotePath(p string) bool {
+	if p == "" {
+		return true
+	}
+	named := 0
+	for _, seg := range strings.FieldsFunc(p, func(r rune) bool { return r == '/' || r == '\\' }) {
+		if seg == "." {
+			continue // current-dir hop, never a name
+		}
+		if isDotDotComponent(seg) {
+			return true
+		}
+		// Windows strips trailing dots and spaces from every component. One that
+		// strips to nothing resolves to its parent, which can be the save root, so
+		// those forms are rejected on every build. One that merely shrinks ("foo ")
+		// aliases a sibling name, which only a Windows disk can reach: reject it
+		// there and let POSIX keep such names.
+		trimmed := strings.TrimRight(seg, ". ")
+		if trimmed == "" {
+			return true
+		}
+		if runtime.GOOS == "windows" && trimmed != seg {
+			return true
+		}
+		named++
+	}
+	// "/", "." and friends resolve to the save root itself. That is never a legitimate
+	// target: the rename branch would drive os.Remove or RenameShared on the root.
+	return named == 0
+}
+
+// isUnsafeNotify reports whether a peer notification carries a path that could escape
+// the save root or target it directly. OldPath is only meaningful for a rename, where
+// it must be present and safe; every other type legitimately leaves it empty.
+func isUnsafeNotify(t bindings.NotifyType, path, oldPath string) bool {
+	if isUnsafeRemotePath(path) {
+		return true
+	}
+	if t == bindings.NotifyType_RENAME_FILE || t == bindings.NotifyType_RENAME_DIR {
+		return isUnsafeRemotePath(oldPath)
+	}
+	return oldPath != "" && isUnsafeRemotePath(oldPath)
+}
+
+// isDotDotComponent reports whether a component reaches the filesystem as "..".
+// Windows strips trailing spaces and dots from every component, so ".. " and
+// "..." also land as a parent hop. A name holding anything else, like
+// "..bashrc", is an ordinary file and must still pass.
+func isDotDotComponent(seg string) bool {
+	dots := 0
+	for _, r := range seg {
+		switch r {
+		case '.':
+			dots++
+		case ' ':
+		default:
+			return false
+		}
+	}
+	return dots >= 2
+}

--- a/pkg/logic/service/pathsafety_fuzz_test.go
+++ b/pkg/logic/service/pathsafety_fuzz_test.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// ABOUTME: Fuzzes isUnsafeRemotePath for the one-directional containment
+// ABOUTME: property: an accepted path must never resolve outside the root.
+
+package service
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// FuzzIsUnsafeRemotePath asserts a one-directional property: whenever
+// isUnsafeRemotePath accepts a path (returns false), joining it under a root
+// with filepath.Join and filepath.Clean must not escape that root.
+//
+// The function deliberately rejects any literal ".." component without
+// resolving the path, so a rejected input (e.g. "a/b/../c", which nets out
+// safe once resolved) makes no claim either way. Only acceptance is checked.
+func FuzzIsUnsafeRemotePath(f *testing.F) {
+	seeds := []string{
+		"../etc/passwd",
+		"..\\windows\\system32",
+		"a/../../b",
+		"%2e%2e/x",
+		"..foo", // legit: not the exact segment "..", must be accepted
+		"a..b",  // legit: no ".." segment at all
+		"/",
+		"",
+		"/normal/file.txt",
+		"‥/etc/passwd",                           // U+2025 TWO DOT LEADER, not literal ".."
+		"．．/windows/system32",                    // U+FF0E FULLWIDTH FULL STOP x2, not literal ".."
+		strings.Repeat("../", 64) + "etc/passwd", // deeply nested chain
+		"a\\b/../..\\c/d",                        // mixed separators
+		" ",                                      // strips to nothing on Windows, resolves to the root
+		"/. ",                                    // same, via a trailing dot-space component
+		"foo ",                                   // aliases "foo" on a Windows disk
+		"a/ /b",                                  // interior component strips to nothing
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	// Synthetic root: the oracle is pure string math (filepath.Join/Clean),
+	// so this never needs to exist on disk.
+	const root = "/save/root"
+	sep := string(filepath.Separator)
+
+	f.Fuzz(func(t *testing.T, p string) {
+		if isUnsafeRemotePath(p) {
+			return // rejected: the function makes no claim about the resolved path
+		}
+		joined := filepath.Clean(filepath.Join(root, p))
+		if joined != root && !strings.HasPrefix(joined, root+sep) {
+			t.Fatalf("accepted path %q escapes root: joined=%q root=%q", p, joined, root)
+		}
+		// Model the Windows per-component strip of trailing dots and spaces: even
+		// after every component shrinks, an accepted path must stay contained and
+		// must not land on the root itself.
+		segs := strings.FieldsFunc(p, func(r rune) bool { return r == '/' || r == '\\' })
+		for i, seg := range segs {
+			segs[i] = strings.TrimRight(seg, ". ")
+		}
+		winJoined := filepath.Clean(filepath.Join(root, strings.Join(segs, "/")))
+		if winJoined == root || !strings.HasPrefix(winJoined, root+sep) {
+			t.Fatalf("accepted path %q lands on or escapes the root after the Windows strip: %q", p, winJoined)
+		}
+	})
+}

--- a/pkg/logic/service/pathsafety_test.go
+++ b/pkg/logic/service/pathsafety_test.go
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// ABOUTME: Tests isUnsafeRemotePath and the Notify guard that rejects a peer
+// ABOUTME: path escaping the save root before it reaches the sync tracker.
+
+package service
+
+import (
+	"context"
+	"runtime"
+	"testing"
+
+	bindings "github.com/KeibiSoft/KeibiDrop/grpc_bindings"
+	"github.com/KeibiSoft/KeibiDrop/internal/testkit"
+	synctracker "github.com/KeibiSoft/KeibiDrop/pkg/sync-tracker"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsUnsafeRemotePath(t *testing.T) {
+	cases := []struct {
+		name   string
+		path   string
+		unsafe bool
+	}{
+		{"empty", "", true},
+		{"parent-prefix", "../config/x", true},
+		{"parent-nested", "a/../../x", true},
+		{"absolute-unix", "/etc/passwd", false}, // absolute/leading-separator is kept under the save root by Join
+		{"dot-dot-alone", "..", true},
+		{"backslash-parent", "a\\..\\b", true},
+		{"backslash-absolute", "\\config\\x", false}, // absolute/leading-separator is kept under the save root by Join
+		// a/b/../c carries a literal ".." component; the helper rejects any
+		// such component outright rather than resolving the net path, so
+		// this is unsafe even though "b" cancels it out.
+		{"forward-slash-internal-parent", "a/b/../c", true},
+		{"plain-file", "doc.pdf", false},
+		{"nested-safe", "sub/dir/file", false},
+		// Starts with ".." but is not the exact segment "..": must not
+		// false-positive on a Contains-style check.
+		{"dotdot-like-prefix-not-exact", "..bashrc", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.unsafe, isUnsafeRemotePath(c.path), "path %q", c.path)
+		})
+	}
+}
+
+// newPathSafetyTestService builds a minimal KeibidropServiceImpl. Only
+// Logger and SyncTracker are used, so this compiles and runs unchanged
+// against either build variant's struct definition.
+func newPathSafetyTestService() *KeibidropServiceImpl {
+	return &KeibidropServiceImpl{
+		Logger:      testkit.DiscardLogger(),
+		SyncTracker: synctracker.NewSyncTracker(),
+	}
+}
+
+func TestNotify_RefusesUnsafePath(t *testing.T) {
+	svc := newPathSafetyTestService()
+
+	_, err := svc.Notify(context.Background(), &bindings.NotifyRequest{
+		Type: bindings.NotifyType_ADD_FILE,
+		Path: "../config/identity.enc",
+		Name: "identity.enc",
+		Attr: &bindings.Attr{Size: 10, ModificationTime: 1000},
+	})
+	require.ErrorIs(t, err, ErrGRPCUnsafePath)
+
+	svc.SyncTracker.RemoteFilesMu.RLock()
+	_, ok := svc.SyncTracker.RemoteFiles["../config/identity.enc"]
+	svc.SyncTracker.RemoteFilesMu.RUnlock()
+	assert.False(t, ok, "unsafe path must not reach the tracker")
+}
+
+func TestNotify_RefusesUnsafeOldPathOnRename(t *testing.T) {
+	svc := newPathSafetyTestService()
+
+	_, err := svc.Notify(context.Background(), &bindings.NotifyRequest{
+		Type:    bindings.NotifyType_RENAME_FILE,
+		OldPath: "../config/identity.enc",
+		Path:    "renamed.txt",
+	})
+	require.ErrorIs(t, err, ErrGRPCUnsafePath)
+}
+
+func TestNotify_AcceptsSafePath(t *testing.T) {
+	svc := newPathSafetyTestService()
+
+	_, err := svc.Notify(context.Background(), &bindings.NotifyRequest{
+		Type: bindings.NotifyType_ADD_FILE,
+		Path: "sub/dir/file.txt",
+		Name: "file.txt",
+		Attr: &bindings.Attr{Size: 10, ModificationTime: 1000},
+	})
+	require.NoError(t, err)
+
+	svc.SyncTracker.RemoteFilesMu.RLock()
+	_, ok := svc.SyncTracker.RemoteFiles["sub/dir/file.txt"]
+	svc.SyncTracker.RemoteFilesMu.RUnlock()
+	assert.True(t, ok, "safe path must be tracked normally")
+}
+
+// Windows strips trailing spaces and dots from each path component, so a
+// segment like ".. " reaches the filesystem as "..". Reject anything made only
+// of dots and spaces that carries at least two dots.
+func TestIsUnsafeRemotePath_WindowsDotSpaceComponents(t *testing.T) {
+	unsafe := []string{".. /evil", "a/.. /b", "...", "a/... /b", ". ./evil", ".. ", "..\\.. \\evil"}
+	for _, p := range unsafe {
+		assert.True(t, isUnsafeRemotePath(p), "must reject %q: normalizes to .. on Windows", p)
+	}
+	safe := []string{"..bashrc", "a..b", "file. txt", "a. b/c", "...leading", "normal.txt", "/a/b.txt"}
+	for _, p := range safe {
+		assert.False(t, isUnsafeRemotePath(p), "must accept legit name %q", p)
+	}
+}
+
+// A peer path that resolves to the save root itself is never a legitimate target:
+// the rename branch would drive os.Remove or RenameShared on the root directory.
+func TestIsUnsafeRemotePath_RejectsRootResolvingPaths(t *testing.T) {
+	for _, p := range []string{"/", ".", "./", "/.", "././", "\\", ".\\"} {
+		assert.True(t, isUnsafeRemotePath(p), "must reject %q: resolves to the save root", p)
+	}
+	for _, p := range []string{"./a", "a", "/a/b.txt", ".hidden"} {
+		assert.False(t, isUnsafeRemotePath(p), "must accept %q", p)
+	}
+}
+
+// OldPath is mandatory for a rename. An empty one joins to the save root, so the
+// general "empty OldPath is fine" exemption must not apply to rename types.
+func TestIsUnsafeNotify_RenameRequiresSafeOldPath(t *testing.T) {
+	for _, old := range []string{"", "/", ".", "../escape"} {
+		assert.True(t, isUnsafeNotify(bindings.NotifyType_RENAME_FILE, "x", old),
+			"rename with OldPath %q must be refused", old)
+		assert.True(t, isUnsafeNotify(bindings.NotifyType_RENAME_DIR, "x", old),
+			"rename dir with OldPath %q must be refused", old)
+	}
+	assert.False(t, isUnsafeNotify(bindings.NotifyType_RENAME_FILE, "new.txt", "old.txt"))
+	// A non-rename legitimately carries no OldPath.
+	assert.False(t, isUnsafeNotify(bindings.NotifyType_ADD_FILE, "a.txt", ""))
+	assert.True(t, isUnsafeNotify(bindings.NotifyType_ADD_FILE, "a.txt", "../x"))
+}
+
+// Windows also strips a component made ONLY of dots and spaces to nothing, so
+// "/. " or " " resolve to the parent, i.e. the save root. Reject those forms on
+// every build. Names that merely SHRINK ("foo ") alias a sibling only on a
+// Windows disk, so they are rejected there and stay legal on POSIX.
+func TestIsUnsafeRemotePath_RejectsStripToNothingComponents(t *testing.T) {
+	for _, p := range []string{" ", ". ", " . ", "/. ", "/ ", ".  ", "a/ /b", "a\\ \\b", "a/. "} {
+		assert.True(t, isUnsafeRemotePath(p), "must reject %q: a component strips to nothing on Windows", p)
+	}
+	for _, p := range []string{"foo ", "foo.", "a/b. ", "dir /f"} {
+		want := runtime.GOOS == "windows"
+		assert.Equal(t, want, isUnsafeRemotePath(p), "aliasing name %q is Windows-only unsafe", p)
+	}
+}

--- a/pkg/logic/service/readsize.go
+++ b/pkg/logic/service/readsize.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// ABOUTME: Bounds a peer-requested read length to the serve buffer, failing
+// ABOUTME: closed on a 32-bit int(uint32) negative wrap of the requested size.
+
+package service
+
+import "math"
+
+// clampReadSize bounds a peer-requested read length to [0, bufLen]. On the 32-bit
+// builds we ship (armeabi-v7a, x86), int(rec.Size) can wrap negative for a large
+// uint32; a high-only "size > bufLen" bound misses that, and slicing buf[:size]
+// with a negative size is out of range. Clamping the low end too fails closed.
+func clampReadSize(size, bufLen int) int {
+	if size < 0 || size > bufLen {
+		return bufLen
+	}
+	return size
+}
+
+// safeReadOffset converts a peer-requested offset, reporting false when it cannot be
+// represented. rec.Offset is uint64, so anything at or above 1<<63 lands negative in an
+// int64 and ReadAt would only reject it after the handler has already opened the file.
+func safeReadOffset(off uint64) (int64, bool) {
+	if off > math.MaxInt64 {
+		return 0, false
+	}
+	return int64(off), true
+}

--- a/pkg/logic/service/readsize_test.go
+++ b/pkg/logic/service/readsize_test.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// ABOUTME: Tests clampReadSize, which bounds a peer-requested read length
+// ABOUTME: to the serve buffer and fails closed on a 32-bit negative wrap.
+
+package service
+
+import (
+	"math"
+	"testing"
+)
+
+func TestClampReadSize(t *testing.T) {
+	cases := []struct{ size, bufLen, want int }{
+		{10, 100, 10},             // normal
+		{100, 100, 100},           // exact
+		{200, 100, 100},           // oversized -> bufLen
+		{0, 100, 0},               // zero
+		{-1, 100, 100},            // negative wrap -> bufLen (the crash the finding is about)
+		{math.MinInt32, 100, 100}, // int32 min, what int(large uint32) yields on 32-bit
+	}
+	for _, c := range cases {
+		if got := clampReadSize(c.size, c.bufLen); got != c.want {
+			t.Errorf("clampReadSize(%d, %d) = %d, want %d", c.size, c.bufLen, got, c.want)
+		}
+	}
+}
+
+func TestSafeReadOffset(t *testing.T) {
+	cases := []struct {
+		in   uint64
+		want int64
+		ok   bool
+	}{
+		{0, 0, true},
+		{4096, 4096, true},
+		{math.MaxInt64, math.MaxInt64, true},
+		{1 << 63, 0, false},        // wraps negative through int64
+		{math.MaxUint64, 0, false}, // the -1 case
+	}
+	for _, c := range cases {
+		got, ok := safeReadOffset(c.in)
+		if ok != c.ok || got != c.want {
+			t.Errorf("safeReadOffset(%d) = (%d, %v), want (%d, %v)", c.in, got, ok, c.want, c.ok)
+		}
+	}
+}

--- a/pkg/logic/service/service.go
+++ b/pkg/logic/service/service.go
@@ -39,6 +39,7 @@ var (
 	ErrGRPCAlreadyExists      = status.Error(codes.AlreadyExists, "already exists")
 	ErrGRPCNotFound           = status.Error(codes.NotFound, "notFound")
 	ErrGRPCReadOnlyShare      = status.Error(codes.PermissionDenied, "share is read-only")
+	ErrGRPCUnsafePath         = status.Error(codes.InvalidArgument, "path escapes the save root")
 )
 
 type KeibidropServiceImpl struct {
@@ -132,6 +133,11 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 			logger.Warn("Refusing peer mutation: share is read-only", "first-path", req.Path)
 		}
 		return nil, ErrGRPCReadOnlyShare
+	}
+	// Reject a peer path that could escape the save root, before it reaches the tracker.
+	if isUnsafeNotify(req.Type, req.Path, req.OldPath) {
+		logger.Warn("Refusing peer path outside the save root", "oldPath", req.OldPath)
+		return nil, ErrGRPCUnsafePath
 	}
 
 	// Drop macOS/FUSE internal files — ephemeral, never meant to be synced.
@@ -798,6 +804,7 @@ func (kd *KeibidropServiceImpl) Read(stream bindings.KeibiService_ReadServer) er
 				}
 				openedPath = rec.Path
 			} else if openedPath != rec.Path {
+				fh.Close()
 				logger.Error("Multiple paths in same stream not supported", "requested", rec.Path)
 				return status.Error(codes.InvalidArgument, "stream can only read a single file")
 			}
@@ -805,15 +812,21 @@ func (kd *KeibidropServiceImpl) Read(stream bindings.KeibiService_ReadServer) er
 			if buf == nil {
 				buf = make([]byte, config.GRPCStreamBuffer)
 			}
-			size := int(rec.Size)
-			offset := int64(rec.Offset)
-			if size > len(buf) {
-				logger.Warn("Requested size too large, truncating to buffer size", "requested", size, "buffer", len(buf))
-				size = len(buf)
+			requested := int(rec.Size)
+			size := clampReadSize(requested, len(buf))
+			offset, offsetOK := safeReadOffset(rec.Offset)
+			if !offsetOK {
+				fh.Close()
+				logger.Warn("Peer requested an out-of-range read offset", "offset", rec.Offset)
+				return status.Error(codes.InvalidArgument, "read offset out of range")
+			}
+			if size != requested {
+				logger.Warn("Requested size out of range, clamped to buffer", "requested", requested, "buffer", len(buf))
 			}
 
 			n, err := fh.ReadAt(buf[:size], offset)
 			if err != nil && !errors.Is(err, io.EOF) {
+				fh.Close()
 				logger.Error("Failed to read file", "error", err)
 				return status.Error(codes.Internal, "error reading file")
 			}
@@ -886,6 +899,7 @@ func (kd *KeibidropServiceImpl) Read(stream bindings.KeibiService_ReadServer) er
 			}
 			openedPath = rec.Path
 		} else if openedPath != rec.Path {
+			fh.Close()
 			logger.Error("Multiple paths in same stream not supported", "requested", rec.Path)
 			return status.Error(codes.InvalidArgument, "stream can only read a single file")
 		}
@@ -893,15 +907,21 @@ func (kd *KeibidropServiceImpl) Read(stream bindings.KeibiService_ReadServer) er
 		if buf == nil {
 			buf = make([]byte, config.GRPCStreamBuffer)
 		}
-		size := int(rec.Size)
-		offset := int64(rec.Offset)
-		if size > len(buf) {
-			logger.Warn("Requested size too large, truncating to buffer size", "requested", size, "buffer", len(buf))
-			size = len(buf)
+		requested := int(rec.Size)
+		size := clampReadSize(requested, len(buf))
+		offset, offsetOK := safeReadOffset(rec.Offset)
+		if !offsetOK {
+			fh.Close()
+			logger.Warn("Peer requested an out-of-range read offset", "offset", rec.Offset)
+			return status.Error(codes.InvalidArgument, "read offset out of range")
+		}
+		if size != requested {
+			logger.Warn("Requested size out of range, clamped to buffer", "requested", requested, "buffer", len(buf))
 		}
 
 		n, err := fh.ReadAt(buf[:size], offset)
 		if err != nil && !errors.Is(err, io.EOF) {
+			fh.Close()
 			logger.Error("Failed to read file", "error", err)
 			return status.Error(codes.Internal, "error reading file")
 		}

--- a/pkg/logic/service/service_android.go
+++ b/pkg/logic/service/service_android.go
@@ -40,6 +40,7 @@ var (
 	ErrGRPCAlreadyExists      = status.Error(codes.AlreadyExists, "already exists")
 	ErrGRPCNotFound           = status.Error(codes.NotFound, "notFound")
 	ErrGRPCReadOnlyShare      = status.Error(codes.PermissionDenied, "share is read-only")
+	ErrGRPCUnsafePath         = status.Error(codes.InvalidArgument, "path escapes the save root")
 )
 
 type KeibidropServiceImpl struct {
@@ -99,6 +100,11 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 			logger.Warn("Refusing peer mutation: share is read-only", "first-path", req.Path)
 		}
 		return nil, ErrGRPCReadOnlyShare
+	}
+	// Reject a peer path that could escape the save root, before it reaches the tracker.
+	if isUnsafeNotify(req.Type, req.Path, req.OldPath) {
+		logger.Warn("Refusing peer path outside the save root", "path", req.Path, "oldPath", req.OldPath)
+		return nil, ErrGRPCUnsafePath
 	}
 
 	if kd.SyncTracker == nil {
@@ -376,11 +382,16 @@ func (kd *KeibidropServiceImpl) Read(stream bindings.KeibiService_ReadServer) er
 		if buf == nil {
 			buf = make([]byte, config.GRPCStreamBuffer)
 		}
-		size := int(rec.Size)
-		offset := int64(rec.Offset)
-		if size > len(buf) {
-			logger.Warn("Requested size too large, truncating to buffer size", "requested", size, "buffer", len(buf))
-			size = len(buf)
+		requested := int(rec.Size)
+		size := clampReadSize(requested, len(buf))
+		offset, offsetOK := safeReadOffset(rec.Offset)
+		if !offsetOK {
+			fh.Close()
+			logger.Warn("Peer requested an out-of-range read offset", "offset", rec.Offset)
+			return status.Error(codes.InvalidArgument, "read offset out of range")
+		}
+		if size != requested {
+			logger.Warn("Requested size out of range, clamped to buffer", "requested", requested, "buffer", len(buf))
 		}
 
 		n, err := fh.ReadAt(buf[:size], offset)

--- a/pkg/logic/service/service_read_test.go
+++ b/pkg/logic/service/service_read_test.go
@@ -12,12 +12,14 @@
 package service
 
 import (
+	"math"
 	"os"
 	"sync"
 	"testing"
 
 	bindings "github.com/KeibiSoft/KeibiDrop/grpc_bindings"
 	"github.com/KeibiSoft/KeibiDrop/internal/testkit"
+	"github.com/KeibiSoft/KeibiDrop/pkg/config"
 	"github.com/KeibiSoft/KeibiDrop/pkg/filesystem"
 	synctracker "github.com/KeibiSoft/KeibiDrop/pkg/sync-tracker"
 	"github.com/stretchr/testify/assert"
@@ -131,4 +133,94 @@ func TestRead_FUSEMode_FileNotFoundAnywhere(t *testing.T) {
 	st, ok := status.FromError(err)
 	require.True(t, ok)
 	assert.Equal(t, codes.NotFound, st.Code())
+}
+
+// TestRead_HostileSizeNeverExceedsBuffer verifies the real Read call site
+// (T4: clampReadSize) does not panic when a peer requests a Size far larger
+// than the serve buffer, and that the response never exceeds the buffer.
+// ReadRequest.Size is uint32, so int(rec.Size) cannot go negative on this
+// amd64 host; only the size>bufLen bound is reachable here. The negative-wrap
+// case (32-bit builds) is covered by TestClampReadSize in readsize_test.go.
+func TestRead_HostileSizeNeverExceedsBuffer(t *testing.T) {
+	tmpFile, err := os.CreateTemp(t.TempDir(), "hostile-*.txt")
+	require.NoError(t, err)
+	content := []byte("small file, huge requested size")
+	_, err = tmpFile.Write(content)
+	require.NoError(t, err)
+	tmpFile.Close()
+
+	svc := &KeibidropServiceImpl{
+		Logger:      testkit.DiscardLogger(),
+		SyncTracker: synctracker.NewSyncTracker(),
+	}
+	fsForSvc := &filesystem.FS{}
+	fsForSvc.SetRoot(&filesystem.Dir{
+		AfmLock:    sync.RWMutex{},
+		AllFileMap: make(map[string]*filesystem.File),
+	})
+	svc.SetFS(fsForSvc)
+
+	svc.SyncTracker.LocalFiles["hostile.txt"] = &synctracker.File{
+		Name:           "hostile.txt",
+		RelativePath:   "hostile.txt",
+		RealPathOfFile: tmpFile.Name(),
+		Size:           uint64(len(content)),
+	}
+
+	stream := &testkit.Stream[*bindings.ReadRequest, *bindings.ReadResponse]{
+		Requests: []*bindings.ReadRequest{
+			{Handle: 0, Path: "hostile.txt", Offset: 0, Size: math.MaxUint32},
+		},
+	}
+
+	require.NotPanics(t, func() {
+		err = svc.Read(stream)
+	})
+	require.NoError(t, err)
+	require.Len(t, stream.Sent, 1)
+	assert.LessOrEqual(t, len(stream.Sent[0].Data), config.GRPCStreamBuffer,
+		"response must never exceed the serve buffer")
+	assert.Equal(t, content, stream.Sent[0].Data,
+		"small file must still be served in full despite the hostile size")
+}
+
+// TestRead_HostileOffsetRejected verifies the real Read call site refuses an offset
+// that cannot be represented as int64. rec.Offset is uint64, so 1<<63 wraps negative
+// and would otherwise reach ReadAt and leave the open handle behind.
+func TestRead_HostileOffsetRejected(t *testing.T) {
+	tmpFile, err := os.CreateTemp(t.TempDir(), "offset-*.txt")
+	require.NoError(t, err)
+	_, err = tmpFile.Write([]byte("payload"))
+	require.NoError(t, err)
+	tmpFile.Close()
+
+	svc := &KeibidropServiceImpl{
+		Logger:      testkit.DiscardLogger(),
+		SyncTracker: synctracker.NewSyncTracker(),
+	}
+	fsForSvc := &filesystem.FS{}
+	fsForSvc.SetRoot(&filesystem.Dir{
+		AfmLock:    sync.RWMutex{},
+		AllFileMap: make(map[string]*filesystem.File),
+	})
+	svc.SetFS(fsForSvc)
+	svc.SyncTracker.LocalFiles["offset.txt"] = &synctracker.File{
+		Name:           "offset.txt",
+		RelativePath:   "offset.txt",
+		RealPathOfFile: tmpFile.Name(),
+		Size:           7,
+	}
+
+	stream := &testkit.Stream[*bindings.ReadRequest, *bindings.ReadResponse]{
+		Requests: []*bindings.ReadRequest{
+			{Handle: 0, Path: "offset.txt", Offset: 1 << 63, Size: 1},
+		},
+	}
+
+	require.NotPanics(t, func() { err = svc.Read(stream) })
+	require.Error(t, err, "an unrepresentable offset must be refused")
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code(), "must be InvalidArgument, not Internal")
+	assert.Empty(t, stream.Sent, "nothing may be served for a rejected offset")
 }

--- a/pkg/session/handshake.go
+++ b/pkg/session/handshake.go
@@ -21,6 +21,15 @@ import (
 	kbc "github.com/KeibiSoft/KeibiDrop/pkg/crypto"
 )
 
+// Inbound handshake bounds. Two phases, because a silent peer and a slow peer deserve
+// different budgets: a connect-and-hold never speaks, so rejecting it fast keeps an accept
+// window usable for real peers, while a peer that is already talking gets room to finish.
+// Vars, not consts, so tests can shrink them.
+var (
+	firstByteTimeout        = 3 * time.Second
+	inboundHandshakeTimeout = 30 * time.Second
+)
+
 // PeerHandshakeMessage defines the JSON payload sent during handshake.
 type PeerHandshakeMessage struct {
 	Fingerprint      string            `json:"fingerprint"`
@@ -46,12 +55,25 @@ func keyUpdateBinding(on bool) []byte {
 }
 
 // PerformInboundHandshake handles the first plaintext connection from Bob to Alice.
+// The peer dialed us, so its first byte is due within a round trip: accept sites
+// get the short default budget.
 func PerformInboundHandshake(session *Session, conn net.Conn) error {
+	return PerformInboundHandshakeWait(session, conn, firstByteTimeout)
+}
+
+// PerformInboundHandshakeWait is the wait-for-peer variant for the bridge legs, where
+// the peer can legitimately arrive well after our dial: the caller owns the first-byte
+// budget. The full-handshake bound still applies once the peer speaks.
+func PerformInboundHandshakeWait(session *Session, conn net.Conn, firstByte time.Duration) error {
 	if session == nil || conn == nil {
 		return fmt.Errorf("nil pointer deference")
 	}
 
 	logger := session.logger.With("phase", "inbound-handshake")
+
+	// Bound the wait for the first byte: a peer that connects and holds without
+	// speaking is cheap to reject, so an accept loop keeps its window for real peers.
+	_ = conn.SetReadDeadline(time.Now().Add(firstByte))
 
 	// Read handshake: 4-byte big-endian length prefix, then JSON payload. Must NOT use
 	// json.Decoder: it buffers ahead and would consume bytes meant for the SecureConn that
@@ -61,6 +83,10 @@ func PerformInboundHandshake(session *Session, conn net.Conn) error {
 		logger.Error("Failed to read handshake length", "error", err)
 		return fmt.Errorf("read handshake length: %w", err)
 	}
+	// The peer is talking, so give the rest of the exchange room to finish. Cleared
+	// on success below, because the conn then becomes the long-lived transport.
+	_ = conn.SetDeadline(time.Now().Add(inboundHandshakeTimeout))
+
 	msgLen := binary.BigEndian.Uint32(lenBuf[:])
 	if msgLen > 64*1024 { // sanity limit: 64 KiB
 		return fmt.Errorf("handshake message too large: %d bytes", msgLen)
@@ -206,6 +232,10 @@ func PerformInboundHandshake(session *Session, conn net.Conn) error {
 		session.Session = &SessionSockets{}
 	}
 	session.installInbound(secure)
+
+	// The handshake is done and this conn is now the session transport, so it must not
+	// inherit the bound: leaving it armed would kill every long-lived connection.
+	_ = conn.SetDeadline(time.Time{})
 
 	return nil
 }

--- a/pkg/session/handshake_bench_test.go
+++ b/pkg/session/handshake_bench_test.go
@@ -1,0 +1,67 @@
+// ABOUTME: Micro-benchmark for a full inbound handshake, the once-per-connection
+// ABOUTME: cost that any deadline bookkeeping on that path has to stay trivial against.
+
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package session
+
+import (
+	"io"
+	"log/slog"
+	"net"
+	"testing"
+
+	kbc "github.com/KeibiSoft/KeibiDrop/pkg/crypto"
+)
+
+// BenchmarkInboundHandshake times one complete PQC handshake over a pipe. Key
+// generation is excluded from the timer, so the number is the handshake itself.
+func BenchmarkInboundHandshake(b *testing.B) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		alice, err := InitSession(logger, 26002, 26001)
+		if err != nil {
+			b.Fatal(err)
+		}
+		bob, err := InitSession(logger, 26004, 26003)
+		if err != nil {
+			b.Fatal(err)
+		}
+		alicePeer, err := kbc.ParsePeerKeys(map[string][]byte{
+			"x25519": alice.OwnKeys.X25519Public.Bytes(),
+			"mlkem":  alice.OwnKeys.MlKemPublic.Bytes(),
+		})
+		if err != nil {
+			b.Fatal(err)
+		}
+		bob.PeerPubKeys = alicePeer
+		alice.ExpectedPeerFingerprint, err = bob.OwnKeys.Fingerprint()
+		if err != nil {
+			b.Fatal(err)
+		}
+		bobEnd, aliceEnd := net.Pipe()
+		errCh := make(chan error, 1)
+		b.StartTimer()
+
+		go func() { errCh <- PerformOutboundHandshakeOnConn(bob, bobEnd) }()
+		if err := PerformInboundHandshake(alice, aliceEnd); err != nil {
+			b.Fatal(err)
+		}
+		if err := <-errCh; err != nil {
+			b.Fatal(err)
+		}
+
+		b.StopTimer()
+		bobEnd.Close()
+		aliceEnd.Close()
+		b.StartTimer()
+	}
+}

--- a/pkg/session/handshake_bound_test.go
+++ b/pkg/session/handshake_bound_test.go
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// ABOUTME: Tests the two-phase inbound handshake bound: a silent peer is rejected on the
+// ABOUTME: short first-byte budget, a talking one gets the longer one, and success clears it.
+
+package session
+
+import (
+	"io"
+	"log/slog"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/KeibiSoft/KeibiDrop/internal/testkit"
+	"github.com/KeibiSoft/KeibiDrop/pkg/config"
+	kbc "github.com/KeibiSoft/KeibiDrop/pkg/crypto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// shrinkHandshakeBounds makes the two budgets small enough to assert on without sleeping.
+func shrinkHandshakeBounds(t *testing.T, firstByte, full time.Duration) {
+	t.Helper()
+	origFirst, origFull := firstByteTimeout, inboundHandshakeTimeout
+	firstByteTimeout, inboundHandshakeTimeout = firstByte, full
+	t.Cleanup(func() { firstByteTimeout, inboundHandshakeTimeout = origFirst, origFull })
+}
+
+// deadlineSpy records what the handshake does to the conn's deadlines.
+type deadlineSpy struct {
+	net.Conn
+	deadlines []time.Time
+}
+
+func (c *deadlineSpy) SetDeadline(t time.Time) error {
+	c.deadlines = append(c.deadlines, t)
+	return c.Conn.SetDeadline(t)
+}
+
+// A peer that connects and never speaks must be rejected on the SHORT budget, so an
+// accept loop keeps enough of its window to serve a real peer afterwards.
+func TestInboundHandshakeRejectsSilentPeerOnFirstByteBound(t *testing.T) {
+	shrinkHandshakeBounds(t, 60*time.Millisecond, 5*time.Second)
+	bob, err := InitSession(testkit.DiscardLogger(), config.OutboundPort, config.InboundPort)
+	require.NoError(t, err)
+
+	server, client := net.Pipe()
+	defer server.Close()
+	defer client.Close()
+
+	start := time.Now()
+	done := make(chan error, 1)
+	go func() { done <- PerformInboundHandshake(bob, server) }()
+
+	select {
+	case err := <-done:
+		require.Error(t, err, "a silent peer must fail the handshake")
+		assert.Less(t, time.Since(start), 2*time.Second,
+			"must fail on the first-byte budget, not the full one")
+	case <-time.After(4 * time.Second):
+		t.Fatal("inbound handshake hung on a silent peer")
+	}
+}
+
+// Once the peer has actually spoken, the bound extends: a stall after the length prefix
+// must survive well past the first-byte budget before failing.
+func TestInboundHandshakeExtendsBoundOncePeerSpeaks(t *testing.T) {
+	shrinkHandshakeBounds(t, 60*time.Millisecond, 700*time.Millisecond)
+	bob, err := InitSession(testkit.DiscardLogger(), config.OutboundPort, config.InboundPort)
+	require.NoError(t, err)
+
+	server, client := net.Pipe()
+	defer server.Close()
+	defer client.Close()
+
+	start := time.Now()
+	done := make(chan error, 1)
+	go func() { done <- PerformInboundHandshake(bob, server) }()
+	// Announce a payload, then never send it.
+	_, err = client.Write([]byte{0, 0, 0, 32})
+	require.NoError(t, err)
+
+	select {
+	case err := <-done:
+		require.Error(t, err, "a stalled payload must still fail")
+		assert.Greater(t, time.Since(start), 300*time.Millisecond,
+			"a talking peer must get the longer budget, not the first-byte one")
+	case <-time.After(5 * time.Second):
+		t.Fatal("inbound handshake hung after the length prefix")
+	}
+}
+
+// The connection becomes the long-lived session transport, so a successful handshake
+// MUST leave no deadline behind. If this regressed, every session would die at the bound.
+func TestInboundHandshakeClearsDeadlineOnSuccess(t *testing.T) {
+	shrinkHandshakeBounds(t, 2*time.Second, 5*time.Second)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	alice, err := InitSession(logger, 26002, 26001)
+	require.NoError(t, err)
+	bob, err := InitSession(logger, 26004, 26003)
+	require.NoError(t, err)
+
+	alicePeer, err := kbc.ParsePeerKeys(map[string][]byte{
+		"x25519": alice.OwnKeys.X25519Public.Bytes(),
+		"mlkem":  alice.OwnKeys.MlKemPublic.Bytes(),
+	})
+	require.NoError(t, err)
+	bob.PeerPubKeys = alicePeer
+	alice.ExpectedPeerFingerprint, err = bob.OwnKeys.Fingerprint()
+	require.NoError(t, err)
+
+	bobEnd, aliceEnd := net.Pipe()
+	defer bobEnd.Close()
+	defer aliceEnd.Close()
+
+	spy := &deadlineSpy{Conn: aliceEnd}
+	errCh := make(chan error, 1)
+	go func() { errCh <- PerformOutboundHandshakeOnConn(bob, bobEnd) }()
+	require.NoError(t, PerformInboundHandshake(alice, spy))
+	require.NoError(t, <-errCh)
+
+	require.NotEmpty(t, spy.deadlines, "the handshake must arm a bound")
+	assert.True(t, spy.deadlines[len(spy.deadlines)-1].IsZero(),
+		"the last deadline change on success must be the clear")
+}
+
+// Pins the shipped budgets so nobody quietly changes them.
+func TestInboundHandshakeBoundDefaults(t *testing.T) {
+	assert.Equal(t, 3*time.Second, firstByteTimeout)
+	assert.Equal(t, 30*time.Second, inboundHandshakeTimeout)
+}
+
+// A bridge leg waits for a peer that may arrive well into the round, so the wait
+// variant must take the caller's first-byte budget instead of the accept-site default.
+func TestInboundHandshakeWaitAcceptsLateFirstByte(t *testing.T) {
+	shrinkHandshakeBounds(t, 60*time.Millisecond, 5*time.Second)
+	bob, err := InitSession(testkit.DiscardLogger(), config.OutboundPort, config.InboundPort)
+	require.NoError(t, err)
+
+	server, client := net.Pipe()
+	defer server.Close()
+	defer client.Close()
+
+	start := time.Now()
+	done := make(chan error, 1)
+	go func() { done <- PerformInboundHandshakeWait(bob, server, 2*time.Second) }()
+
+	// Arrive late: past the default first-byte budget, inside the caller's.
+	time.Sleep(250 * time.Millisecond)
+	go func() { _, _ = client.Write([]byte{0xff, 0xff, 0xff, 0xff}) }() // oversized length
+
+	select {
+	case err := <-done:
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "too large",
+			"the late first byte must be read, not killed by the default budget")
+		assert.Greater(t, time.Since(start), 200*time.Millisecond,
+			"failure must come from the oversized length, not the first-byte bound")
+	case <-time.After(4 * time.Second):
+		t.Fatal("wait-variant handshake hung")
+	}
+}

--- a/pkg/session/handshake_deadline_test.go
+++ b/pkg/session/handshake_deadline_test.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// ABOUTME: Tests that a read deadline on the conn makes an inbound handshake
+// ABOUTME: fail fast instead of blocking forever on a silent peer.
+
+package session
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/KeibiSoft/KeibiDrop/internal/testkit"
+	"github.com/KeibiSoft/KeibiDrop/pkg/config"
+	"github.com/stretchr/testify/require"
+)
+
+// A connected peer that never writes must not hang the inbound handshake: the handshake
+// arms its own read deadline, so ReadFull fails fast instead of blocking forever. The
+// bound lives inside PerformInboundHandshake, so no call site has to remember it.
+func TestInboundHandshakeRespectsReadDeadline(t *testing.T) {
+	shrinkHandshakeBounds(t, 200*time.Millisecond, 5*time.Second)
+	bob, err := InitSession(testkit.DiscardLogger(), config.OutboundPort, config.InboundPort)
+	require.NoError(t, err)
+
+	server, client := net.Pipe()
+	defer server.Close()
+	defer client.Close()
+
+	done := make(chan error, 1)
+	go func() { done <- PerformInboundHandshake(bob, server) }()
+
+	select {
+	case err := <-done:
+		require.Error(t, err, "a silent peer under a read deadline must fail the handshake")
+	case <-time.After(5 * time.Second):
+		t.Fatal("inbound handshake hung despite the read deadline")
+	}
+}

--- a/pkg/session/nonce_prefix_check_test.go
+++ b/pkg/session/nonce_prefix_check_test.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// ABOUTME: Tests that the reader rejects a frame carrying the wrong nonce
+// ABOUTME: direction prefix, closing a same-key reflection on one socket.
+
+package session
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/KeibiSoft/KeibiDrop/internal/testkit"
+)
+
+// A frame carries its writer's direction prefix in the nonce. Reader and writer on
+// one socket share a key, separated only by that prefix, so the reader MUST reject a
+// frame whose prefix is not the peer writer's expected one. Otherwise an on-path
+// attacker can reflect a frame the peer itself wrote back at the same key, and it
+// opens cleanly.
+func TestReaderRejectsWrongDirectionPrefix(t *testing.T) {
+	for _, suite := range cipherSuites {
+		suite := suite
+		t.Run(string(suite), func(t *testing.T) {
+			key := testkit.RandBytes(t, 32)
+
+			var sink bytes.Buffer
+			w := NewSecureWriterWithPrefix(&sink, key, suite, NoncePrefixOutbound)
+			if _, err := w.Write([]byte("control-frame")); err != nil {
+				t.Fatal(err)
+			}
+			frame := sink.Bytes()
+
+			// Positive control: a reader that expects the peer to write OUTBOUND opens it.
+			rOK := NewSecureReader(bytes.NewReader(frame), key, suite, NoncePrefixOutbound)
+			if _, err := rOK.Read(); err != nil {
+				t.Fatalf("correctly-directed frame must open: %v", err)
+			}
+
+			// The reflection: a reader on the same key but the OPPOSITE direction is fed
+			// the OUTBOUND frame. It must be rejected. Before the fix it opens cleanly.
+			rReflect := NewSecureReader(bytes.NewReader(frame), key, suite, NoncePrefixInbound)
+			if _, err := rReflect.Read(); err == nil {
+				t.Fatal("reader accepted a frame carrying the wrong direction prefix (reflection)")
+			}
+		})
+	}
+}

--- a/pkg/session/nonce_prefix_ratchet_test.go
+++ b/pkg/session/nonce_prefix_ratchet_test.go
@@ -1,0 +1,119 @@
+// ABOUTME: Regression tests pinning the nonce direction prefix invariant across the in-band
+// ABOUTME: rekey ratchet: the prefix bytes must stay constant across epochs and counters.
+
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package session
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/KeibiSoft/KeibiDrop/internal/testkit"
+	"github.com/stretchr/testify/require"
+)
+
+// A legitimate frame must still be accepted once the writer has ratcheted past epoch 0.
+// Regression guard: the prefix check in secureconn.go Read must never reject a valid
+// frame just because the rekey ratchet advanced the epoch.
+func TestReaderAcceptsCorrectPrefixAfterRatchet(t *testing.T) {
+	for _, suite := range cipherSuites {
+		suite := suite
+		t.Run(string(suite), func(t *testing.T) {
+			key := testkit.RandBytes(t, 32)
+
+			var sink bytes.Buffer
+			w := NewSecureWriterWithPrefix(&sink, key, suite, NoncePrefixOutbound)
+			require.NoError(t, w.ratchet(nil), "ratchet the writer to epoch 1")
+			require.Equal(t, uint16(1), w.epoch)
+
+			_, err := w.Write([]byte("post-ratchet payload"))
+			require.NoError(t, err)
+
+			r := NewSecureReader(bytes.NewReader(sink.Bytes()), key, suite, NoncePrefixOutbound)
+			r.keyUpdate.Store(true)
+			pt, err := r.Read()
+			require.NoError(t, err, "a correctly-prefixed frame must open after the writer ratcheted")
+			require.Equal(t, []byte("post-ratchet payload"), pt)
+		})
+	}
+}
+
+// Many frames in sequence, crossing several epoch bumps, must all decrypt: the counter reset
+// at each bump must not disturb the prefix bytes, and the reader must follow every bump in turn.
+func TestReaderAcceptsManyFramesAcrossEpochBump(t *testing.T) {
+	shrinkRekeyThresholds(t, 2048, 1<<20) // trigger on bytes, matching TestSecureConn_WriterRatchetsEpochOnWire
+
+	for _, suite := range cipherSuites {
+		suite := suite
+		t.Run(string(suite), func(t *testing.T) {
+			key := testkit.RandBytes(t, 32)
+			sink := &writeSink{}
+			sc := NewSecureConn(sink, key, suite, NoncePrefixOutbound)
+			sc.SetKeyUpdate(true)
+
+			const msgSize = 1024
+			const numMsgs = 8
+			payloads := make([][]byte, numMsgs)
+			for i := range payloads {
+				payloads[i] = testkit.RandBytes(t, msgSize)
+				_, err := sc.Write(payloads[i])
+				require.NoError(t, err)
+			}
+			require.Greater(t, sc.w.epoch, uint16(0), "the writer must have ratcheted at least once")
+
+			frames := nonces(t, sink.buf.Bytes())
+			require.Len(t, frames, numMsgs)
+			for i, n := range frames {
+				require.Equal(t, prefixBytes(NoncePrefixOutbound), n[:4],
+					"frame %d must keep the OUTB prefix regardless of epoch/counter", i)
+			}
+
+			r := NewSecureReader(bytes.NewReader(sink.buf.Bytes()), key, suite, NoncePrefixOutbound)
+			r.keyUpdate.Store(true)
+			for i, want := range payloads {
+				got, err := r.Read()
+				require.NoError(t, err, "frame %d must decrypt", i)
+				require.Equal(t, want, got, "frame %d payload mismatch", i)
+			}
+		})
+	}
+}
+
+// A reflected frame (written by the OUTBOUND writer, fed to a reader expecting the opposite
+// direction) must still be rejected once the writer has ratcheted past epoch 0, not just at
+// epoch 0: the prefix check runs before any epoch-aware decryption, so a later epoch must not
+// open a bypass window.
+func TestReaderRejectsWrongDirectionPrefixAfterRatchet(t *testing.T) {
+	for _, suite := range cipherSuites {
+		suite := suite
+		t.Run(string(suite), func(t *testing.T) {
+			key := testkit.RandBytes(t, 32)
+
+			var sink bytes.Buffer
+			w := NewSecureWriterWithPrefix(&sink, key, suite, NoncePrefixOutbound)
+			require.NoError(t, w.ratchet(nil), "ratchet the writer to epoch 1")
+			require.Equal(t, uint16(1), w.epoch)
+
+			_, err := w.Write([]byte("control-frame-ratcheted"))
+			require.NoError(t, err)
+			frame := sink.Bytes()
+
+			// Positive control: the matching-direction reader still opens it post-ratchet.
+			rOK := NewSecureReader(bytes.NewReader(frame), key, suite, NoncePrefixOutbound)
+			rOK.keyUpdate.Store(true)
+			_, err = rOK.Read()
+			require.NoError(t, err, "correctly-directed frame must open after ratchet")
+
+			// The reflection: a reader on the same key but the OPPOSITE direction, same epoch.
+			rReflect := NewSecureReader(bytes.NewReader(frame), key, suite, NoncePrefixInbound)
+			rReflect.keyUpdate.Store(true)
+			_, err = rReflect.Read()
+			require.Error(t, err, "reader accepted a reflected frame carrying the wrong direction prefix at epoch > 0")
+		})
+	}
+}

--- a/pkg/session/reconnect.go
+++ b/pkg/session/reconnect.go
@@ -313,7 +313,9 @@ func (r *ReconnectManager) reconnectBridge(logger *slog.Logger, initiator bool) 
 	if err != nil {
 		return fmt.Errorf("bridge dial (inbound): %w", err)
 	}
-	if err := PerformInboundHandshake(r.session, inConn); err != nil {
+	// Bridge leg: the peer arrives on its own reconnect cadence, so give the
+	// first byte the full handshake bound instead of the accept-site default.
+	if err := PerformInboundHandshakeWait(r.session, inConn, inboundHandshakeTimeout); err != nil {
 		_ = inConn.Close()
 		return fmt.Errorf("bridge inbound handshake: %w", err)
 	}

--- a/pkg/session/secureconn.go
+++ b/pkg/session/secureconn.go
@@ -314,6 +314,13 @@ func (s *SecureReader) Read() ([]byte, error) {
 	nonce := encrypted[:kbc.NonceSize]
 	ciphertext := encrypted[kbc.NonceSize:]
 
+	// Reject a frame whose nonce carries the wrong direction prefix. Reader and writer on
+	// one socket share a key, separated only by this prefix, so without the check an on-path
+	// attacker could reflect a frame the peer wrote back at the same key and it would open.
+	if got := binary.BigEndian.Uint32(nonce[:4]); got != s.prefix {
+		return nil, fmt.Errorf("nonce direction prefix %#x does not match expected %#x", got, s.prefix)
+	}
+
 	if !s.keyUpdate.Load() {
 		// Old-peer / epoch-0 path: decrypt with the current key, no epoch tracking, so
 		// the wire behaviour is exactly as before the ratchet existed.


### PR DESCRIPTION
Security fixes for the 0.4.2 release: a nonce direction-prefix check (socket reflection), a peer path-traversal guard, a read-size clamp with a 32-bit wrap guard, a bounded inbound handshake, and the Go 1.25.14 stdlib bump (27 CVEs to 0 reachable).

Also strips and trimpaths the bindings archive and repairs its module prep under go1.25.14. Validated: go build plus the pkg/logic/service and pkg/session suites green, govulncheck 0 reachable. One signed commit.
