### PR TITLE
ci: add govulncheck vulnerability scan

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,0 +1,40 @@
+# ABOUTME: govulncheck CI, scans Go modules + stdlib for known CVEs (golang.org/x/vuln).
+# ABOUTME: Source mode needs the cgo/FUSE build deps (ubuntu-22.04 like ci.yml); toolchain pinned via go.mod.
+name: govulncheck
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - 'tests/maestro/**'
+      - '*.md'
+      - 'docs/**'
+      - 'LICENSE*'
+      - '.github/ISSUE_TEMPLATE/**'
+  schedule:
+    - cron: "0 6 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  govulncheck:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+      - name: Install FUSE headers for the cgo build
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libfuse-dev libfuse3-dev
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+      - name: Scan modules and stdlib
+        env:
+          CGO_ENABLED: "1"
+        run: govulncheck ./...


### PR DESCRIPTION
Adds a standalone govulncheck workflow: source-mode scan of all packages plus stdlib, with the cgo/FUSE build deps mirroring ci.yml. Runs on PRs and pushes to main, plus a weekly cron so new vuln DB entries surface without a code change. Kept separate from ci.yml so the cron does not rerun the build matrix.

Current main scans clean (one module-level x/crypto/openpgp advisory, not called, does not fail the job).