### PR TITLE
fix(sync): cancel buffered peer remove on local write

### DIFF
--- a/pkg/filesystem/api.go
+++ b/pkg/filesystem/api.go
@@ -11,6 +11,7 @@ package filesystem
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -65,6 +66,33 @@ type FS struct {
 	// or resume keeps the cache: no re-fetch, files still there.
 	cacheOwnerFP string
 	cacheOwnerMu sync.Mutex
+}
+
+// NewBareRoot builds a minimal root Dir over saveDir. Unit-test and bench
+// scaffolding shared across packages (service, logic, and this package's
+// own tests): one definition instead of a hand-rolled Dir literal per file.
+// It cannot live in internal/testkit: testkit must stay an import leaf, and
+// importing this package from there cycles through the packages whose tests
+// use testkit.
+func NewBareRoot(saveDir string) *Dir {
+	d := &Dir{
+		RelativePath:        "/",
+		RealPathOfFile:      saveDir,
+		LocalDownloadFolder: saveDir,
+		IsLocalPresent:      true,
+		OpenMapLock:         sync.RWMutex{},
+		OpenFileHandlers:    make(map[uint64]*HandleEntry),
+		Adm:                 sync.RWMutex{},
+		AllDirMap:           make(map[string]*Dir),
+		AfmLock:             sync.RWMutex{},
+		AllFileMap:          make(map[string]*File),
+		RemoteFilesLock:     sync.RWMutex{},
+		RemoteFiles:         make(map[string]*File),
+		PrefetchSem:         make(chan struct{}, 8),
+		logger:              slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError})),
+	}
+	d.Root = d
+	return d
 }
 
 func NewFS(logger *slog.Logger) *FS {

--- a/pkg/filesystem/api.go
+++ b/pkg/filesystem/api.go
@@ -11,6 +11,7 @@ package filesystem
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -39,6 +40,12 @@ type FS struct {
 	MountReadOnly     bool // If true, every mutating FUSE op returns EROFS. Peer updates still apply.
 	PreserveMetadata  bool // If true, apply the origin's mode and times to files saved on disk when their content completes.
 
+	// TieBreakPeerWins: on an exactly equal version stamp against our own
+	// concurrent write, the peer's write wins. Set from the fingerprint
+	// order at peer verification, so both machines pick the same winner.
+	// Without it an exact tie rejects on both sides and never converges.
+	TieBreakPeerWins atomic.Bool
+
 	// host and root are published by Mount and cleared by Unmount while other
 	// goroutines (Run, teardown, gRPC handlers) read them, so access is atomic.
 	host atomic.Pointer[winfuse.FileSystemHost]
@@ -59,6 +66,33 @@ type FS struct {
 	// or resume keeps the cache: no re-fetch, files still there.
 	cacheOwnerFP string
 	cacheOwnerMu sync.Mutex
+}
+
+// NewBareRoot builds a minimal root Dir over saveDir. Unit-test and bench
+// scaffolding shared across packages (service, logic, and this package's
+// own tests): one definition instead of a hand-rolled Dir literal per file.
+// It cannot live in internal/testkit: testkit must stay an import leaf, and
+// importing this package from there cycles through the packages whose tests
+// use testkit.
+func NewBareRoot(saveDir string) *Dir {
+	d := &Dir{
+		RelativePath:        "/",
+		RealPathOfFile:      saveDir,
+		LocalDownloadFolder: saveDir,
+		IsLocalPresent:      true,
+		OpenMapLock:         sync.RWMutex{},
+		OpenFileHandlers:    make(map[uint64]*HandleEntry),
+		Adm:                 sync.RWMutex{},
+		AllDirMap:           make(map[string]*Dir),
+		AfmLock:             sync.RWMutex{},
+		AllFileMap:          make(map[string]*File),
+		RemoteFilesLock:     sync.RWMutex{},
+		RemoteFiles:         make(map[string]*File),
+		PrefetchSem:         make(chan struct{}, 8),
+		logger:              slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError})),
+	}
+	d.Root = d
+	return d
 }
 
 func NewFS(logger *slog.Logger) *FS {
@@ -172,6 +206,7 @@ func (fs *FS) Mount(mountPoint string, isSecond bool, downloadPath string) error
 	}
 
 	root.Root = root
+	root.TieBreakPeerWins.Store(fs.TieBreakPeerWins.Load())
 	root.warmDisabled = os.Getenv("KEIBIDROP_WARM_SIBLINGS") == "0"
 	root.SetCallbacks(fs.OnLocalChange, fs.OpenStreamProvider)
 	fs.ctxMu.Lock()
@@ -343,6 +378,16 @@ func (fs *FS) EnsurePeerScope(fp string) {
 		fs.ClearFiles() // Different peer: drop the previous peer's view.
 	}
 	fs.cacheOwnerFP = fp
+}
+
+// SetTieBreakPeerWins records the version tie-break direction for this peer
+// pairing. Called at peer verification, so a root built later inherits it and
+// a root already mounted (reconnect) is updated in place.
+func (fs *FS) SetTieBreakPeerWins(peerWins bool) {
+	fs.TieBreakPeerWins.Store(peerWins)
+	if root := fs.root.Load(); root != nil {
+		root.TieBreakPeerWins.Store(peerWins)
+	}
 }
 
 func (fs *FS) forceUnmount() {

--- a/pkg/filesystem/api.go
+++ b/pkg/filesystem/api.go
@@ -39,6 +39,12 @@ type FS struct {
 	MountReadOnly     bool // If true, every mutating FUSE op returns EROFS. Peer updates still apply.
 	PreserveMetadata  bool // If true, apply the origin's mode and times to files saved on disk when their content completes.
 
+	// TieBreakPeerWins: on an exactly equal version stamp against our own
+	// concurrent write, the peer's write wins. Set from the fingerprint
+	// order at peer verification, so both machines pick the same winner.
+	// Without it an exact tie rejects on both sides and never converges.
+	TieBreakPeerWins atomic.Bool
+
 	// host and root are published by Mount and cleared by Unmount while other
 	// goroutines (Run, teardown, gRPC handlers) read them, so access is atomic.
 	host atomic.Pointer[winfuse.FileSystemHost]
@@ -172,6 +178,7 @@ func (fs *FS) Mount(mountPoint string, isSecond bool, downloadPath string) error
 	}
 
 	root.Root = root
+	root.TieBreakPeerWins.Store(fs.TieBreakPeerWins.Load())
 	root.warmDisabled = os.Getenv("KEIBIDROP_WARM_SIBLINGS") == "0"
 	root.SetCallbacks(fs.OnLocalChange, fs.OpenStreamProvider)
 	fs.ctxMu.Lock()
@@ -343,6 +350,16 @@ func (fs *FS) EnsurePeerScope(fp string) {
 		fs.ClearFiles() // Different peer: drop the previous peer's view.
 	}
 	fs.cacheOwnerFP = fp
+}
+
+// SetTieBreakPeerWins records the version tie-break direction for this peer
+// pairing. Called at peer verification, so a root built later inherits it and
+// a root already mounted (reconnect) is updated in place.
+func (fs *FS) SetTieBreakPeerWins(peerWins bool) {
+	fs.TieBreakPeerWins.Store(peerWins)
+	if root := fs.root.Load(); root != nil {
+		root.TieBreakPeerWins.Store(peerWins)
+	}
 }
 
 func (fs *FS) forceUnmount() {

--- a/pkg/filesystem/api.go
+++ b/pkg/filesystem/api.go
@@ -40,10 +40,8 @@ type FS struct {
 	MountReadOnly     bool // If true, every mutating FUSE op returns EROFS. Peer updates still apply.
 	PreserveMetadata  bool // If true, apply the origin's mode and times to files saved on disk when their content completes.
 
-	// TieBreakPeerWins: on an exactly equal version stamp against our own
-	// concurrent write, the peer's write wins. Set from the fingerprint
-	// order at peer verification, so both machines pick the same winner.
-	// Without it an exact tie rejects on both sides and never converges.
+	// TieBreakPeerWins: on an exact stamp tie with a dirty local write the
+	// peer wins. Set from the fingerprint order at each handshake.
 	TieBreakPeerWins atomic.Bool
 
 	// host and root are published by Mount and cleared by Unmount while other
@@ -68,12 +66,8 @@ type FS struct {
 	cacheOwnerMu sync.Mutex
 }
 
-// NewBareRoot builds a minimal root Dir over saveDir. Unit-test and bench
-// scaffolding shared across packages (service, logic, and this package's
-// own tests): one definition instead of a hand-rolled Dir literal per file.
-// It cannot live in internal/testkit: testkit must stay an import leaf, and
-// importing this package from there cycles through the packages whose tests
-// use testkit.
+// NewBareRoot builds a minimal root over saveDir: the one unit-test scaffold
+// for every package. testkit cannot host it (import cycle via its users).
 func NewBareRoot(saveDir string) *Dir {
 	d := &Dir{
 		RelativePath:        "/",
@@ -380,9 +374,8 @@ func (fs *FS) EnsurePeerScope(fp string) {
 	fs.cacheOwnerFP = fp
 }
 
-// SetTieBreakPeerWins records the version tie-break direction for this peer
-// pairing. Called at peer verification, so a root built later inherits it and
-// a root already mounted (reconnect) is updated in place.
+// SetTieBreakPeerWins records the tie rank: a later root inherits it, a
+// mounted root updates in place.
 func (fs *FS) SetTieBreakPeerWins(peerWins bool) {
 	fs.TieBreakPeerWins.Store(peerWins)
 	if root := fs.root.Load(); root != nil {

--- a/pkg/filesystem/dirmove_cross_test.go
+++ b/pkg/filesystem/dirmove_cross_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// The crossing predicate: mv A B/ against mv B A/ must be detected in both
-// orientations, same-source rename-rename too, and unrelated moves never.
+// The crossing predicate: both orientations and same-source detected,
+// unrelated moves never.
 func TestCrossingDirMove(t *testing.T) {
 	d := newTestDir(t.TempDir())
 	d.RecordLocalDirMove("/A", "/B/A")

--- a/pkg/filesystem/dirmove_cross_test.go
+++ b/pkg/filesystem/dirmove_cross_test.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package filesystem
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The crossing predicate: mv A B/ against mv B A/ must be detected in both
+// orientations, same-source rename-rename too, and unrelated moves never.
+func TestCrossingDirMove(t *testing.T) {
+	d := newTestDir(t.TempDir())
+	d.RecordLocalDirMove("/A", "/B/A")
+	crossed, ourNew, ourOld := d.CrossingDirMove("/B", "/A/B")
+	require.True(t, crossed, "mutual nesting must be detected")
+	require.Equal(t, "/B/A", ourNew)
+	require.Equal(t, "/A", ourOld)
+
+	d2 := newTestDir(t.TempDir())
+	d2.RecordLocalDirMove("/B", "/A/B")
+	c2, _, _ := d2.CrossingDirMove("/A", "/B/A")
+	require.True(t, c2, "the reverse orientation must be detected")
+
+	d3 := newTestDir(t.TempDir())
+	d3.RecordLocalDirMove("/X", "/Y")
+	c3, _, _ := d3.CrossingDirMove("/X", "/Z")
+	require.True(t, c3, "same-source rename-rename must be detected")
+
+	d4 := newTestDir(t.TempDir())
+	d4.RecordLocalDirMove("/A", "/B/A")
+	c4, _, _ := d4.CrossingDirMove("/C", "/D/C")
+	require.False(t, c4, "unrelated moves must not cross")
+
+	d5 := newTestDir(t.TempDir())
+	c5, _, _ := d5.CrossingDirMove("/B", "/A/B")
+	require.False(t, c5, "no recorded local move, no crossing")
+}

--- a/pkg/filesystem/edit_conflict_test.go
+++ b/pkg/filesystem/edit_conflict_test.go
@@ -9,6 +9,7 @@ package filesystem
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -235,6 +236,75 @@ func TestBlindOverwrite_BaseIsHeldVersion(t *testing.T) {
 	require.Equal(t, 0, d.Release("/doc.txt", fi2.Fh))
 	require.Equal(t, remote.UnixNano(), lastBase(),
 		"post-fetch overwrite must announce the accepted version as its base")
+}
+
+// A preserve that fails on every route (rename and the byte-copy fallback)
+// must REFUSE the acceptance: local authority intact, no silent last-writer-
+// wins, watermark rolled back so the retried announce is not compared-equal
+// into a wedge. Once the blocker clears, the same announce accepts and
+// preserves. The ADD path shares the same helper and rollback shape.
+func TestPreserveFailure_RefusesAcceptanceThenRetries(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("read-only parent does not block rename the same way on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores the read-only parent, the rename cannot be made to fail")
+	}
+	d, _ := newConflictTestDir(t)
+	f := seedLocalFile(t, d, "/doc.txt", "only-copy-of-these-bytes")
+	identity := localIdentity(f)
+
+	// A read-only parent fails both the rename and the copy fallback: no new
+	// name can be created next to the file.
+	require.NoError(t, os.Chmod(d.LocalDownloadFolder, 0o555))
+	t.Cleanup(func() { _ = os.Chmod(d.LocalDownloadFolder, 0o755) })
+
+	st := remoteStat(9, time.Now().Add(2*time.Second))
+	incoming := st.Mtim.Sec*1e9 + st.Mtim.Nsec
+	err := d.EditRemoteFileWithBase(nopLogger(), "/doc.txt", "doc.txt", st, identity-1)
+	require.Error(t, err, "acceptance must be refused when the loser cannot be preserved")
+
+	require.NoError(t, os.Chmod(d.LocalDownloadFolder, 0o755))
+	require.Empty(t, conflictSiblings(t, d.LocalDownloadFolder))
+	got, rerr := os.ReadFile(filepath.Join(d.LocalDownloadFolder, "doc.txt"))
+	require.NoError(t, rerr)
+	require.Equal(t, "only-copy-of-these-bytes", string(got))
+	f.metaMu.Lock()
+	localNewer := f.LocalNewer
+	watermark := f.RemoteMtimeNs
+	f.metaMu.Unlock()
+	require.True(t, localNewer, "refused acceptance must keep local authority")
+	require.Less(t, watermark, incoming, "watermark must roll back so a retry can accept")
+
+	// The blocker is gone: the SAME announce now accepts and preserves.
+	require.NoError(t, d.EditRemoteFileWithBase(nopLogger(), "/doc.txt", "doc.txt", st, identity-1))
+	conflicts := conflictSiblings(t, d.LocalDownloadFolder)
+	require.Len(t, conflicts, 1)
+	got2, rerr2 := os.ReadFile(filepath.Join(d.LocalDownloadFolder, conflicts[0]))
+	require.NoError(t, rerr2)
+	require.Equal(t, "only-copy-of-these-bytes", string(got2))
+}
+
+// Unlink must announce the newest version this peer holds as the delete's
+// base, so the receiver can prove a delete-vs-edit race. Captured before the
+// maps are cleaned; a fresh local file's base is its own write stamp.
+func TestUnlink_AnnounceCarriesBase(t *testing.T) {
+	d, snapshot := newConflictTestDir(t)
+	f := seedLocalFile(t, d, "/doc.txt", "bytes-to-delete")
+	identity := localIdentity(f)
+
+	require.Equal(t, 0, d.Unlink("/doc.txt"))
+
+	var removeBase int64
+	var sawRemove bool
+	for _, ev := range snapshot() {
+		if ev.Action == types.RemoveFile && ev.Path == "/doc.txt" {
+			sawRemove = true
+			removeBase = ev.BaseMtimeNs
+		}
+	}
+	require.True(t, sawRemove, "Unlink must announce the removal")
+	require.Equal(t, identity, removeBase, "the delete must declare the held version as its base")
 }
 
 // A stale EDIT (older than the local write) keeps local authority: rejected

--- a/pkg/filesystem/edit_conflict_test.go
+++ b/pkg/filesystem/edit_conflict_test.go
@@ -238,11 +238,8 @@ func TestBlindOverwrite_BaseIsHeldVersion(t *testing.T) {
 		"post-fetch overwrite must announce the accepted version as its base")
 }
 
-// A preserve that fails on every route (rename and the byte-copy fallback)
-// must REFUSE the acceptance: local authority intact, no silent last-writer-
-// wins, watermark rolled back so the retried announce is not compared-equal
-// into a wedge. Once the blocker clears, the same announce accepts and
-// preserves. The ADD path shares the same helper and rollback shape.
+// A preserve that fails on every route refuses the acceptance and rolls the
+// watermark back. Once the blocker clears the same announce preserves.
 func TestPreserveFailure_RefusesAcceptanceThenRetries(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("read-only parent does not block rename the same way on Windows")
@@ -254,8 +251,7 @@ func TestPreserveFailure_RefusesAcceptanceThenRetries(t *testing.T) {
 	f := seedLocalFile(t, d, "/doc.txt", "only-copy-of-these-bytes")
 	identity := localIdentity(f)
 
-	// A read-only parent fails both the rename and the copy fallback: no new
-	// name can be created next to the file.
+	// A read-only parent fails the rename and the copy fallback.
 	require.NoError(t, os.Chmod(d.LocalDownloadFolder, 0o555))
 	t.Cleanup(func() { _ = os.Chmod(d.LocalDownloadFolder, 0o755) })
 
@@ -285,9 +281,8 @@ func TestPreserveFailure_RefusesAcceptanceThenRetries(t *testing.T) {
 	require.Equal(t, "only-copy-of-these-bytes", string(got2))
 }
 
-// Unlink must announce the newest version this peer holds as the delete's
-// base, so the receiver can prove a delete-vs-edit race. Captured before the
-// maps are cleaned; a fresh local file's base is its own write stamp.
+// Unlink announces the held version as the delete's base, captured before
+// the maps are cleaned.
 func TestUnlink_AnnounceCarriesBase(t *testing.T) {
 	d, snapshot := newConflictTestDir(t)
 	f := seedLocalFile(t, d, "/doc.txt", "bytes-to-delete")

--- a/pkg/filesystem/fuse_directory.go
+++ b/pkg/filesystem/fuse_directory.go
@@ -1696,8 +1696,8 @@ func (d *Dir) Rename(oldpath string, newpath string) (errCode int) {
 		return int(convertOsErrToSyscallErrno("rename", err))
 	}
 
-	// One stat, reused for the directory check here and the announce attr
-	// below: the file-rename hot path pays no extra syscall.
+	// One stat serves the dir check and the announce attr: no extra
+	// syscall on the file-rename hot path.
 	var renStat winfuse.Stat_t
 	renStatOK := false
 	if stgo, statErr := platLstat(cleanNewPath); statErr == nil {
@@ -1735,9 +1735,8 @@ func (d *Dir) Rename(oldpath string, newpath string) (errCode int) {
 	}
 	d.Adm.Unlock()
 
-	// A directory carried its whole subtree: re-key every child entry, or
-	// the old paths keep serving as ghosts. Recorded for the crossing check
-	// against an incoming peer move.
+	// A directory move carries its subtree: re-key the children and
+	// record the move for the crossing check.
 	if isDirRename {
 		d.RekeyChildren(oldpath, newpath)
 		d.RecordLocalDirMove(oldpath, newpath)
@@ -2011,11 +2010,8 @@ func (d *Dir) unlinkInternal(path string, notifyPeer bool) (errCode int) {
 	// d.logger.Info("FUSE unlink", "path", path, "notifyPeer", notifyPeer)
 	logger := d.logger.With("method", "unlink", "path", path)
 
-	// The delete's base: the newest version this peer holds for the path,
-	// captured before the maps are cleaned. The receiver compares it with its
-	// own authority: a dirty receiver above the base proves the delete raced
-	// an edit the deleter never saw, and preserves instead of discarding.
-	// One map lookup; can only overstate, so it never fires a false copy.
+	// Capture the delete's base before the maps are cleaned: a dirty
+	// receiver above it proves the delete raced an edit and preserves.
 	var removeBase int64
 	if notifyPeer {
 		removeBase = d.targetIdentity(path)
@@ -3245,22 +3241,15 @@ func conflictNames(relPath, realPath string) (string, string) {
 }
 
 // pathIsUnder reports whether p equals base or lies inside base's subtree.
-// FUSE relative paths are slash-separated on every platform: use the stdlib
-// path package on them (path.Dir, path.Clean), never filepath, whose Dir
-// returns backslashes on Windows and broke the crossing predicate there.
-// filepath stays correct for DISK paths.
+// Rel paths are slash-only on all platforms: use path.*, never filepath.
 func pathIsUnder(p, base string) bool {
 	p = path.Clean(p)
 	base = path.Clean(base)
 	return p == base || strings.HasPrefix(p, base+"/")
 }
 
-// RekeyChildren re-keys every tracked entry under oldpath to newpath after a
-// DIRECTORY rename, and updates the path fields the objects carry. Without
-// it the old child keys keep serving forever: the peer sees the moved child
-// under BOTH names (ghost), or a phantom entry readdir lists but stat
-// rejects. The walk is O(tracked entries); file renames, the app hot path,
-// never call it.
+// RekeyChildren re-keys all entries below oldpath after a directory rename.
+// Without it the old child keys serve forever. File renames never call it.
 func (d *Dir) RekeyChildren(oldpath, newpath string) {
 	oldPrefix := oldpath + "/"
 	reroot := func(k string) string { return newpath + k[len(oldpath):] }
@@ -3320,21 +3309,19 @@ func (d *Dir) RekeyChildren(oldpath, newpath string) {
 	d.Adm.Unlock()
 }
 
-// localDirMove records one local directory rename for the crossing check.
+// localDirMove is one local directory rename, kept for the crossing check.
 type localDirMove struct {
 	oldPath string
 	newPath string
 	at      time.Time
 }
 
-// dirMoveWindow bounds how long a local directory move counts as concurrent
-// with an incoming one. Crossing moves meet within network latency; a minute
-// is generous and keeps the table tiny.
+// dirMoveWindow bounds how long a local move counts as concurrent with an
+// incoming one. Crossing moves meet within network latency.
 const dirMoveWindow = time.Minute
 
-// RecordLocalDirMove notes a LOCAL directory rename so an incoming peer
-// rename can be checked for a crossing (mv A B/ against mv B A/). Only
-// kernel-originated moves are recorded; applying a peer move never counts.
+// RecordLocalDirMove notes a kernel-originated directory rename for the
+// crossing check. Applied peer moves are never recorded.
 func (d *Dir) RecordLocalDirMove(oldpath, newpath string) {
 	r := d.Root
 	if r == nil {
@@ -3353,11 +3340,8 @@ func (d *Dir) RecordLocalDirMove(oldpath, newpath string) {
 	r.dirMovesMu.Unlock()
 }
 
-// CrossingDirMove reports whether the incoming directory rename crosses a
-// recent local one. Two shapes: mutual nesting (the incoming target sits in
-// the tree we moved away while our target sits in the tree they moved), and
-// a rename-rename of the same source. Returns our move so the loser side can
-// undo it.
+// CrossingDirMove reports whether the incoming rename crosses a recent local
+// one: mutual nesting or same source. Returns our move for the undo.
 func (d *Dir) CrossingDirMove(inOld, inNew string) (bool, string, string) {
 	r := d.Root
 	if r == nil {
@@ -3380,8 +3364,7 @@ func (d *Dir) CrossingDirMove(inOld, inNew string) (bool, string, string) {
 	return false, "", ""
 }
 
-// ForgetLocalDirMove drops one recorded move (after an undo, so the same
-// incoming rename cannot match it twice).
+// ForgetLocalDirMove drops one recorded move after an undo.
 func (d *Dir) ForgetLocalDirMove(newpath string) {
 	r := d.Root
 	if r == nil {
@@ -3397,10 +3380,8 @@ func (d *Dir) ForgetLocalDirMove(newpath string) {
 	r.dirMovesMu.Unlock()
 }
 
-// UndoLocalDirMove reverses a local directory move on disk and in the maps,
-// WITHOUT announcing: the winning peer never applied our move (it skips it
-// under the same rank rule), so there is nothing to undo on their side. Used
-// by the crossing-move loser before it applies the winner's move.
+// UndoLocalDirMove reverses a local directory move without an announce: the
+// winner skipped our move, so there is nothing to undo on their side.
 func (d *Dir) UndoLocalDirMove(movedTo, movedFrom string) error {
 	realNew := filepath.Clean(filepath.Join(d.LocalDownloadFolder, movedTo))
 	realOld := filepath.Clean(filepath.Join(d.LocalDownloadFolder, movedFrom))
@@ -3443,9 +3424,8 @@ func (d *Dir) UndoLocalDirMove(movedTo, movedFrom string) error {
 	return nil
 }
 
-// copyFileContents copies src to dst byte for byte. Fallback for a failed
-// preserve rename. Not atomic; callers read dst only after success. O_EXCL:
-// conflictNames guarantees a free name, a survivor there means a race.
+// copyFileContents copies src to dst. Fallback for a failed preserve rename;
+// O_EXCL because conflictNames guarantees a free name.
 func copyFileContents(src, dst string) error {
 	in, err := os.Open(src) // #nosec G304 -- both paths are cache-internal
 	if err != nil {
@@ -3464,12 +3444,8 @@ func copyFileContents(src, dst string) error {
 	return out.Close()
 }
 
-// preserveLoserBytes moves the losing local version aside under the conflict
-// name. Rename is the O(1) fast path. On failure it closes local handles for
-// the path (the realistic rename blocker on Windows), retries once, then
-// falls back to a byte copy. An error means every route failed; the caller
-// MUST refuse the acceptance then, because proceeding would destroy the only
-// copy of the loser's bytes (silent last-writer-wins).
+// preserveLoserBytes moves the losing version to the conflict name: rename,
+// on failure close handles and retry, then copy. On error the caller refuses.
 func (d *Dir) preserveLoserBytes(logger *slog.Logger, relPath, realPath string) (string, string, error) {
 	conflictRel, conflictReal := conflictNames(relPath, realPath)
 	renErr := os.Rename(realPath, conflictReal)
@@ -3497,14 +3473,10 @@ func (d *Dir) preserveLoserBytes(logger *slog.Logger, relPath, realPath string) 
 	return conflictRel, conflictReal, nil
 }
 
-// PreserveConflictSiblingForDelete preserves the local version of path as a
-// conflict sibling, for a peer delete that provably raced a local edit. The
-// canonical entry stays for the caller to remove. An error means the bytes
-// could not be preserved on any route: the caller must then refuse the
-// delete rather than lose the only copy.
+// PreserveConflictSiblingForDelete preserves the local version before a peer
+// delete that raced a local edit. On error the caller must refuse the delete.
 func (d *Dir) PreserveConflictSiblingForDelete(logger *slog.Logger, path string) (string, error) {
-	// An edited remote file lives in RemoteFiles; a purely local one in
-	// AllFileMap. Same lookup order as SwapWouldConflict.
+	// Same lookup order as SwapWouldConflict.
 	d.RemoteFilesLock.RLock()
 	f := d.RemoteFiles[path]
 	d.RemoteFilesLock.RUnlock()
@@ -3526,11 +3498,8 @@ func (d *Dir) PreserveConflictSiblingForDelete(logger *slog.Logger, path string)
 	return conflictRel, nil
 }
 
-// UnsyncedConflictSiblings returns the conflict siblings this peer minted
-// and still holds write authority for (LocalNewer): the set to re-announce
-// on connect. A drop between the preserve and its delivery strands the
-// sibling on this side; re-announcing is idempotent because the peer
-// rejects an equal stamp. Each entry is {relative path, real path}.
+// UnsyncedConflictSiblings returns the siblings this peer minted and still
+// owns (LocalNewer): the set the connect path re-announces. {rel, real} pairs.
 func (d *Dir) UnsyncedConflictSiblings() [][2]string {
 	var out [][2]string
 	d.AfmLock.RLock()
@@ -3640,10 +3609,8 @@ func (d *Dir) AddRemoteFileWithBase(logger *slog.Logger, path string, name strin
 			existingMtime = existingStatMtime
 		}
 		accepted := incomingMtime > existingMtime
-		// Exact tie against our own concurrent write: the fingerprint rank
-		// picks the same winner on both machines. Without it both sides
-		// reject and the pair never converges. A tie against the remote
-		// watermark (wasLocalNewer false) is a redelivery and stays rejected.
+		// Exact tie with our own write: the fingerprint rank picks the same
+		// winner on both peers. A tie with the watermark is a redelivery.
 		if !accepted && wasLocalNewer && incomingMtime > 0 && incomingMtime == existingMtime &&
 			d.Root != nil && d.Root.TieBreakPeerWins.Load() {
 			accepted = true
@@ -3690,12 +3657,8 @@ func (d *Dir) AddRemoteFileWithBase(logger *slog.Logger, path string, name strin
 			return nil
 		}
 
-		// Preserve the losing local version before the acceptance clobbers it.
-		// A rename is O(1); the canonical name re-fetches the winner in full.
-		// A failed preserve refuses the acceptance and rolls the watermark and
-		// authority back, so the retried announce is not compared-equal into a
-		// permanent wedge. Silent last-writer-wins here would destroy the only
-		// copy of the loser's bytes.
+		// Preserve the loser before the winner clobbers it. A failed preserve
+		// refuses the acceptance and rolls back, never silent last-writer-wins.
 		var conflictRel, conflictReal string
 		if conflict && existing.RealPathOfFile != "" {
 			var pErr error
@@ -4158,13 +4121,8 @@ func (d *Dir) EditRemoteFileWithBase(logger *slog.Logger, path string, name stri
 		d.RemoteFilesLock.Unlock()
 		return syscall.ECANCELED
 	}
-	// Exact tie against our own concurrent write: without a rank both sides
-	// accept and the contents SWAP (each ends holding the other's bytes).
-	// The fingerprint rank picks one winner on both machines; the loser
-	// accepts and the conflict predicate below preserves its bytes. An
-	// equal stamp without dirty local bytes stays accepted: that is a
-	// metadata refresh or a redelivery, and rejecting it would break
-	// mode-only propagation.
+	// Exact tie with a dirty local write: the rank picks one winner; the
+	// loser accepts and preserves. An equal stamp when clean stays accepted.
 	if incomingEditMtime == editRef && editLocalNewer &&
 		(d.Root == nil || !d.Root.TieBreakPeerWins.Load()) {
 		d.RemoteFilesLock.Unlock()
@@ -4194,11 +4152,8 @@ func (d *Dir) EditRemoteFileWithBase(logger *slog.Logger, path string, name stri
 	// the same struct Getattr may mutate, so reading it post-unlock would race.
 	newSize := stat.Size
 
-	// Preserve the losing local version before the acceptance clobbers it.
-	// A rename is O(1); the canonical name re-fetches the winner in full.
-	// A failed preserve refuses the acceptance and rolls the watermark back,
-	// so the retried announce is not compared-equal into a permanent wedge.
-	// Silent last-writer-wins here would destroy the only copy of the bytes.
+	// Preserve the loser before the winner clobbers it. A failed preserve
+	// refuses the acceptance and rolls back, never silent last-writer-wins.
 	var conflictRel, conflictReal string
 	if conflict && f.RealPathOfFile != "" {
 		var pErr error

--- a/pkg/filesystem/fuse_directory.go
+++ b/pkg/filesystem/fuse_directory.go
@@ -17,10 +17,11 @@ package filesystem
 import (
 	"context"
 	"errors"
-	// "fmt"
+	"fmt"
 	"io"
 	"log/slog"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -1695,6 +1696,16 @@ func (d *Dir) Rename(oldpath string, newpath string) (errCode int) {
 		return int(convertOsErrToSyscallErrno("rename", err))
 	}
 
+	// One stat, reused for the directory check here and the announce attr
+	// below: the file-rename hot path pays no extra syscall.
+	var renStat winfuse.Stat_t
+	renStatOK := false
+	if stgo, statErr := platLstat(cleanNewPath); statErr == nil {
+		renStat = stgo
+		renStatOK = true
+	}
+	isDirRename := renStatOK && renStat.Mode&winfuse.S_IFMT == winfuse.S_IFDIR
+
 	// Remove the destination entry from AllFileMap (rename-over-existing).
 	// Do not remove it from RemoteFiles: the peer still tracks this file.
 	d.AfmLock.Lock()
@@ -1723,6 +1734,14 @@ func (d *Dir) Rename(oldpath string, newpath string) (errCode int) {
 		d.AllDirMap[newpath] = dir
 	}
 	d.Adm.Unlock()
+
+	// A directory carried its whole subtree: re-key every child entry, or
+	// the old paths keep serving as ghosts. Recorded for the crossing check
+	// against an incoming peer move.
+	if isDirRename {
+		d.RekeyChildren(oldpath, newpath)
+		d.RecordLocalDirMove(oldpath, newpath)
+	}
 
 	// Refresh stats after the map update.
 	oldParent := filepath.Dir(oldpath)
@@ -1766,13 +1785,13 @@ func (d *Dir) Rename(oldpath string, newpath string) (errCode int) {
 	// adopted own file. Peer-driven renames do not pass through this op, so
 	// there is no echo.
 	if d.hasOnLocalChange() {
-		// Get stat of the renamed file.
+		// Stat of the renamed file, taken once right after the disk rename.
 		var attr *keibidrop.Attr
-		if stgo, statErr := platLstat(cleanNewPath); statErr == nil {
-			attr = types.StatToAttr(&stgo)
+		if renStatOK {
+			attr = types.StatToAttr(&renStat)
 			if movedLocal != nil {
 				movedLocal.metaMu.Lock()
-				movedLocal.LastAnnouncedMtimeNs = stgo.Mtim.Sec*1e9 + stgo.Mtim.Nsec
+				movedLocal.LastAnnouncedMtimeNs = renStat.Mtim.Sec*1e9 + renStat.Mtim.Nsec
 				movedLocal.metaMu.Unlock()
 			}
 		}
@@ -1992,6 +2011,16 @@ func (d *Dir) unlinkInternal(path string, notifyPeer bool) (errCode int) {
 	// d.logger.Info("FUSE unlink", "path", path, "notifyPeer", notifyPeer)
 	logger := d.logger.With("method", "unlink", "path", path)
 
+	// The delete's base: the newest version this peer holds for the path,
+	// captured before the maps are cleaned. The receiver compares it with its
+	// own authority: a dirty receiver above the base proves the delete raced
+	// an edit the deleter never saw, and preserves instead of discarding.
+	// One map lookup; can only overstate, so it never fires a false copy.
+	var removeBase int64
+	if notifyPeer {
+		removeBase = d.targetIdentity(path)
+	}
+
 	// Check if this is a remote-only file (not downloaded locally).
 	d.RemoteFilesLock.Lock()
 	_, isRemote := d.RemoteFiles[path]
@@ -2049,9 +2078,10 @@ func (d *Dir) unlinkInternal(path string, notifyPeer bool) (errCode int) {
 	// Notify peer about the removed file.
 	if notifyPeer && d.hasOnLocalChange() && (!isRemote || err == nil) {
 		d.OnLocalChange(types.FileEvent{
-			Path:   path,
-			Action: types.RemoveFile,
-			Attr:   nil,
+			Path:        path,
+			Action:      types.RemoveFile,
+			Attr:        nil,
+			BaseMtimeNs: removeBase,
 		})
 	}
 
@@ -3214,6 +3244,311 @@ func conflictNames(relPath, realPath string) (string, string) {
 	}
 }
 
+// pathIsUnder reports whether p equals base or lies inside base's subtree.
+// FUSE relative paths are slash-separated on every platform: use the stdlib
+// path package on them (path.Dir, path.Clean), never filepath, whose Dir
+// returns backslashes on Windows and broke the crossing predicate there.
+// filepath stays correct for DISK paths.
+func pathIsUnder(p, base string) bool {
+	p = path.Clean(p)
+	base = path.Clean(base)
+	return p == base || strings.HasPrefix(p, base+"/")
+}
+
+// RekeyChildren re-keys every tracked entry under oldpath to newpath after a
+// DIRECTORY rename, and updates the path fields the objects carry. Without
+// it the old child keys keep serving forever: the peer sees the moved child
+// under BOTH names (ghost), or a phantom entry readdir lists but stat
+// rejects. The walk is O(tracked entries); file renames, the app hot path,
+// never call it.
+func (d *Dir) RekeyChildren(oldpath, newpath string) {
+	oldPrefix := oldpath + "/"
+	reroot := func(k string) string { return newpath + k[len(oldpath):] }
+	realOf := func(nk string) string { return filepath.Clean(filepath.Join(d.LocalDownloadFolder, nk)) }
+
+	d.AfmLock.Lock()
+	var fileKeys []string
+	for k := range d.AllFileMap {
+		if strings.HasPrefix(k, oldPrefix) {
+			fileKeys = append(fileKeys, k)
+		}
+	}
+	for _, k := range fileKeys {
+		f := d.AllFileMap[k]
+		delete(d.AllFileMap, k)
+		nk := reroot(k)
+		f.RelativePath = nk
+		f.Name = getNameFromPath(nk)
+		f.RealPathOfFile = realOf(nk)
+		d.AllFileMap[nk] = f
+	}
+	d.AfmLock.Unlock()
+
+	d.RemoteFilesLock.Lock()
+	var remoteKeys []string
+	for k := range d.RemoteFiles {
+		if strings.HasPrefix(k, oldPrefix) {
+			remoteKeys = append(remoteKeys, k)
+		}
+	}
+	for _, k := range remoteKeys {
+		f := d.RemoteFiles[k]
+		delete(d.RemoteFiles, k)
+		nk := reroot(k)
+		f.RelativePath = nk
+		f.Name = getNameFromPath(nk)
+		f.RealPathOfFile = realOf(nk)
+		d.RemoteFiles[nk] = f
+	}
+	d.RemoteFilesLock.Unlock()
+
+	d.Adm.Lock()
+	var dirKeys []string
+	for k := range d.AllDirMap {
+		if strings.HasPrefix(k, oldPrefix) {
+			dirKeys = append(dirKeys, k)
+		}
+	}
+	for _, k := range dirKeys {
+		sub := d.AllDirMap[k]
+		delete(d.AllDirMap, k)
+		nk := reroot(k)
+		sub.RelativePath = nk
+		sub.LocalDownloadFolder = realOf(nk)
+		d.AllDirMap[nk] = sub
+	}
+	d.Adm.Unlock()
+}
+
+// localDirMove records one local directory rename for the crossing check.
+type localDirMove struct {
+	oldPath string
+	newPath string
+	at      time.Time
+}
+
+// dirMoveWindow bounds how long a local directory move counts as concurrent
+// with an incoming one. Crossing moves meet within network latency; a minute
+// is generous and keeps the table tiny.
+const dirMoveWindow = time.Minute
+
+// RecordLocalDirMove notes a LOCAL directory rename so an incoming peer
+// rename can be checked for a crossing (mv A B/ against mv B A/). Only
+// kernel-originated moves are recorded; applying a peer move never counts.
+func (d *Dir) RecordLocalDirMove(oldpath, newpath string) {
+	r := d.Root
+	if r == nil {
+		return
+	}
+	r.dirMovesMu.Lock()
+	now := time.Now()
+	for i := 0; i < len(r.recentDirMoves); {
+		if now.Sub(r.recentDirMoves[i].at) > dirMoveWindow {
+			r.recentDirMoves = append(r.recentDirMoves[:i], r.recentDirMoves[i+1:]...)
+		} else {
+			i++
+		}
+	}
+	r.recentDirMoves = append(r.recentDirMoves, localDirMove{oldPath: oldpath, newPath: newpath, at: now})
+	r.dirMovesMu.Unlock()
+}
+
+// CrossingDirMove reports whether the incoming directory rename crosses a
+// recent local one. Two shapes: mutual nesting (the incoming target sits in
+// the tree we moved away while our target sits in the tree they moved), and
+// a rename-rename of the same source. Returns our move so the loser side can
+// undo it.
+func (d *Dir) CrossingDirMove(inOld, inNew string) (bool, string, string) {
+	r := d.Root
+	if r == nil {
+		return false, "", ""
+	}
+	r.dirMovesMu.Lock()
+	defer r.dirMovesMu.Unlock()
+	now := time.Now()
+	for _, m := range r.recentDirMoves {
+		if now.Sub(m.at) > dirMoveWindow {
+			continue
+		}
+		if inOld == m.oldPath && inNew != m.newPath {
+			return true, m.newPath, m.oldPath
+		}
+		if pathIsUnder(path.Dir(inNew), m.oldPath) && pathIsUnder(m.newPath, inOld) {
+			return true, m.newPath, m.oldPath
+		}
+	}
+	return false, "", ""
+}
+
+// ForgetLocalDirMove drops one recorded move (after an undo, so the same
+// incoming rename cannot match it twice).
+func (d *Dir) ForgetLocalDirMove(newpath string) {
+	r := d.Root
+	if r == nil {
+		return
+	}
+	r.dirMovesMu.Lock()
+	for i := 0; i < len(r.recentDirMoves); i++ {
+		if r.recentDirMoves[i].newPath == newpath {
+			r.recentDirMoves = append(r.recentDirMoves[:i], r.recentDirMoves[i+1:]...)
+			break
+		}
+	}
+	r.dirMovesMu.Unlock()
+}
+
+// UndoLocalDirMove reverses a local directory move on disk and in the maps,
+// WITHOUT announcing: the winning peer never applied our move (it skips it
+// under the same rank rule), so there is nothing to undo on their side. Used
+// by the crossing-move loser before it applies the winner's move.
+func (d *Dir) UndoLocalDirMove(movedTo, movedFrom string) error {
+	realNew := filepath.Clean(filepath.Join(d.LocalDownloadFolder, movedTo))
+	realOld := filepath.Clean(filepath.Join(d.LocalDownloadFolder, movedFrom))
+	if err := os.MkdirAll(filepath.Dir(realOld), 0o755); err != nil {
+		return err
+	}
+	if err := platRename(realNew, realOld); err != nil {
+		return err
+	}
+	d.AfmLock.Lock()
+	if f, ok := d.AllFileMap[movedTo]; ok {
+		delete(d.AllFileMap, movedTo)
+		f.RelativePath = movedFrom
+		f.Name = getNameFromPath(movedFrom)
+		f.RealPathOfFile = realOld
+		d.AllFileMap[movedFrom] = f
+	}
+	d.AfmLock.Unlock()
+	d.Adm.Lock()
+	if sub, ok := d.AllDirMap[movedTo]; ok {
+		delete(d.AllDirMap, movedTo)
+		sub.RelativePath = movedFrom
+		sub.LocalDownloadFolder = realOld
+		d.AllDirMap[movedFrom] = sub
+	}
+	d.Adm.Unlock()
+	d.RemoteFilesLock.Lock()
+	if f, ok := d.RemoteFiles[movedTo]; ok {
+		delete(d.RemoteFiles, movedTo)
+		f.RelativePath = movedFrom
+		f.Name = getNameFromPath(movedFrom)
+		f.RealPathOfFile = realOld
+		d.RemoteFiles[movedFrom] = f
+	}
+	d.RemoteFilesLock.Unlock()
+	d.RekeyChildren(movedTo, movedFrom)
+	d.ForgetLocalDirMove(movedTo)
+	d.refreshDirStat(path.Dir(movedFrom))
+	d.refreshDirStat(path.Dir(movedTo))
+	return nil
+}
+
+// copyFileContents copies src to dst byte for byte. Fallback for a failed
+// preserve rename. Not atomic; callers read dst only after success. O_EXCL:
+// conflictNames guarantees a free name, a survivor there means a race.
+func copyFileContents(src, dst string) error {
+	in, err := os.Open(src) // #nosec G304 -- both paths are cache-internal
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644) // #nosec G304
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		_ = os.Remove(dst)
+		return err
+	}
+	return out.Close()
+}
+
+// preserveLoserBytes moves the losing local version aside under the conflict
+// name. Rename is the O(1) fast path. On failure it closes local handles for
+// the path (the realistic rename blocker on Windows), retries once, then
+// falls back to a byte copy. An error means every route failed; the caller
+// MUST refuse the acceptance then, because proceeding would destroy the only
+// copy of the loser's bytes (silent last-writer-wins).
+func (d *Dir) preserveLoserBytes(logger *slog.Logger, relPath, realPath string) (string, string, error) {
+	conflictRel, conflictReal := conflictNames(relPath, realPath)
+	renErr := os.Rename(realPath, conflictReal)
+	if renErr != nil && runtime.GOOS == "windows" {
+		clean := filepath.Clean(realPath)
+		d.OpenMapLock.Lock()
+		for fh, entry := range d.OpenFileHandlers {
+			entryPath := filepath.Clean(filepath.Join(d.LocalDownloadFolder, entry.File.RelativePath))
+			if entryPath == clean {
+				_ = platClose(entry.FD)
+				delete(d.OpenFileHandlers, fh)
+			}
+		}
+		d.OpenMapLock.Unlock()
+		renErr = os.Rename(realPath, conflictReal)
+	}
+	if renErr != nil {
+		if cpErr := copyFileContents(realPath, conflictReal); cpErr != nil {
+			logger.Error("Conflict preserve failed on every route, refusing the acceptance",
+				"path", relPath, "renameError", renErr, "copyError", cpErr)
+			return "", "", fmt.Errorf("conflict preserve for %s: %w", relPath, renErr)
+		}
+		logger.Warn("Conflict preserve fell back to a byte copy", "path", relPath, "renameError", renErr)
+	}
+	return conflictRel, conflictReal, nil
+}
+
+// PreserveConflictSiblingForDelete preserves the local version of path as a
+// conflict sibling, for a peer delete that provably raced a local edit. The
+// canonical entry stays for the caller to remove. An error means the bytes
+// could not be preserved on any route: the caller must then refuse the
+// delete rather than lose the only copy.
+func (d *Dir) PreserveConflictSiblingForDelete(logger *slog.Logger, path string) (string, error) {
+	// An edited remote file lives in RemoteFiles; a purely local one in
+	// AllFileMap. Same lookup order as SwapWouldConflict.
+	d.RemoteFilesLock.RLock()
+	f := d.RemoteFiles[path]
+	d.RemoteFilesLock.RUnlock()
+	if f == nil {
+		d.AfmLock.RLock()
+		f = d.AllFileMap[path]
+		d.AfmLock.RUnlock()
+	}
+	if f == nil || f.RealPathOfFile == "" {
+		return "", nil
+	}
+	conflictRel, conflictReal, err := d.preserveLoserBytes(logger, path, f.RealPathOfFile)
+	if err != nil {
+		return "", err
+	}
+	_ = os.Remove(BitmapPath(f.RealPathOfFile))
+	d.registerConflictCopy(logger, conflictRel, conflictReal)
+	logger.Info("Peer delete raced a local edit: version preserved", "path", path, "conflict", conflictRel)
+	return conflictRel, nil
+}
+
+// UnsyncedConflictSiblings returns the conflict siblings this peer minted
+// and still holds write authority for (LocalNewer): the set to re-announce
+// on connect. A drop between the preserve and its delivery strands the
+// sibling on this side; re-announcing is idempotent because the peer
+// rejects an equal stamp. Each entry is {relative path, real path}.
+func (d *Dir) UnsyncedConflictSiblings() [][2]string {
+	var out [][2]string
+	d.AfmLock.RLock()
+	for k, f := range d.AllFileMap {
+		if f == nil || !strings.Contains(getNameFromPath(k), ".conflict-") {
+			continue
+		}
+		f.metaMu.Lock()
+		mine := f.LocalNewer && f.IsLocalPresent
+		f.metaMu.Unlock()
+		if mine {
+			out = append(out, [2]string{k, f.RealPathOfFile})
+		}
+	}
+	d.AfmLock.RUnlock()
+	return out
+}
+
 // registerConflictCopy makes a preserved version a normal local file: visible
 // in the tree and announced, so both peers end with both versions.
 func (d *Dir) registerConflictCopy(logger *slog.Logger, relPath, realPath string) {
@@ -3305,6 +3640,14 @@ func (d *Dir) AddRemoteFileWithBase(logger *slog.Logger, path string, name strin
 			existingMtime = existingStatMtime
 		}
 		accepted := incomingMtime > existingMtime
+		// Exact tie against our own concurrent write: the fingerprint rank
+		// picks the same winner on both machines. Without it both sides
+		// reject and the pair never converges. A tie against the remote
+		// watermark (wasLocalNewer false) is a redelivery and stays rejected.
+		if !accepted && wasLocalNewer && incomingMtime > 0 && incomingMtime == existingMtime &&
+			d.Root != nil && d.Root.TieBreakPeerWins.Load() {
+			accepted = true
+		}
 		// The edit is concurrent when its declared base is older than the
 		// version we hold: it provably never saw our bytes.
 		// Turn-taking edits carry base == our version and never trip this.
@@ -3324,11 +3667,12 @@ func (d *Dir) AddRemoteFileWithBase(logger *slog.Logger, path string, name strin
 			existing.LocalNewer = false // Remote has newer content.
 			existing.metaMu.Unlock()
 		}
+		existing.metaMu.Lock()
+		prevRemoteMtime := existing.RemoteMtimeNs
 		if incomingMtime > existing.RemoteMtimeNs {
-			existing.metaMu.Lock()
 			existing.RemoteMtimeNs = incomingMtime
-			existing.metaMu.Unlock()
 		}
+		existing.metaMu.Unlock()
 		if fuseOpLog {
 			d.logger.Debug("oplog AddRemoteFile existing", "path", path, "sizeChanged", sizeChanged,
 				"incomingMtime", incomingMtime, "existingMtime", existingMtime)
@@ -3348,20 +3692,30 @@ func (d *Dir) AddRemoteFileWithBase(logger *slog.Logger, path string, name strin
 
 		// Preserve the losing local version before the acceptance clobbers it.
 		// A rename is O(1); the canonical name re-fetches the winner in full.
+		// A failed preserve refuses the acceptance and rolls the watermark and
+		// authority back, so the retried announce is not compared-equal into a
+		// permanent wedge. Silent last-writer-wins here would destroy the only
+		// copy of the loser's bytes.
 		var conflictRel, conflictReal string
 		if conflict && existing.RealPathOfFile != "" {
-			conflictRel, conflictReal = conflictNames(path, existing.RealPathOfFile)
-			if renErr := os.Rename(existing.RealPathOfFile, conflictReal); renErr != nil {
-				logger.Warn("Conflict preserve failed, last-writer-wins", "path", path, "error", renErr)
-				conflictRel, conflictReal = "", ""
-			} else {
-				_ = os.Remove(BitmapPath(existing.RealPathOfFile))
-				if cf, cErr := os.OpenFile(existing.RealPathOfFile, os.O_CREATE|os.O_WRONLY, 0o644); cErr == nil { // #nosec G304
-					_ = cf.Truncate(newSize)
-					_ = cf.Close()
+			var pErr error
+			conflictRel, conflictReal, pErr = d.preserveLoserBytes(logger, path, existing.RealPathOfFile)
+			if pErr != nil {
+				existing.metaMu.Lock()
+				if existing.RemoteMtimeNs == incomingMtime {
+					existing.RemoteMtimeNs = prevRemoteMtime
 				}
-				logger.Info("Concurrent edit: local version preserved", "path", path, "conflict", conflictRel)
+				existing.LocalNewer = wasLocalNewer
+				existing.metaMu.Unlock()
+				d.RemoteFilesLock.Unlock()
+				return pErr
 			}
+			_ = os.Remove(BitmapPath(existing.RealPathOfFile))
+			if cf, cErr := os.OpenFile(existing.RealPathOfFile, os.O_CREATE|os.O_WRONLY, 0o644); cErr == nil { // #nosec G304
+				_ = cf.Truncate(newSize)
+				_ = cf.Close()
+			}
+			logger.Info("Concurrent edit: local version preserved", "path", path, "conflict", conflictRel)
 		}
 
 		existing.metaMu.Lock()
@@ -3804,6 +4158,18 @@ func (d *Dir) EditRemoteFileWithBase(logger *slog.Logger, path string, name stri
 		d.RemoteFilesLock.Unlock()
 		return syscall.ECANCELED
 	}
+	// Exact tie against our own concurrent write: without a rank both sides
+	// accept and the contents SWAP (each ends holding the other's bytes).
+	// The fingerprint rank picks one winner on both machines; the loser
+	// accepts and the conflict predicate below preserves its bytes. An
+	// equal stamp without dirty local bytes stays accepted: that is a
+	// metadata refresh or a redelivery, and rejecting it would break
+	// mode-only propagation.
+	if incomingEditMtime == editRef && editLocalNewer &&
+		!(d.Root != nil && d.Root.TieBreakPeerWins.Load()) {
+		d.RemoteFilesLock.Unlock()
+		return syscall.ECANCELED
+	}
 	// The edit is concurrent when its declared base is older than the version
 	// we hold: it provably never saw our bytes (same predicate as ADD).
 	conflict := editLocalNewer && baseMtimeNs != 0 && baseMtimeNs < editRef
@@ -3818,6 +4184,7 @@ func (d *Dir) EditRemoteFileWithBase(logger *slog.Logger, path string, name stri
 		d.OnLocalChange(types.FileEvent{Path: path, Action: types.CancelPendingNotify})
 	}
 	f.metaMu.Lock()
+	prevRemoteMtime := f.RemoteMtimeNs
 	if incomingEditMtime > f.RemoteMtimeNs {
 		f.RemoteMtimeNs = incomingEditMtime
 	}
@@ -3829,20 +4196,28 @@ func (d *Dir) EditRemoteFileWithBase(logger *slog.Logger, path string, name stri
 
 	// Preserve the losing local version before the acceptance clobbers it.
 	// A rename is O(1); the canonical name re-fetches the winner in full.
+	// A failed preserve refuses the acceptance and rolls the watermark back,
+	// so the retried announce is not compared-equal into a permanent wedge.
+	// Silent last-writer-wins here would destroy the only copy of the bytes.
 	var conflictRel, conflictReal string
 	if conflict && f.RealPathOfFile != "" {
-		conflictRel, conflictReal = conflictNames(path, f.RealPathOfFile)
-		if renErr := os.Rename(f.RealPathOfFile, conflictReal); renErr != nil {
-			logger.Warn("Conflict preserve failed, last-writer-wins", "path", path, "error", renErr)
-			conflictRel, conflictReal = "", ""
-		} else {
-			_ = os.Remove(BitmapPath(f.RealPathOfFile))
-			if cf, cErr := os.OpenFile(f.RealPathOfFile, os.O_CREATE|os.O_WRONLY, 0o644); cErr == nil { // #nosec G304
-				_ = cf.Truncate(newSize)
-				_ = cf.Close()
+		var pErr error
+		conflictRel, conflictReal, pErr = d.preserveLoserBytes(logger, path, f.RealPathOfFile)
+		if pErr != nil {
+			f.metaMu.Lock()
+			if f.RemoteMtimeNs == incomingEditMtime {
+				f.RemoteMtimeNs = prevRemoteMtime
 			}
-			logger.Info("Concurrent edit: local version preserved", "path", path, "conflict", conflictRel)
+			f.metaMu.Unlock()
+			d.RemoteFilesLock.Unlock()
+			return pErr
 		}
+		_ = os.Remove(BitmapPath(f.RealPathOfFile))
+		if cf, cErr := os.OpenFile(f.RealPathOfFile, os.O_CREATE|os.O_WRONLY, 0o644); cErr == nil { // #nosec G304
+			_ = cf.Truncate(newSize)
+			_ = cf.Close()
+		}
+		logger.Info("Concurrent edit: local version preserved", "path", path, "conflict", conflictRel)
 	}
 
 	// logger.Info("Remote file edited", "path", path, "mtime", stat.Mtim.Time())

--- a/pkg/filesystem/fuse_directory.go
+++ b/pkg/filesystem/fuse_directory.go
@@ -4166,7 +4166,7 @@ func (d *Dir) EditRemoteFileWithBase(logger *slog.Logger, path string, name stri
 	// metadata refresh or a redelivery, and rejecting it would break
 	// mode-only propagation.
 	if incomingEditMtime == editRef && editLocalNewer &&
-		!(d.Root != nil && d.Root.TieBreakPeerWins.Load()) {
+		(d.Root == nil || !d.Root.TieBreakPeerWins.Load()) {
 		d.RemoteFilesLock.Unlock()
 		return syscall.ECANCELED
 	}

--- a/pkg/filesystem/readdir_phantom_regression_test.go
+++ b/pkg/filesystem/readdir_phantom_regression_test.go
@@ -10,7 +10,6 @@ package filesystem
 
 import (
 	"os"
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -19,24 +18,9 @@ import (
 )
 
 // newTestDir builds a minimal Dir rooted at saveDir suitable for unit tests.
+// One definition for every package: NewBareRoot in api.go.
 func newTestDir(saveDir string) *Dir {
-	d := &Dir{
-		Inode:               0,
-		Name:                "",
-		RelativePath:        "/",
-		RealPathOfFile:      saveDir,
-		LocalDownloadFolder: saveDir,
-		IsLocalPresent:      true,
-		OpenMapLock:         sync.RWMutex{},
-		OpenFileHandlers:    make(map[uint64]*HandleEntry),
-		Adm:                 sync.RWMutex{},
-		AllDirMap:           make(map[string]*Dir),
-		AfmLock:             sync.RWMutex{},
-		AllFileMap:          make(map[string]*File),
-		RemoteFilesLock:     sync.RWMutex{},
-		RemoteFiles:         make(map[string]*File),
-	}
-	d.Root = d
+	d := NewBareRoot(saveDir)
 	d.logger = nopLogger()
 	return d
 }

--- a/pkg/filesystem/tie_break_test.go
+++ b/pkg/filesystem/tie_break_test.go
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Exact version-stamp ties. Observed once in CI (bidirectional-edit-matrix
+// iter-7): two peers wrote within the same nanosecond and both sides rejected
+// each other's announce forever. The rank rule (TieBreakPeerWins, from the
+// fingerprint order) makes exactly one side accept. These tests drive both
+// sides of the tie through the real acceptance paths: the ranked loser
+// accepts and preserves its bytes as a conflict sibling, the ranked winner
+// keeps rejecting. The model twin is tests/model/twopeer_tie_model_test.go.
+
+package filesystem
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	winfuse "github.com/winfsp/cgofuse/fuse"
+
+	"github.com/stretchr/testify/require"
+)
+
+// setExactIdentity pins the file's in-memory identity to an exact stamp so
+// the incoming announce can tie it deterministically.
+func setExactIdentity(f *File, ts time.Time) {
+	f.metaMu.Lock()
+	f.stat.Mtim = winfuse.NewTimespec(ts)
+	f.metaMu.Unlock()
+}
+
+// The ranked winner: the peer does NOT outrank us, so a tied ADD stays
+// rejected and local authority survives untouched.
+func TestTieBreak_AddWinnerKeepsRejecting(t *testing.T) {
+	d, _ := newConflictTestDir(t)
+	f := seedLocalFile(t, d, "/doc.txt", "winner-side-content")
+	tie := time.Now().Add(2 * time.Second).Truncate(time.Microsecond)
+	setExactIdentity(f, tie)
+
+	st := remoteStat(10, tie)
+	_ = d.AddRemoteFileWithBase(nopLogger(), "/doc.txt", "doc.txt", st, tie.UnixNano()-5e9)
+
+	require.Empty(t, conflictSiblings(t, d.LocalDownloadFolder))
+	got, err := os.ReadFile(filepath.Join(d.LocalDownloadFolder, "doc.txt"))
+	require.NoError(t, err)
+	require.Equal(t, "winner-side-content", string(got))
+	f.metaMu.Lock()
+	localNewer := f.LocalNewer
+	f.metaMu.Unlock()
+	require.True(t, localNewer, "a tied ADD without rank must keep local authority")
+}
+
+// The ranked loser: the peer outranks us, so the tied ADD is accepted, the
+// winner takes the canonical path, and our concurrent bytes survive as a
+// conflict sibling (the tie is provably concurrent, base below the stamp).
+func TestTieBreak_AddLoserAcceptsAndPreserves(t *testing.T) {
+	d, _ := newConflictTestDir(t)
+	d.Root.TieBreakPeerWins.Store(true)
+	f := seedLocalFile(t, d, "/doc.txt", "loser-side-content")
+	tie := time.Now().Add(2 * time.Second).Truncate(time.Microsecond)
+	setExactIdentity(f, tie)
+
+	st := remoteStat(10, tie)
+	require.NoError(t, d.AddRemoteFileWithBase(nopLogger(), "/doc.txt", "doc.txt", st, tie.UnixNano()-5e9))
+
+	conflicts := conflictSiblings(t, d.LocalDownloadFolder)
+	require.Len(t, conflicts, 1, "the tie loser must preserve its bytes")
+	got, err := os.ReadFile(filepath.Join(d.LocalDownloadFolder, conflicts[0]))
+	require.NoError(t, err)
+	require.Equal(t, "loser-side-content", string(got))
+	fi, err := os.Stat(filepath.Join(d.LocalDownloadFolder, "doc.txt"))
+	require.NoError(t, err)
+	require.EqualValues(t, 10, fi.Size(), "canonical cache must hold the winner's size")
+	f.metaMu.Lock()
+	localNewer := f.LocalNewer
+	f.metaMu.Unlock()
+	require.False(t, localNewer, "the tie loser hands authority to the winner")
+}
+
+// A tie against the REMOTE watermark (no dirty local write) is a redelivery,
+// not a concurrent write: rank must not turn it into an acceptance, so no
+// sibling appears and no authority changes. Same size on purpose: a size
+// change rides the separate metadata-refresh path for clean files, which is
+// existing behaviour outside this rule.
+func TestTieBreak_AddRedeliveryMintsNoConflict(t *testing.T) {
+	d, _ := newConflictTestDir(t)
+	d.Root.TieBreakPeerWins.Store(true)
+	f := seedLocalFile(t, d, "/doc.txt", "settled-content")
+	tie := time.Now().Add(2 * time.Second).Truncate(time.Microsecond)
+	f.metaMu.Lock()
+	f.RemoteMtimeNs = tie.UnixNano()
+	f.LocalNewer = false
+	f.metaMu.Unlock()
+
+	st := remoteStat(int64(len("settled-content")), tie)
+	_ = d.AddRemoteFileWithBase(nopLogger(), "/doc.txt", "doc.txt", st, 0)
+
+	require.Empty(t, conflictSiblings(t, d.LocalDownloadFolder))
+	got, err := os.ReadFile(filepath.Join(d.LocalDownloadFolder, "doc.txt"))
+	require.NoError(t, err)
+	require.Equal(t, "settled-content", string(got), "a redelivered tie must not clobber the cache")
+	f.metaMu.Lock()
+	localNewer := f.LocalNewer
+	f.metaMu.Unlock()
+	require.False(t, localNewer, "redelivery must not fabricate authority")
+}
+
+// The EDIT twin of the winner side. Before the rank rule an equal stamp
+// PASSED the strictly-older rejection, so two tied dirty peers each adopted
+// the other's edit and the contents swapped. The winner must reject.
+func TestTieBreak_EditWinnerRejectsTie(t *testing.T) {
+	d, _ := newConflictTestDir(t)
+	f := seedLocalFile(t, d, "/doc.txt", "winner-edit-content")
+	tie := time.Now().Add(2 * time.Second).Truncate(time.Microsecond)
+	setExactIdentity(f, tie)
+
+	st := remoteStat(10, tie)
+	err := d.EditRemoteFileWithBase(nopLogger(), "/doc.txt", "doc.txt", st, tie.UnixNano()-5e9)
+	require.Error(t, err, "a tied EDIT without rank must be rejected, not adopted")
+
+	require.Empty(t, conflictSiblings(t, d.LocalDownloadFolder))
+	got, rerr := os.ReadFile(filepath.Join(d.LocalDownloadFolder, "doc.txt"))
+	require.NoError(t, rerr)
+	require.Equal(t, "winner-edit-content", string(got))
+}
+
+// The EDIT twin of the loser side: accepted, and the concurrent local bytes
+// survive as a sibling.
+func TestTieBreak_EditLoserAcceptsAndPreserves(t *testing.T) {
+	d, _ := newConflictTestDir(t)
+	d.Root.TieBreakPeerWins.Store(true)
+	f := seedLocalFile(t, d, "/doc.txt", "loser-edit-content")
+	tie := time.Now().Add(2 * time.Second).Truncate(time.Microsecond)
+	setExactIdentity(f, tie)
+
+	st := remoteStat(10, tie)
+	require.NoError(t, d.EditRemoteFileWithBase(nopLogger(), "/doc.txt", "doc.txt", st, tie.UnixNano()-5e9))
+
+	conflicts := conflictSiblings(t, d.LocalDownloadFolder)
+	require.Len(t, conflicts, 1, "the tie loser must preserve its bytes")
+	got, err := os.ReadFile(filepath.Join(d.LocalDownloadFolder, conflicts[0]))
+	require.NoError(t, err)
+	require.Equal(t, "loser-edit-content", string(got))
+}
+
+// An equal stamp WITHOUT dirty local bytes is a metadata refresh (mode-only
+// propagation stamps the same mtime) and must stay accepted on both ranks.
+func TestTieBreak_EditEqualNotDirtyStillAccepted(t *testing.T) {
+	for _, peerWins := range []bool{false, true} {
+		d, _ := newConflictTestDir(t)
+		d.Root.TieBreakPeerWins.Store(peerWins)
+		f := seedLocalFile(t, d, "/doc.txt", "settled-content")
+		tie := time.Now().Add(2 * time.Second).Truncate(time.Microsecond)
+		f.metaMu.Lock()
+		f.stat.Mtim = winfuse.NewTimespec(tie)
+		f.RemoteMtimeNs = tie.UnixNano()
+		f.LocalNewer = false
+		f.metaMu.Unlock()
+
+		st := remoteStat(int64(len("settled-content")), tie)
+		require.NoError(t, d.EditRemoteFileWithBase(nopLogger(), "/doc.txt", "doc.txt", st, tie.UnixNano()),
+			"peerWins=%v: an equal-stamp metadata refresh must stay accepted", peerWins)
+		require.Empty(t, conflictSiblings(t, d.LocalDownloadFolder))
+	}
+}

--- a/pkg/filesystem/tie_break_test.go
+++ b/pkg/filesystem/tie_break_test.go
@@ -4,13 +4,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Exact version-stamp ties. Observed once in CI (bidirectional-edit-matrix
-// iter-7): two peers wrote within the same nanosecond and both sides rejected
-// each other's announce forever. The rank rule (TieBreakPeerWins, from the
-// fingerprint order) makes exactly one side accept. These tests drive both
-// sides of the tie through the real acceptance paths: the ranked loser
-// accepts and preserves its bytes as a conflict sibling, the ranked winner
-// keeps rejecting. The model twin is tests/model/twopeer_tie_model_test.go.
+// Exact version-stamp ties (observed once in CI). The rank rule makes exactly
+// one side accept; the loser preserves. Model twin: twopeer_tie_model_test.go.
 
 package filesystem
 
@@ -25,16 +20,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// setExactIdentity pins the file's in-memory identity to an exact stamp so
-// the incoming announce can tie it deterministically.
+// setExactIdentity pins the identity so the incoming announce ties it.
 func setExactIdentity(f *File, ts time.Time) {
 	f.metaMu.Lock()
 	f.stat.Mtim = winfuse.NewTimespec(ts)
 	f.metaMu.Unlock()
 }
 
-// The ranked winner: the peer does NOT outrank us, so a tied ADD stays
-// rejected and local authority survives untouched.
+// The winner: a tied ADD stays rejected, local authority survives.
 func TestTieBreak_AddWinnerKeepsRejecting(t *testing.T) {
 	d, _ := newConflictTestDir(t)
 	f := seedLocalFile(t, d, "/doc.txt", "winner-side-content")
@@ -54,9 +47,8 @@ func TestTieBreak_AddWinnerKeepsRejecting(t *testing.T) {
 	require.True(t, localNewer, "a tied ADD without rank must keep local authority")
 }
 
-// The ranked loser: the peer outranks us, so the tied ADD is accepted, the
-// winner takes the canonical path, and our concurrent bytes survive as a
-// conflict sibling (the tie is provably concurrent, base below the stamp).
+// The loser: the tied ADD is accepted and the concurrent local bytes
+// survive as a conflict sibling.
 func TestTieBreak_AddLoserAcceptsAndPreserves(t *testing.T) {
 	d, _ := newConflictTestDir(t)
 	d.Root.TieBreakPeerWins.Store(true)
@@ -81,11 +73,8 @@ func TestTieBreak_AddLoserAcceptsAndPreserves(t *testing.T) {
 	require.False(t, localNewer, "the tie loser hands authority to the winner")
 }
 
-// A tie against the REMOTE watermark (no dirty local write) is a redelivery,
-// not a concurrent write: rank must not turn it into an acceptance, so no
-// sibling appears and no authority changes. Same size on purpose: a size
-// change rides the separate metadata-refresh path for clean files, which is
-// existing behaviour outside this rule.
+// A tie with the remote watermark is a redelivery: no acceptance, no
+// sibling. Same size on purpose: a size change rides the refresh path.
 func TestTieBreak_AddRedeliveryMintsNoConflict(t *testing.T) {
 	d, _ := newConflictTestDir(t)
 	d.Root.TieBreakPeerWins.Store(true)
@@ -109,9 +98,8 @@ func TestTieBreak_AddRedeliveryMintsNoConflict(t *testing.T) {
 	require.False(t, localNewer, "redelivery must not fabricate authority")
 }
 
-// The EDIT twin of the winner side. Before the rank rule an equal stamp
-// PASSED the strictly-older rejection, so two tied dirty peers each adopted
-// the other's edit and the contents swapped. The winner must reject.
+// EDIT winner side: before the rank an equal stamp passed and tied dirty
+// peers swapped contents. The winner must reject.
 func TestTieBreak_EditWinnerRejectsTie(t *testing.T) {
 	d, _ := newConflictTestDir(t)
 	f := seedLocalFile(t, d, "/doc.txt", "winner-edit-content")
@@ -128,8 +116,7 @@ func TestTieBreak_EditWinnerRejectsTie(t *testing.T) {
 	require.Equal(t, "winner-edit-content", string(got))
 }
 
-// The EDIT twin of the loser side: accepted, and the concurrent local bytes
-// survive as a sibling.
+// EDIT loser side: accepted, local bytes survive as a sibling.
 func TestTieBreak_EditLoserAcceptsAndPreserves(t *testing.T) {
 	d, _ := newConflictTestDir(t)
 	d.Root.TieBreakPeerWins.Store(true)
@@ -147,8 +134,7 @@ func TestTieBreak_EditLoserAcceptsAndPreserves(t *testing.T) {
 	require.Equal(t, "loser-edit-content", string(got))
 }
 
-// An equal stamp WITHOUT dirty local bytes is a metadata refresh (mode-only
-// propagation stamps the same mtime) and must stay accepted on both ranks.
+// An equal stamp when clean is a metadata refresh: accepted on both ranks.
 func TestTieBreak_EditEqualNotDirtyStillAccepted(t *testing.T) {
 	for _, peerWins := range []bool{false, true} {
 		d, _ := newConflictTestDir(t)

--- a/pkg/filesystem/types.go
+++ b/pkg/filesystem/types.go
@@ -185,6 +185,19 @@ type Dir struct {
 	// PreserveMetadata is set on the ROOT dir: when a remote file's content
 	// completes on disk, apply the origin's mode and times to the saved file.
 	PreserveMetadata bool
+	// TieBreakPeerWins is set on the ROOT dir: on an exactly equal version
+	// stamp against our own concurrent write, the peer's write wins. Derived
+	// from the fingerprint order, so both machines pick the same winner.
+	// Atomic: peer verification on a reconnect updates it while notify
+	// handlers read it.
+	TieBreakPeerWins atomic.Bool
+
+	// Crossing-move detection, ROOT dir only: recent LOCAL directory
+	// renames, so an incoming peer rename can be checked for the
+	// mv A B/ against mv B A/ crossing. The loser of the fingerprint rank
+	// undoes its own move; the winner skips the peer's.
+	dirMovesMu     sync.Mutex
+	recentDirMoves []localDirMove
 
 	// ReadAheadWindowBlocks caps predictive sequential read-ahead. Sequential
 	// reads fetch up to this many ReadAheadBlock-sized blocks ahead of the read

--- a/pkg/filesystem/types.go
+++ b/pkg/filesystem/types.go
@@ -185,17 +185,12 @@ type Dir struct {
 	// PreserveMetadata is set on the ROOT dir: when a remote file's content
 	// completes on disk, apply the origin's mode and times to the saved file.
 	PreserveMetadata bool
-	// TieBreakPeerWins is set on the ROOT dir: on an exactly equal version
-	// stamp against our own concurrent write, the peer's write wins. Derived
-	// from the fingerprint order, so both machines pick the same winner.
-	// Atomic: peer verification on a reconnect updates it while notify
-	// handlers read it.
+	// TieBreakPeerWins, ROOT only: on an exact stamp tie with a dirty local
+	// write the peer wins. Atomic: reconnects update it under readers.
 	TieBreakPeerWins atomic.Bool
 
-	// Crossing-move detection, ROOT dir only: recent LOCAL directory
-	// renames, so an incoming peer rename can be checked for the
-	// mv A B/ against mv B A/ crossing. The loser of the fingerprint rank
-	// undoes its own move; the winner skips the peer's.
+	// Recent local directory renames, ROOT only, for the crossing check
+	// (mv A B/ against mv B A/).
 	dirMovesMu     sync.Mutex
 	recentDirMoves []localDirMove
 

--- a/pkg/logic/common/remove_cancel_local_test.go
+++ b/pkg/logic/common/remove_cancel_local_test.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// ABOUTME: Tests cancelRemoveOnLocalContent: local add/edit/rename events cancel a
+// ABOUTME: buffered peer REMOVE, other actions don't, and a nil KDSvc is safe.
+
+package common
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	bindings "github.com/KeibiSoft/KeibiDrop/grpc_bindings"
+	"github.com/KeibiSoft/KeibiDrop/internal/testkit"
+	"github.com/KeibiSoft/KeibiDrop/pkg/logic/service"
+	synctracker "github.com/KeibiSoft/KeibiDrop/pkg/sync-tracker"
+	"github.com/KeibiSoft/KeibiDrop/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+func armPendingRemove(t *testing.T, filePath string) *service.KeibidropServiceImpl {
+	t.Helper()
+	st := synctracker.NewSyncTracker()
+	st.RemoteFilesMu.Lock()
+	st.RemoteFiles[filePath] = &synctracker.File{Name: filePath, RelativePath: filePath, Size: 4}
+	st.RemoteFilesMu.Unlock()
+
+	svc := &service.KeibidropServiceImpl{
+		Logger:      testkit.DiscardLogger(),
+		SyncTracker: st,
+	}
+	_, err := svc.Notify(context.Background(), &bindings.NotifyRequest{
+		Type: bindings.NotifyType_REMOVE_FILE, Path: filePath,
+	})
+	require.NoError(t, err)
+	return svc
+}
+
+func trackedIn(svc *service.KeibidropServiceImpl, filePath string) bool {
+	svc.SyncTracker.RemoteFilesMu.RLock()
+	defer svc.SyncTracker.RemoteFilesMu.RUnlock()
+	_, ok := svc.SyncTracker.RemoteFiles[filePath]
+	return ok
+}
+
+// TestCancelRemoveOnLocalContent_EditCancels: a local EDIT event inside the
+// window cancels the buffered peer REMOVE, so the entry survives.
+func TestCancelRemoveOnLocalContent_EditCancels(t *testing.T) {
+	const filePath = "e.txt"
+	svc := armPendingRemove(t, filePath)
+	kd := &KeibiDrop{KDSvc: svc}
+
+	kd.cancelRemoveOnLocalContent(types.EditFile, filePath)
+
+	time.Sleep(1300 * time.Millisecond)
+	require.True(t, trackedIn(svc, filePath), "local edit must cancel the buffered remove")
+}
+
+// TestCancelRemoveOnLocalContent_NonContentActionsDoNot: a local REMOVE event
+// must not cancel the buffered peer REMOVE; it still executes.
+func TestCancelRemoveOnLocalContent_NonContentActionsDoNot(t *testing.T) {
+	const filePath = "r.txt"
+	svc := armPendingRemove(t, filePath)
+	kd := &KeibiDrop{KDSvc: svc}
+
+	kd.cancelRemoveOnLocalContent(types.RemoveFile, filePath)
+	kd.cancelRemoveOnLocalContent(types.CancelPendingNotify, filePath)
+
+	testkit.Eventually(t, 5*time.Second, 25*time.Millisecond, func() bool {
+		return !trackedIn(svc, filePath)
+	}, "non-content local actions must not cancel the remove")
+}
+
+// TestCancelRemoveOnLocalContent_NilSvcSafe: no service wired yet must not panic.
+func TestCancelRemoveOnLocalContent_NilSvcSafe(t *testing.T) {
+	kd := &KeibiDrop{}
+	require.NotPanics(t, func() {
+		kd.cancelRemoveOnLocalContent(types.AddFile, "x.txt")
+	})
+}

--- a/pkg/logic/common/remove_cancel_local_test.go
+++ b/pkg/logic/common/remove_cancel_local_test.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// ABOUTME: Tests cancelRemoveOnLocalContent: local add/edit/rename events cancel a
+// ABOUTME: buffered peer REMOVE, other actions don't, and a nil KDSvc is safe.
+
+package common
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	bindings "github.com/KeibiSoft/KeibiDrop/grpc_bindings"
+	"github.com/KeibiSoft/KeibiDrop/internal/testkit"
+	"github.com/KeibiSoft/KeibiDrop/pkg/logic/service"
+	synctracker "github.com/KeibiSoft/KeibiDrop/pkg/sync-tracker"
+	"github.com/KeibiSoft/KeibiDrop/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func armPendingRemove(t *testing.T, filePath string) *service.KeibidropServiceImpl {
+	t.Helper()
+	st := synctracker.NewSyncTracker()
+	st.RemoteFilesMu.Lock()
+	st.RemoteFiles[filePath] = &synctracker.File{Name: filePath, RelativePath: filePath, Size: 4}
+	st.RemoteFilesMu.Unlock()
+
+	svc := &service.KeibidropServiceImpl{
+		Logger:      testkit.DiscardLogger(),
+		SyncTracker: st,
+	}
+	_, err := svc.Notify(context.Background(), &bindings.NotifyRequest{
+		Type: bindings.NotifyType_REMOVE_FILE, Path: filePath,
+	})
+	require.NoError(t, err)
+	return svc
+}
+
+func trackedIn(svc *service.KeibidropServiceImpl, filePath string) bool {
+	svc.SyncTracker.RemoteFilesMu.RLock()
+	defer svc.SyncTracker.RemoteFilesMu.RUnlock()
+	_, ok := svc.SyncTracker.RemoteFiles[filePath]
+	return ok
+}
+
+// TestCancelRemoveOnLocalContent_EditCancels: a local EDIT event inside the
+// window cancels the buffered peer REMOVE, so the entry survives.
+func TestCancelRemoveOnLocalContent_EditCancels(t *testing.T) {
+	const filePath = "e.txt"
+	svc := armPendingRemove(t, filePath)
+	kd := &KeibiDrop{KDSvc: svc}
+
+	kd.cancelRemoveOnLocalContent(types.EditFile, filePath)
+
+	time.Sleep(1300 * time.Millisecond)
+	assert.True(t, trackedIn(svc, filePath), "local edit must cancel the buffered remove")
+}
+
+// TestCancelRemoveOnLocalContent_NonContentActionsDoNot: a local REMOVE event
+// must not cancel the buffered peer REMOVE; it still executes.
+func TestCancelRemoveOnLocalContent_NonContentActionsDoNot(t *testing.T) {
+	const filePath = "r.txt"
+	svc := armPendingRemove(t, filePath)
+	kd := &KeibiDrop{KDSvc: svc}
+
+	kd.cancelRemoveOnLocalContent(types.RemoveFile, filePath)
+	kd.cancelRemoveOnLocalContent(types.CancelPendingNotify, filePath)
+
+	require.Eventually(t, func() bool {
+		return !trackedIn(svc, filePath)
+	}, 5*time.Second, 25*time.Millisecond, "non-content local actions must not cancel the remove")
+}
+
+// TestCancelRemoveOnLocalContent_NilSvcSafe: no service wired yet must not panic.
+func TestCancelRemoveOnLocalContent_NilSvcSafe(t *testing.T) {
+	kd := &KeibiDrop{}
+	assert.NotPanics(t, func() {
+		kd.cancelRemoveOnLocalContent(types.AddFile, "x.txt")
+	})
+}

--- a/pkg/logic/common/remove_cancel_local_test.go
+++ b/pkg/logic/common/remove_cancel_local_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/KeibiSoft/KeibiDrop/pkg/logic/service"
 	synctracker "github.com/KeibiSoft/KeibiDrop/pkg/sync-tracker"
 	"github.com/KeibiSoft/KeibiDrop/pkg/types"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -54,7 +53,7 @@ func TestCancelRemoveOnLocalContent_EditCancels(t *testing.T) {
 	kd.cancelRemoveOnLocalContent(types.EditFile, filePath)
 
 	time.Sleep(1300 * time.Millisecond)
-	assert.True(t, trackedIn(svc, filePath), "local edit must cancel the buffered remove")
+	require.True(t, trackedIn(svc, filePath), "local edit must cancel the buffered remove")
 }
 
 // TestCancelRemoveOnLocalContent_NonContentActionsDoNot: a local REMOVE event
@@ -67,15 +66,15 @@ func TestCancelRemoveOnLocalContent_NonContentActionsDoNot(t *testing.T) {
 	kd.cancelRemoveOnLocalContent(types.RemoveFile, filePath)
 	kd.cancelRemoveOnLocalContent(types.CancelPendingNotify, filePath)
 
-	require.Eventually(t, func() bool {
+	testkit.Eventually(t, 5*time.Second, 25*time.Millisecond, func() bool {
 		return !trackedIn(svc, filePath)
-	}, 5*time.Second, 25*time.Millisecond, "non-content local actions must not cancel the remove")
+	}, "non-content local actions must not cancel the remove")
 }
 
 // TestCancelRemoveOnLocalContent_NilSvcSafe: no service wired yet must not panic.
 func TestCancelRemoveOnLocalContent_NilSvcSafe(t *testing.T) {
 	kd := &KeibiDrop{}
-	assert.NotPanics(t, func() {
+	require.NotPanics(t, func() {
 		kd.cancelRemoveOnLocalContent(types.AddFile, "x.txt")
 	})
 }

--- a/pkg/logic/common/resilience.go
+++ b/pkg/logic/common/resilience.go
@@ -152,10 +152,8 @@ func (kd *KeibiDrop) InitConnectionResilience() error {
 			if rel == "" {
 				rel = name // entry from an older build: flat announce
 			}
-			// LastEditTime is the announce-time watermark from the store, not
-			// the current disk mtime: it becomes the base of the reconnect
-			// re-announce. The disk mtime here would erase the base and turn
-			// an offline conflict into a silent overwrite.
+			// Keep the stored announce watermark: it becomes the re-announce
+			// base. The disk mtime here would erase offline conflicts.
 			kd.SyncTracker.LocalFiles[rel] = &synctracker.File{
 				Name:           name,
 				RelativePath:   rel,
@@ -177,11 +175,8 @@ func (kd *KeibiDrop) InitConnectionResilience() error {
 	kd.lastSharedFiles = nil
 	kd.lastSharedPeerFP = ""
 
-	// Conflict siblings this peer minted live in the FUSE tree, not in the
-	// tracker, so a session drop between the preserve and its delivery
-	// strands them here. Re-announce them on every connect: idempotent, the
-	// peer rejects an equal stamp. The model checker proves this rule closes
-	// every stranded interleaving (twopeer_conflictcopy_model_test.go).
+	// Siblings live in the FUSE tree, not the tracker: a drop can strand
+	// them here. Re-announce on every connect; idempotent.
 	go kd.announceLocalConflictSiblings(logger)
 
 	// Announce files already in the save folder. Runs after the restore block,
@@ -464,11 +459,8 @@ func (kd *KeibiDrop) onReconnected() {
 	kd.maybeStartEagerFold()
 }
 
-// announceLocalConflictSiblings re-announces the conflict siblings this peer
-// minted and still holds authority for. A session drop between the preserve
-// and its delivery strands the sibling on this side; announcing on every
-// connect closes that. Idempotent: the peer rejects an equal stamp, and base
-// -1 is the fresh-create class, so a dirty same-name receiver preserves.
+// announceLocalConflictSiblings re-announces the siblings this peer still
+// owns. A drop can strand one on this side; re-announcing is idempotent.
 func (kd *KeibiDrop) announceLocalConflictSiblings(logger *slog.Logger) {
 	if kd.FS == nil || kd.FS.Root() == nil {
 		return
@@ -534,10 +526,8 @@ func (kd *KeibiDrop) notifyRestoredFiles(logger *slog.Logger) {
 			continue
 		}
 		atime, btime := statTimes(info)
-		// The base is the watermark of our last announce, not the current
-		// disk mtime. An offline edit raises the disk mtime above it, so the
-		// receiver can prove concurrency and preserve instead of overwrite.
-		// Understating the base can only over-preserve, never lose bytes.
+		// Base = our last announce watermark, not the disk mtime: an offline
+		// edit above it becomes provable and is preserved, not overwritten.
 		_, _ = client.Notify(ctx, &bindings.NotifyRequest{
 			Type:        bindings.NotifyType(types.AddFile),
 			Path:        file.RelativePath,

--- a/pkg/logic/common/resilience.go
+++ b/pkg/logic/common/resilience.go
@@ -152,12 +152,16 @@ func (kd *KeibiDrop) InitConnectionResilience() error {
 			if rel == "" {
 				rel = name // entry from an older build: flat announce
 			}
+			// LastEditTime is the announce-time watermark from the store, not
+			// the current disk mtime: it becomes the base of the reconnect
+			// re-announce. The disk mtime here would erase the base and turn
+			// an offline conflict into a silent overwrite.
 			kd.SyncTracker.LocalFiles[rel] = &synctracker.File{
 				Name:           name,
 				RelativePath:   rel,
 				RealPathOfFile: cleanPath,
 				Size:           uint64(info.Size()),
-				LastEditTime:   uint64(info.ModTime().UnixNano()),
+				LastEditTime:   e.ModTime,
 			}
 			restored++
 		}
@@ -172,6 +176,13 @@ func (kd *KeibiDrop) InitConnectionResilience() error {
 	}
 	kd.lastSharedFiles = nil
 	kd.lastSharedPeerFP = ""
+
+	// Conflict siblings this peer minted live in the FUSE tree, not in the
+	// tracker, so a session drop between the preserve and its delivery
+	// strands them here. Re-announce them on every connect: idempotent, the
+	// peer rejects an equal stamp. The model checker proves this rule closes
+	// every stranded interleaving (twopeer_conflictcopy_model_test.go).
+	go kd.announceLocalConflictSiblings(logger)
 
 	// Announce files already in the save folder. Runs after the restore block,
 	// so restored files are already tracked and the scan skips them.
@@ -453,6 +464,48 @@ func (kd *KeibiDrop) onReconnected() {
 	kd.maybeStartEagerFold()
 }
 
+// announceLocalConflictSiblings re-announces the conflict siblings this peer
+// minted and still holds authority for. A session drop between the preserve
+// and its delivery strands the sibling on this side; announcing on every
+// connect closes that. Idempotent: the peer rejects an equal stamp, and base
+// -1 is the fresh-create class, so a dirty same-name receiver preserves.
+func (kd *KeibiDrop) announceLocalConflictSiblings(logger *slog.Logger) {
+	if kd.FS == nil || kd.FS.Root() == nil {
+		return
+	}
+	kd.mu.Lock()
+	client := kd.KDClient
+	ctx := kd.ctx
+	kd.mu.Unlock()
+	if client == nil || ctx == nil {
+		return
+	}
+	for _, s := range kd.FS.Root().UnsyncedConflictSiblings() {
+		if ctx.Err() != nil {
+			return
+		}
+		info, err := os.Stat(filepath.Clean(s[1]))
+		if err != nil {
+			continue
+		}
+		atime, btime := statTimes(info)
+		_, _ = client.Notify(ctx, &bindings.NotifyRequest{
+			Type:        bindings.NotifyType(types.AddFile),
+			Path:        s[0],
+			BaseMtimeNs: -1,
+			Attr: &bindings.Attr{
+				Mode:             uint32(info.Mode().Perm()) | 0100000,
+				Size:             info.Size(),
+				AccessTime:       atime,
+				ModificationTime: uint64(info.ModTime().UnixNano()),
+				ChangeTime:       uint64(info.ModTime().UnixNano()),
+				BirthTime:        btime,
+			},
+		})
+		logger.Info("Re-announced conflict sibling", "path", s[0])
+	}
+}
+
 // notifyRestoredFiles sends ADD_FILE for each restored LocalFile, so the peer sees
 // them. It runs only after a same-peer reconnect with confirmed files.
 func (kd *KeibiDrop) notifyRestoredFiles(logger *slog.Logger) {
@@ -481,9 +534,14 @@ func (kd *KeibiDrop) notifyRestoredFiles(logger *slog.Logger) {
 			continue
 		}
 		atime, btime := statTimes(info)
+		// The base is the watermark of our last announce, not the current
+		// disk mtime. An offline edit raises the disk mtime above it, so the
+		// receiver can prove concurrency and preserve instead of overwrite.
+		// Understating the base can only over-preserve, never lose bytes.
 		_, _ = client.Notify(ctx, &bindings.NotifyRequest{
-			Type: bindings.NotifyType(types.AddFile),
-			Path: file.RelativePath,
+			Type:        bindings.NotifyType(types.AddFile),
+			Path:        file.RelativePath,
+			BaseMtimeNs: int64(file.LastEditTime),
 			Attr: &bindings.Attr{
 				Mode:             uint32(info.Mode().Perm()) | 0100000,
 				Size:             info.Size(),

--- a/pkg/logic/common/scan_shared.go
+++ b/pkg/logic/common/scan_shared.go
@@ -194,11 +194,8 @@ func (kd *KeibiDrop) ScanAndShareSaveDir(ctx context.Context) (int, error) {
 			kd.SyncTracker.LocalFilesMu.Unlock()
 
 			batchFiles = append(batchFiles, file)
-			// Base -1 is the fresh-create class: no prior version was held.
-			// A scan announce only covers untracked files, and on a receiver
-			// that holds dirty local bytes for the same name -1 proves the
-			// concurrency, so the local version is preserved as a sibling.
-			// Base 0 (the old value) means unknown and disables preservation.
+			// Base -1 = fresh create: a dirty same-name receiver preserves.
+			// Base 0 would mean unknown and disable preservation.
 			batchReqs = append(batchReqs, &bindings.NotifyRequest{
 				Type:        bindings.NotifyType(types.AddFile),
 				Path:        rel,

--- a/pkg/logic/common/scan_shared.go
+++ b/pkg/logic/common/scan_shared.go
@@ -194,9 +194,15 @@ func (kd *KeibiDrop) ScanAndShareSaveDir(ctx context.Context) (int, error) {
 			kd.SyncTracker.LocalFilesMu.Unlock()
 
 			batchFiles = append(batchFiles, file)
+			// Base -1 is the fresh-create class: no prior version was held.
+			// A scan announce only covers untracked files, and on a receiver
+			// that holds dirty local bytes for the same name -1 proves the
+			// concurrency, so the local version is preserved as a sibling.
+			// Base 0 (the old value) means unknown and disables preservation.
 			batchReqs = append(batchReqs, &bindings.NotifyRequest{
-				Type: bindings.NotifyType(types.AddFile),
-				Path: rel,
+				Type:        bindings.NotifyType(types.AddFile),
+				Path:        rel,
+				BaseMtimeNs: -1,
 				Attr: &bindings.Attr{
 					Mode:             file.Mode,
 					Size:             finfo.Size(),

--- a/pkg/logic/common/utils.go
+++ b/pkg/logic/common/utils.go
@@ -404,11 +404,8 @@ func (kd *KeibiDrop) setupFilesystem(logger *slog.Logger, ready chan struct{}) e
 	fs.MountReadOnly = kd.MountReadOnly
 	fs.PreserveMetadata = kd.PreserveMetadata
 
-	// Version tie-break rank: the higher fingerprint wins an exact stamp
-	// tie. setupFilesystem runs on BOTH sides after their handshake verified
-	// the peer (finishConnect), so the rank is set for every session; the
-	// per-side verifiers alone covered only the joiner's path. Swapped
-	// operands on the two machines: exactly one side yields.
+	// Tie rank: the higher fingerprint wins an exact stamp tie. Set here
+	// because both sides run setupFilesystem after their handshake.
 	kd.mu.Lock()
 	sess := kd.session
 	kd.mu.Unlock()

--- a/pkg/logic/common/utils.go
+++ b/pkg/logic/common/utils.go
@@ -366,6 +366,23 @@ func countImmediateNotifies(batch []*bindings.NotifyRequest) int64 {
 	return n
 }
 
+// cancelRemoveOnLocalContent cancels a buffered peer REMOVE when a local
+// event lands new content at path (add/edit/rename destination). Without
+// this, the 1000ms remove window deletes the fresh local bytes.
+func (kd *KeibiDrop) cancelRemoveOnLocalContent(action types.FileAction, path string) {
+	switch action {
+	case types.AddFile, types.EditFile, types.RenameFile:
+	default:
+		return
+	}
+	kd.mu.Lock()
+	svc := kd.KDSvc
+	kd.mu.Unlock()
+	if svc != nil {
+		svc.CancelPendingRemove(path)
+	}
+}
+
 func (kd *KeibiDrop) setupFilesystem(logger *slog.Logger, ready chan struct{}) error {
 	if kd.session == nil || kd.session.GRPCClient == nil {
 		logger.Warn("Session or gRPC client not initialized")
@@ -606,6 +623,9 @@ func (kd *KeibiDrop) setupFilesystem(logger *slog.Logger, ready chan struct{}) e
 	}()
 
 	fs.OnLocalChange = func(event types.FileEvent) {
+		// A local write/rename supersedes any buffered peer REMOVE for the path.
+		kd.cancelRemoveOnLocalContent(event.Action, event.Path)
+
 		// Snapshot under kd.mu; teardown rewrites kd.session on another goroutine.
 		kd.mu.Lock()
 		s := kd.session

--- a/pkg/logic/common/utils.go
+++ b/pkg/logic/common/utils.go
@@ -366,6 +366,23 @@ func countImmediateNotifies(batch []*bindings.NotifyRequest) int64 {
 	return n
 }
 
+// cancelRemoveOnLocalContent cancels a buffered peer REMOVE when a local
+// event lands new content at path (add/edit/rename destination). Without
+// this, the 1000ms remove window deletes the fresh local bytes.
+func (kd *KeibiDrop) cancelRemoveOnLocalContent(action types.FileAction, path string) {
+	switch action {
+	case types.AddFile, types.EditFile, types.RenameFile:
+	default:
+		return
+	}
+	kd.mu.Lock()
+	svc := kd.KDSvc
+	kd.mu.Unlock()
+	if svc != nil {
+		svc.CancelPendingRemove(path)
+	}
+}
+
 func (kd *KeibiDrop) setupFilesystem(logger *slog.Logger, ready chan struct{}) error {
 	if kd.session == nil || kd.session.GRPCClient == nil {
 		logger.Warn("Session or gRPC client not initialized")
@@ -618,6 +635,9 @@ func (kd *KeibiDrop) setupFilesystem(logger *slog.Logger, ready chan struct{}) e
 	}()
 
 	fs.OnLocalChange = func(event types.FileEvent) {
+		// A local write/rename supersedes any buffered peer REMOVE for the path.
+		kd.cancelRemoveOnLocalContent(event.Action, event.Path)
+
 		// Snapshot under kd.mu; teardown rewrites kd.session on another goroutine.
 		kd.mu.Lock()
 		s := kd.session

--- a/pkg/logic/common/utils.go
+++ b/pkg/logic/common/utils.go
@@ -404,6 +404,18 @@ func (kd *KeibiDrop) setupFilesystem(logger *slog.Logger, ready chan struct{}) e
 	fs.MountReadOnly = kd.MountReadOnly
 	fs.PreserveMetadata = kd.PreserveMetadata
 
+	// Version tie-break rank: the higher fingerprint wins an exact stamp
+	// tie. setupFilesystem runs on BOTH sides after their handshake verified
+	// the peer (finishConnect), so the rank is set for every session; the
+	// per-side verifiers alone covered only the joiner's path. Swapped
+	// operands on the two machines: exactly one side yields.
+	kd.mu.Lock()
+	sess := kd.session
+	kd.mu.Unlock()
+	if sess != nil && sess.OwnFingerprint != "" && sess.ExpectedPeerFingerprint != "" {
+		fs.SetTieBreakPeerWins(sess.ExpectedPeerFingerprint > sess.OwnFingerprint)
+	}
+
 	// The handshake emits OnPeerVerified; the FUSE cache reacts by scoping to that peer. A
 	// different peer drops the prior cache (no cross-peer leak); the same peer reconnecting or
 	// resuming keeps it (no re-fetch).

--- a/pkg/logic/common/utils.go
+++ b/pkg/logic/common/utils.go
@@ -387,6 +387,18 @@ func (kd *KeibiDrop) setupFilesystem(logger *slog.Logger, ready chan struct{}) e
 	fs.MountReadOnly = kd.MountReadOnly
 	fs.PreserveMetadata = kd.PreserveMetadata
 
+	// Version tie-break rank: the higher fingerprint wins an exact stamp
+	// tie. setupFilesystem runs on BOTH sides after their handshake verified
+	// the peer (finishConnect), so the rank is set for every session; the
+	// per-side verifiers alone covered only the joiner's path. Swapped
+	// operands on the two machines: exactly one side yields.
+	kd.mu.Lock()
+	sess := kd.session
+	kd.mu.Unlock()
+	if sess != nil && sess.OwnFingerprint != "" && sess.ExpectedPeerFingerprint != "" {
+		fs.SetTieBreakPeerWins(sess.ExpectedPeerFingerprint > sess.OwnFingerprint)
+	}
+
 	// The handshake emits OnPeerVerified; the FUSE cache reacts by scoping to that peer. A
 	// different peer drops the prior cache (no cross-peer leak); the same peer reconnecting or
 	// resuming keeps it (no re-fetch).

--- a/pkg/logic/service/pathsafety_fuzz_test.go
+++ b/pkg/logic/service/pathsafety_fuzz_test.go
@@ -47,9 +47,11 @@ func FuzzIsUnsafeRemotePath(f *testing.F) {
 	}
 
 	// Synthetic root: the oracle is pure string math (filepath.Join/Clean),
-	// so this never needs to exist on disk.
-	const root = "/save/root"
+	// so this never needs to exist on disk. Native separator on purpose: a
+	// unix-literal root never prefix-matches the joined paths on Windows,
+	// which failed every accepted seed there.
 	sep := string(filepath.Separator)
+	root := filepath.Clean(sep + "save" + sep + "root")
 
 	f.Fuzz(func(t *testing.T, p string) {
 		if isUnsafeRemotePath(p) {

--- a/pkg/logic/service/remove_buffer_race_test.go
+++ b/pkg/logic/service/remove_buffer_race_test.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// ABOUTME: Tests the receiver remove-buffer race: a local write landing inside the
+// ABOUTME: 1000ms REMOVE window must survive; a genuine remove must still execute.
+
+//go:build !android
+
+package service
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	bindings "github.com/KeibiSoft/KeibiDrop/grpc_bindings"
+	"github.com/KeibiSoft/KeibiDrop/internal/testkit"
+	"github.com/KeibiSoft/KeibiDrop/pkg/filesystem"
+	synctracker "github.com/KeibiSoft/KeibiDrop/pkg/sync-tracker"
+	"github.com/stretchr/testify/require"
+)
+
+func newFuseServiceForRemoveTests(t *testing.T) (*KeibidropServiceImpl, *filesystem.Dir, string) {
+	t.Helper()
+	tmpDir := t.TempDir()
+	root := filesystem.NewBareRoot(tmpDir)
+	svc := &KeibidropServiceImpl{
+		Logger:      testkit.DiscardLogger(),
+		SyncTracker: synctracker.NewSyncTracker(),
+	}
+	fsForSvc := &filesystem.FS{}
+	fsForSvc.SetRoot(root)
+	svc.SetFS(fsForSvc)
+	return svc, root, tmpDir
+}
+
+// TestRemoveFile_FuseMode_LocalWriteDuringWindowSurvives reproduces the
+// remove-buffer race: a peer REMOVE arms the 1000ms window, a local write
+// lands and closes inside it, and the fired timer must NOT delete the bytes.
+func TestRemoveFile_FuseMode_LocalWriteDuringWindowSurvives(t *testing.T) {
+	svc, _, tmpDir := newFuseServiceForRemoveTests(t)
+	const filePath = "/doc.txt"
+
+	_, err := svc.Notify(context.Background(), &bindings.NotifyRequest{
+		Type: bindings.NotifyType_ADD_FILE, Path: filePath, Name: "doc.txt",
+		Attr: &bindings.Attr{Size: 8, ModificationTime: 1000000, Mode: 0o644},
+	})
+	require.NoError(t, err)
+	cachePath := filepath.Join(tmpDir, filePath)
+	require.NoError(t, os.WriteFile(cachePath, []byte("original"), 0o644))
+
+	_, err = svc.Notify(context.Background(), &bindings.NotifyRequest{
+		Type: bindings.NotifyType_REMOVE_FILE, Path: filePath,
+	})
+	require.NoError(t, err)
+
+	// The local write lands and closes well inside the 1000ms window.
+	time.Sleep(50 * time.Millisecond)
+	require.NoError(t, os.WriteFile(cachePath, []byte("fresh local bytes"), 0o644))
+
+	// Let the buffered remove fire; the local bytes must still be there.
+	time.Sleep(1300 * time.Millisecond)
+	got, err := os.ReadFile(cachePath)
+	require.NoError(t, err, "local write inside the remove window must survive")
+	require.Equal(t, "fresh local bytes", string(got))
+}
+
+// TestRemoveFile_FuseMode_GenuineRemoveStillExecutes: with no local activity
+// after the peer REMOVE, the buffered remove must still delete file and state.
+func TestRemoveFile_FuseMode_GenuineRemoveStillExecutes(t *testing.T) {
+	svc, root, tmpDir := newFuseServiceForRemoveTests(t)
+	const filePath = "/gone.txt"
+
+	cachePath := filepath.Join(tmpDir, filePath)
+	require.NoError(t, os.WriteFile(cachePath, []byte("stale"), 0o644))
+	_, err := svc.Notify(context.Background(), &bindings.NotifyRequest{
+		Type: bindings.NotifyType_ADD_FILE, Path: filePath, Name: "gone.txt",
+		Attr: &bindings.Attr{Size: 5, ModificationTime: 1000000, Mode: 0o644},
+	})
+	require.NoError(t, err)
+
+	// The file's mtime predates the REMOVE arming below.
+	time.Sleep(50 * time.Millisecond)
+	_, err = svc.Notify(context.Background(), &bindings.NotifyRequest{
+		Type: bindings.NotifyType_REMOVE_FILE, Path: filePath,
+	})
+	require.NoError(t, err)
+
+	testkit.Eventually(t, 5*time.Second, 25*time.Millisecond, func() bool {
+		root.AfmLock.RLock()
+		_, inAfm := root.AllFileMap[filePath]
+		root.AfmLock.RUnlock()
+		_, statErr := os.Stat(cachePath)
+		return !inAfm && os.IsNotExist(statErr)
+	}, "genuine buffered remove must still execute")
+}

--- a/pkg/logic/service/remove_buffer_race_test.go
+++ b/pkg/logic/service/remove_buffer_race_test.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// ABOUTME: Tests the receiver remove-buffer race: a local write landing inside the
+// ABOUTME: 1000ms REMOVE window must survive; a genuine remove must still execute.
+
+//go:build !android
+
+package service
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	bindings "github.com/KeibiSoft/KeibiDrop/grpc_bindings"
+	"github.com/KeibiSoft/KeibiDrop/internal/testkit"
+	"github.com/KeibiSoft/KeibiDrop/pkg/filesystem"
+	synctracker "github.com/KeibiSoft/KeibiDrop/pkg/sync-tracker"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newFuseServiceForRemoveTests(t *testing.T) (*KeibidropServiceImpl, *filesystem.Dir, string) {
+	t.Helper()
+	tmpDir := t.TempDir()
+	root := &filesystem.Dir{
+		RemoteFilesLock:     sync.RWMutex{},
+		RemoteFiles:         make(map[string]*filesystem.File),
+		AfmLock:             sync.RWMutex{},
+		AllFileMap:          make(map[string]*filesystem.File),
+		OpenMapLock:         sync.RWMutex{},
+		OpenFileHandlers:    make(map[uint64]*filesystem.HandleEntry),
+		Adm:                 sync.RWMutex{},
+		AllDirMap:           make(map[string]*filesystem.Dir),
+		RealPathOfFile:      tmpDir,
+		LocalDownloadFolder: tmpDir,
+		PrefetchSem:         make(chan struct{}, 8),
+	}
+	root.Root = root
+	svc := &KeibidropServiceImpl{
+		Logger:      testkit.DiscardLogger(),
+		SyncTracker: synctracker.NewSyncTracker(),
+	}
+	fsForSvc := &filesystem.FS{}
+	fsForSvc.SetRoot(root)
+	svc.SetFS(fsForSvc)
+	return svc, root, tmpDir
+}
+
+// TestRemoveFile_FuseMode_LocalWriteDuringWindowSurvives reproduces the
+// remove-buffer race: a peer REMOVE arms the 1000ms window, a local write
+// lands and closes inside it, and the fired timer must NOT delete the bytes.
+func TestRemoveFile_FuseMode_LocalWriteDuringWindowSurvives(t *testing.T) {
+	svc, _, tmpDir := newFuseServiceForRemoveTests(t)
+	const filePath = "/doc.txt"
+
+	_, err := svc.Notify(context.Background(), &bindings.NotifyRequest{
+		Type: bindings.NotifyType_ADD_FILE, Path: filePath, Name: "doc.txt",
+		Attr: &bindings.Attr{Size: 8, ModificationTime: 1000000, Mode: 0o644},
+	})
+	require.NoError(t, err)
+	cachePath := filepath.Join(tmpDir, filePath)
+	require.NoError(t, os.WriteFile(cachePath, []byte("original"), 0o644))
+
+	_, err = svc.Notify(context.Background(), &bindings.NotifyRequest{
+		Type: bindings.NotifyType_REMOVE_FILE, Path: filePath,
+	})
+	require.NoError(t, err)
+
+	// The local write lands and closes well inside the 1000ms window.
+	time.Sleep(50 * time.Millisecond)
+	require.NoError(t, os.WriteFile(cachePath, []byte("fresh local bytes"), 0o644))
+
+	// Let the buffered remove fire; the local bytes must still be there.
+	time.Sleep(1300 * time.Millisecond)
+	got, err := os.ReadFile(cachePath)
+	require.NoError(t, err, "local write inside the remove window must survive")
+	assert.Equal(t, "fresh local bytes", string(got))
+}
+
+// TestRemoveFile_FuseMode_GenuineRemoveStillExecutes: with no local activity
+// after the peer REMOVE, the buffered remove must still delete file and state.
+func TestRemoveFile_FuseMode_GenuineRemoveStillExecutes(t *testing.T) {
+	svc, root, tmpDir := newFuseServiceForRemoveTests(t)
+	const filePath = "/gone.txt"
+
+	cachePath := filepath.Join(tmpDir, filePath)
+	require.NoError(t, os.WriteFile(cachePath, []byte("stale"), 0o644))
+	_, err := svc.Notify(context.Background(), &bindings.NotifyRequest{
+		Type: bindings.NotifyType_ADD_FILE, Path: filePath, Name: "gone.txt",
+		Attr: &bindings.Attr{Size: 5, ModificationTime: 1000000, Mode: 0o644},
+	})
+	require.NoError(t, err)
+
+	// The file's mtime predates the REMOVE arming below.
+	time.Sleep(50 * time.Millisecond)
+	_, err = svc.Notify(context.Background(), &bindings.NotifyRequest{
+		Type: bindings.NotifyType_REMOVE_FILE, Path: filePath,
+	})
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		root.AfmLock.RLock()
+		_, inAfm := root.AllFileMap[filePath]
+		root.AfmLock.RUnlock()
+		_, statErr := os.Stat(cachePath)
+		return !inAfm && os.IsNotExist(statErr)
+	}, 5*time.Second, 25*time.Millisecond, "genuine buffered remove must still execute")
+}

--- a/pkg/logic/service/remove_buffer_race_test.go
+++ b/pkg/logic/service/remove_buffer_race_test.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"os"
 	"path/filepath"
-	"sync"
 	"testing"
 	"time"
 
@@ -19,27 +18,13 @@ import (
 	"github.com/KeibiSoft/KeibiDrop/internal/testkit"
 	"github.com/KeibiSoft/KeibiDrop/pkg/filesystem"
 	synctracker "github.com/KeibiSoft/KeibiDrop/pkg/sync-tracker"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func newFuseServiceForRemoveTests(t *testing.T) (*KeibidropServiceImpl, *filesystem.Dir, string) {
 	t.Helper()
 	tmpDir := t.TempDir()
-	root := &filesystem.Dir{
-		RemoteFilesLock:     sync.RWMutex{},
-		RemoteFiles:         make(map[string]*filesystem.File),
-		AfmLock:             sync.RWMutex{},
-		AllFileMap:          make(map[string]*filesystem.File),
-		OpenMapLock:         sync.RWMutex{},
-		OpenFileHandlers:    make(map[uint64]*filesystem.HandleEntry),
-		Adm:                 sync.RWMutex{},
-		AllDirMap:           make(map[string]*filesystem.Dir),
-		RealPathOfFile:      tmpDir,
-		LocalDownloadFolder: tmpDir,
-		PrefetchSem:         make(chan struct{}, 8),
-	}
-	root.Root = root
+	root := filesystem.NewBareRoot(tmpDir)
 	svc := &KeibidropServiceImpl{
 		Logger:      testkit.DiscardLogger(),
 		SyncTracker: synctracker.NewSyncTracker(),
@@ -78,7 +63,7 @@ func TestRemoveFile_FuseMode_LocalWriteDuringWindowSurvives(t *testing.T) {
 	time.Sleep(1300 * time.Millisecond)
 	got, err := os.ReadFile(cachePath)
 	require.NoError(t, err, "local write inside the remove window must survive")
-	assert.Equal(t, "fresh local bytes", string(got))
+	require.Equal(t, "fresh local bytes", string(got))
 }
 
 // TestRemoveFile_FuseMode_GenuineRemoveStillExecutes: with no local activity
@@ -102,11 +87,11 @@ func TestRemoveFile_FuseMode_GenuineRemoveStillExecutes(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	require.Eventually(t, func() bool {
+	testkit.Eventually(t, 5*time.Second, 25*time.Millisecond, func() bool {
 		root.AfmLock.RLock()
 		_, inAfm := root.AllFileMap[filePath]
 		root.AfmLock.RUnlock()
 		_, statErr := os.Stat(cachePath)
 		return !inAfm && os.IsNotExist(statErr)
-	}, 5*time.Second, 25*time.Millisecond, "genuine buffered remove must still execute")
+	}, "genuine buffered remove must still execute")
 }

--- a/pkg/logic/service/service.go
+++ b/pkg/logic/service/service.go
@@ -71,7 +71,7 @@ type KeibidropServiceImpl struct {
 	// RENAME_FILE arrives for the same path within that window, the REMOVE is
 	// cancelled (it was part of git's atomic .lock→rename dance, not a real deletion).
 	pendingRemovesMu sync.Mutex
-	pendingRemoves   map[string]*time.Timer
+	pendingRemoves   map[string]*pendingRemove
 }
 
 // FS returns the current FUSE tree, or nil before the first publish or after
@@ -196,7 +196,7 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 	case bindings.NotifyType_ADD_FILE:
 		// Cancel any pending buffered REMOVE for this path — the file wasn't
 		// really deleted, git just did REMOVE→CREATE as part of atomic write.
-		kd.cancelPendingRemove(req.Path)
+		kd.CancelPendingRemove(req.Path)
 
 		if req.Attr == nil {
 			logger.Error("Failed to add file, invalid attr", "error", ErrGRPCInvalidArgument)
@@ -271,7 +271,7 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 			kd.OnEvent(fmt.Sprintf("file_arrived:%s:%d", name, req.Attr.Size))
 		}
 	case bindings.NotifyType_EDIT_FILE:
-		kd.cancelPendingRemove(req.Path)
+		kd.CancelPendingRemove(req.Path)
 
 		if req.Attr == nil {
 			logger.Error("Failed to add file, invalid attr", "error", ErrGRPCInvalidArgument)
@@ -346,8 +346,8 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 	case bindings.NotifyType_RENAME_FILE:
 		// Cancel pending removes for both old and new path.
 		// Git renames .lock→final: the final path may have a pending REMOVE.
-		kd.cancelPendingRemove(req.Path)
-		kd.cancelPendingRemove(req.OldPath)
+		kd.CancelPendingRemove(req.Path)
+		kd.CancelPendingRemove(req.OldPath)
 
 		// Peer renamed/moved a file. OldPath -> Path.
 		logger.Info("Rename file", "oldPath", req.OldPath, "newPath", req.Path)
@@ -580,45 +580,56 @@ func (kd *KeibidropServiceImpl) BatchNotify(ctx context.Context, req *bindings.B
 // because the share is read-only.
 func (kd *KeibidropServiceImpl) ReadOnlyRefusals() uint64 { return kd.readOnlyRefusals.Load() }
 
-// bufferRemove delays a REMOVE_FILE by 1000ms. If cancelPendingRemove is called
+// pendingRemove is one buffered REMOVE_FILE: its timer plus when it was
+// armed, so executeRemove can skip the delete if a local write is newer.
+type pendingRemove struct {
+	timer   *time.Timer
+	armedAt time.Time
+}
+
+// bufferRemove delays a REMOVE_FILE by 1000ms. If CancelPendingRemove is called
 // for the same path before the timer fires, the remove is discarded.
 func (kd *KeibidropServiceImpl) bufferRemove(path string, logger *slog.Logger) {
 	kd.pendingRemovesMu.Lock()
 	defer kd.pendingRemovesMu.Unlock()
 
 	if kd.pendingRemoves == nil {
-		kd.pendingRemoves = make(map[string]*time.Timer)
+		kd.pendingRemoves = make(map[string]*pendingRemove)
 	}
 
 	// Cancel any existing pending remove for this path.
-	if t, ok := kd.pendingRemoves[path]; ok {
-		t.Stop()
+	if pr, ok := kd.pendingRemoves[path]; ok {
+		pr.timer.Stop()
 	}
 
-	kd.pendingRemoves[path] = time.AfterFunc(1000*time.Millisecond, func() {
+	armedAt := time.Now()
+	pr := &pendingRemove{armedAt: armedAt}
+	pr.timer = time.AfterFunc(1000*time.Millisecond, func() {
 		kd.pendingRemovesMu.Lock()
 		delete(kd.pendingRemoves, path)
 		kd.pendingRemovesMu.Unlock()
 
 		logger.Info("Executing buffered remove (no ADD/RENAME arrived)", "path", path)
-		kd.executeRemove(path, logger)
+		kd.executeRemove(path, logger, armedAt)
 	})
+	kd.pendingRemoves[path] = pr
 }
 
-// cancelPendingRemove cancels a buffered REMOVE_FILE if one exists.
-// Called when ADD_FILE, EDIT_FILE, or RENAME_FILE arrives for the same path,
-// indicating the REMOVE was part of git's atomic .lock→rename dance.
-func (kd *KeibidropServiceImpl) cancelPendingRemove(path string) {
+// CancelPendingRemove cancels a buffered REMOVE_FILE if one exists. Called
+// when a peer ADD_FILE/EDIT_FILE/RENAME_FILE arrives for the same path (git's
+// atomic .lock→rename dance) and when a LOCAL event lands new content at the
+// path: the buffered remove would otherwise delete the fresh local bytes.
+func (kd *KeibidropServiceImpl) CancelPendingRemove(path string) {
 	kd.pendingRemovesMu.Lock()
 	defer kd.pendingRemovesMu.Unlock()
 
 	if kd.pendingRemoves == nil {
 		return
 	}
-	if t, ok := kd.pendingRemoves[path]; ok {
-		t.Stop()
+	if pr, ok := kd.pendingRemoves[path]; ok {
+		pr.timer.Stop()
 		delete(kd.pendingRemoves, path)
-		kd.Logger.Info("Cancelled buffered remove (ADD/RENAME arrived)", "path", path)
+		kd.Logger.Info("Cancelled buffered remove", "path", path)
 	}
 }
 
@@ -628,18 +639,31 @@ func (kd *KeibidropServiceImpl) cancelPendingRemove(path string) {
 func (kd *KeibidropServiceImpl) cancelAllPendingRemoves() {
 	kd.pendingRemovesMu.Lock()
 	defer kd.pendingRemovesMu.Unlock()
-	for _, t := range kd.pendingRemoves {
-		t.Stop()
+	for _, pr := range kd.pendingRemoves {
+		pr.timer.Stop()
 	}
 	kd.pendingRemoves = nil
 }
 
-// executeRemove performs the actual REMOVE_FILE logic (previously inline in Notify).
-func (kd *KeibidropServiceImpl) executeRemove(path string, logger *slog.Logger) {
-	if kd.FS() != nil && kd.FS().Root() != nil {
+// executeRemove performs the actual REMOVE_FILE logic (previously inline in
+// Notify). armedAt is when the remove was buffered: a cache file whose mtime
+// is newer was written locally inside the window and must not be deleted.
+func (kd *KeibidropServiceImpl) executeRemove(path string, logger *slog.Logger, armedAt time.Time) {
+	// Snapshot FS/root once: teardown may SetFS(nil) while this timer
+	// goroutine runs, and repeated loads would race it (nil-receiver panic).
+	var root *filesystem.Dir
+	if fs := kd.FS(); fs != nil {
+		root = fs.Root()
+	}
+	if root != nil {
+		cachePath := filepath.Clean(filepath.Join(root.LocalDownloadFolder, path))
+		if st, err := os.Stat(cachePath); err == nil && !armedAt.IsZero() && st.ModTime().After(armedAt) {
+			logger.Info("Skipping buffered remove, local write is newer", "path", path)
+			return
+		}
 		hasOpenHandles := false
-		kd.FS().Root().AfmLock.Lock()
-		file, exists := kd.FS().Root().AllFileMap[path]
+		root.AfmLock.Lock()
+		file, exists := root.AllFileMap[path]
 		if exists && file != nil {
 			openCount := file.CountOpenDescriptors()
 			if openCount > 0 {
@@ -647,23 +671,22 @@ func (kd *KeibidropServiceImpl) executeRemove(path string, logger *slog.Logger) 
 				hasOpenHandles = true
 				logger.Info("File has open handles, marking for removal after download", "path", path, "openHandles", openCount)
 			} else {
-				delete(kd.FS().Root().AllFileMap, path)
+				delete(root.AllFileMap, path)
 			}
 		}
-		kd.FS().Root().AfmLock.Unlock()
+		root.AfmLock.Unlock()
 
-		kd.FS().Root().RemoteFilesLock.Lock()
-		if rf, rfOk := kd.FS().Root().RemoteFiles[path]; rfOk {
+		root.RemoteFilesLock.Lock()
+		if rf, rfOk := root.RemoteFiles[path]; rfOk {
 			if rf.PrefetchCancel != nil {
 				rf.PrefetchCancel()
 				rf.PrefetchCancel = nil
 			}
-			delete(kd.FS().Root().RemoteFiles, path)
+			delete(root.RemoteFiles, path)
 		}
-		kd.FS().Root().RemoteFilesLock.Unlock()
+		root.RemoteFilesLock.Unlock()
 
 		if !hasOpenHandles {
-			cachePath := filepath.Clean(filepath.Join(kd.FS().Root().LocalDownloadFolder, path))
 			if rmErr := os.Remove(cachePath); rmErr != nil && !os.IsNotExist(rmErr) {
 				logger.Warn("Failed to remove cache file", "path", cachePath, "error", rmErr)
 			}

--- a/pkg/logic/service/service.go
+++ b/pkg/logic/service/service.go
@@ -71,7 +71,7 @@ type KeibidropServiceImpl struct {
 	// RENAME_FILE arrives for the same path within that window, the REMOVE is
 	// cancelled (it was part of git's atomic .lock→rename dance, not a real deletion).
 	pendingRemovesMu sync.Mutex
-	pendingRemoves   map[string]*time.Timer
+	pendingRemoves   map[string]*pendingRemove
 }
 
 // FS returns the current FUSE tree, or nil before the first publish or after
@@ -198,7 +198,7 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 	case bindings.NotifyType_ADD_FILE:
 		// Cancel any pending buffered REMOVE for this path — the file wasn't
 		// really deleted, git just did REMOVE→CREATE as part of atomic write.
-		kd.cancelPendingRemove(req.Path)
+		kd.CancelPendingRemove(req.Path)
 
 		if req.Attr == nil {
 			logger.Error("Failed to add file, invalid attr", "error", ErrGRPCInvalidArgument)
@@ -273,7 +273,7 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 			kd.OnEvent(fmt.Sprintf("file_arrived:%s:%d", name, req.Attr.Size))
 		}
 	case bindings.NotifyType_EDIT_FILE:
-		kd.cancelPendingRemove(req.Path)
+		kd.CancelPendingRemove(req.Path)
 
 		if req.Attr == nil {
 			logger.Error("Failed to add file, invalid attr", "error", ErrGRPCInvalidArgument)
@@ -348,8 +348,8 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 	case bindings.NotifyType_RENAME_FILE:
 		// Cancel pending removes for both old and new path.
 		// Git renames .lock→final: the final path may have a pending REMOVE.
-		kd.cancelPendingRemove(req.Path)
-		kd.cancelPendingRemove(req.OldPath)
+		kd.CancelPendingRemove(req.Path)
+		kd.CancelPendingRemove(req.OldPath)
 
 		// Peer renamed/moved a file. OldPath -> Path.
 		logger.Info("Rename file", "oldPath", req.OldPath, "newPath", req.Path)
@@ -652,46 +652,58 @@ func (kd *KeibidropServiceImpl) BatchNotify(ctx context.Context, req *bindings.B
 // because the share is read-only.
 func (kd *KeibidropServiceImpl) ReadOnlyRefusals() uint64 { return kd.readOnlyRefusals.Load() }
 
-// bufferRemove delays a REMOVE_FILE by 1000ms. If cancelPendingRemove is called
-// for the same path before the timer fires, the remove is discarded. The
-// delete's declared base rides along for the edit-race check at execution.
+// pendingRemove is one buffered REMOVE_FILE: its timer plus when it was
+// armed, so executeRemove can skip the delete if a local write is newer.
+type pendingRemove struct {
+	timer   *time.Timer
+	armedAt time.Time
+}
+
+// bufferRemove delays a REMOVE_FILE by 1000ms. If CancelPendingRemove is
+// called for the same path before the timer fires, the remove is discarded.
+// The delete's declared base rides along for the edit-race check at
+// execution.
 func (kd *KeibidropServiceImpl) bufferRemove(path string, baseMtimeNs int64, logger *slog.Logger) {
 	kd.pendingRemovesMu.Lock()
 	defer kd.pendingRemovesMu.Unlock()
 
 	if kd.pendingRemoves == nil {
-		kd.pendingRemoves = make(map[string]*time.Timer)
+		kd.pendingRemoves = make(map[string]*pendingRemove)
 	}
 
 	// Cancel any existing pending remove for this path.
-	if t, ok := kd.pendingRemoves[path]; ok {
-		t.Stop()
+	if pr, ok := kd.pendingRemoves[path]; ok {
+		pr.timer.Stop()
 	}
 
-	kd.pendingRemoves[path] = time.AfterFunc(1000*time.Millisecond, func() {
+	armedAt := time.Now()
+	pr := &pendingRemove{armedAt: armedAt}
+	pr.timer = time.AfterFunc(1000*time.Millisecond, func() {
 		kd.pendingRemovesMu.Lock()
 		delete(kd.pendingRemoves, path)
 		kd.pendingRemovesMu.Unlock()
 
 		logger.Info("Executing buffered remove (no ADD/RENAME arrived)", "path", path)
-		kd.executeRemove(path, baseMtimeNs, logger)
+		kd.executeRemove(path, baseMtimeNs, logger, armedAt)
 	})
+	kd.pendingRemoves[path] = pr
 }
 
-// cancelPendingRemove cancels a buffered REMOVE_FILE if one exists.
-// Called when ADD_FILE, EDIT_FILE, or RENAME_FILE arrives for the same path,
-// indicating the REMOVE was part of git's atomic .lock→rename dance.
-func (kd *KeibidropServiceImpl) cancelPendingRemove(path string) {
+// CancelPendingRemove cancels a buffered REMOVE_FILE if one exists. Called
+// when a peer ADD_FILE/EDIT_FILE/RENAME_FILE arrives for the same path (git's
+// atomic .lock→rename dance) and when a LOCAL event lands new content at the
+// path: the buffered remove would otherwise delete the fresh local bytes.
+func (kd *KeibidropServiceImpl) CancelPendingRemove(path string) {
 	kd.pendingRemovesMu.Lock()
 	defer kd.pendingRemovesMu.Unlock()
 
 	if kd.pendingRemoves == nil {
 		return
 	}
-	if t, ok := kd.pendingRemoves[path]; ok {
-		t.Stop()
+	if pr, ok := kd.pendingRemoves[path]; ok {
+		pr.timer.Stop()
 		delete(kd.pendingRemoves, path)
-		kd.Logger.Info("Cancelled buffered remove (ADD/RENAME arrived)", "path", path)
+		kd.Logger.Info("Cancelled buffered remove", "path", path)
 	}
 }
 
@@ -701,15 +713,30 @@ func (kd *KeibidropServiceImpl) cancelPendingRemove(path string) {
 func (kd *KeibidropServiceImpl) cancelAllPendingRemoves() {
 	kd.pendingRemovesMu.Lock()
 	defer kd.pendingRemovesMu.Unlock()
-	for _, t := range kd.pendingRemoves {
-		t.Stop()
+	for _, pr := range kd.pendingRemoves {
+		pr.timer.Stop()
 	}
 	kd.pendingRemoves = nil
 }
 
-// executeRemove performs the actual REMOVE_FILE logic (previously inline in Notify).
-func (kd *KeibidropServiceImpl) executeRemove(path string, baseMtimeNs int64, logger *slog.Logger) {
-	if kd.FS() != nil && kd.FS().Root() != nil {
+// executeRemove performs the actual REMOVE_FILE logic (previously inline in
+// Notify). armedAt is when the remove was buffered: a cache file whose mtime
+// is newer was written locally inside the window and must not be deleted.
+// baseMtimeNs is the delete's declared base: a dirty local file above it
+// raced an edit the deleter never saw and is preserved as a sibling first.
+func (kd *KeibidropServiceImpl) executeRemove(path string, baseMtimeNs int64, logger *slog.Logger, armedAt time.Time) {
+	// Snapshot FS/root once: teardown may SetFS(nil) while this timer
+	// goroutine runs, and repeated loads would race it (nil-receiver panic).
+	var root *filesystem.Dir
+	if fs := kd.FS(); fs != nil {
+		root = fs.Root()
+	}
+	if root != nil {
+		cachePath := filepath.Clean(filepath.Join(root.LocalDownloadFolder, path))
+		if st, err := os.Stat(cachePath); err == nil && !armedAt.IsZero() && st.ModTime().After(armedAt) {
+			logger.Info("Skipping buffered remove, local write is newer", "path", path)
+			return
+		}
 		// A delete whose base is below local authority raced an edit the
 		// deleter never saw (same predicate as the swap path). Preserve the
 		// local version as a sibling first; its announce recreates it on the
@@ -720,16 +747,16 @@ func (kd *KeibidropServiceImpl) executeRemove(path string, baseMtimeNs int64, lo
 		if !strings.HasPrefix(fusePath, "/") {
 			fusePath = "/" + fusePath
 		}
-		if baseMtimeNs != 0 && kd.FS().Root().SwapWouldConflict(fusePath, baseMtimeNs) {
-			if _, pErr := kd.FS().Root().PreserveConflictSiblingForDelete(logger, fusePath); pErr != nil {
+		if baseMtimeNs != 0 && root.SwapWouldConflict(fusePath, baseMtimeNs) {
+			if _, pErr := root.PreserveConflictSiblingForDelete(logger, fusePath); pErr != nil {
 				logger.Error("Delete raced a local edit and preservation failed, refusing the delete",
 					"path", path, "error", pErr)
 				return
 			}
 		}
 		hasOpenHandles := false
-		kd.FS().Root().AfmLock.Lock()
-		file, exists := kd.FS().Root().AllFileMap[path]
+		root.AfmLock.Lock()
+		file, exists := root.AllFileMap[path]
 		if exists && file != nil {
 			openCount := file.CountOpenDescriptors()
 			if openCount > 0 {
@@ -737,23 +764,22 @@ func (kd *KeibidropServiceImpl) executeRemove(path string, baseMtimeNs int64, lo
 				hasOpenHandles = true
 				logger.Info("File has open handles, marking for removal after download", "path", path, "openHandles", openCount)
 			} else {
-				delete(kd.FS().Root().AllFileMap, path)
+				delete(root.AllFileMap, path)
 			}
 		}
-		kd.FS().Root().AfmLock.Unlock()
+		root.AfmLock.Unlock()
 
-		kd.FS().Root().RemoteFilesLock.Lock()
-		if rf, rfOk := kd.FS().Root().RemoteFiles[path]; rfOk {
+		root.RemoteFilesLock.Lock()
+		if rf, rfOk := root.RemoteFiles[path]; rfOk {
 			if rf.PrefetchCancel != nil {
 				rf.PrefetchCancel()
 				rf.PrefetchCancel = nil
 			}
-			delete(kd.FS().Root().RemoteFiles, path)
+			delete(root.RemoteFiles, path)
 		}
-		kd.FS().Root().RemoteFilesLock.Unlock()
+		root.RemoteFilesLock.Unlock()
 
 		if !hasOpenHandles {
-			cachePath := filepath.Clean(filepath.Join(kd.FS().Root().LocalDownloadFolder, path))
 			if rmErr := os.Remove(cachePath); rmErr != nil && !os.IsNotExist(rmErr) {
 				logger.Warn("Failed to remove cache file", "path", cachePath, "error", rmErr)
 			}

--- a/pkg/logic/service/service.go
+++ b/pkg/logic/service/service.go
@@ -149,8 +149,8 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 			strings.Contains(req.Path, ".fuse_hidden") &&
 			req.OldPath != "" && !strings.Contains(req.OldPath, ".fuse_hidden") {
 			logger.Info("Rename to FUSE hidden name, buffering remove of source", "path", req.OldPath)
-			// Base 0 on purpose: the rename's base describes the hidden
-			// TARGET, not the source leaving the folder. Plain delete.
+			// Base 0: the rename base describes the hidden target, not
+			// the source leaving the folder.
 			kd.bufferRemove(req.OldPath, 0, logger)
 		}
 		return &bindings.NotifyResponse{}, nil
@@ -359,12 +359,8 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 			oldDiskPath := filepath.Clean(filepath.Join(kd.FS().Root().RealPathOfFile, req.OldPath))
 			newDiskPath := filepath.Clean(filepath.Join(kd.FS().Root().RealPathOfFile, req.Path))
 
-			// Crossing directory moves (mv A B/ against mv B A/): both peers
-			// moved concurrently, and applying the peer's move on top would
-			// nest the trees into each other via the MkdirAll below. The
-			// fingerprint rank picks ONE move on both machines: the loser
-			// undoes its own and applies the winner's; the winner skips the
-			// peer's. One converged tree, no resurrection.
+			// Crossing directory moves: applying the peer's move over ours
+			// nests the trees. The rank keeps ONE move; the loser undoes.
 			if crossed, ourNew, ourOld := kd.FS().Root().CrossingDirMove(req.OldPath, req.Path); crossed {
 				if kd.FS().Root().TieBreakPeerWins.Load() {
 					if undoErr := kd.FS().Root().UndoLocalDirMove(ourNew, ourOld); undoErr != nil {
@@ -461,10 +457,8 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 			}
 			kd.FS().Root().AfmLock.Unlock()
 
-			// A directory travels as RENAME_FILE too: re-key the dir's own
-			// entry and every child, or the old paths keep serving as
-			// ghosts, and keep it away from the file-shaped acceptance
-			// branches below.
+			// A directory travels as RENAME_FILE: re-key its entry and
+			// children, and skip the file-shaped branches below.
 			if st, statErr := os.Stat(newDiskPath); statErr == nil && st.IsDir() {
 				isDirRename = true
 				root := kd.FS().Root()
@@ -568,9 +562,8 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 				}
 				logger.Info("Created file from RENAME (old path not tracked)", "path", req.Path, "size", req.Attr.Size)
 			}
-			// Children of a renamed directory, both key shapes (FUSE-origin
-			// keys carry a leading slash, API-origin none). File renames take
-			// the exact-hit path above and never pay the walk.
+			// Children of a renamed directory, both key shapes. File
+			// renames take the exact hit above and never pay the walk.
 			if isDirRename || !exactHit {
 				rekeyPrefix := func(oldP, newP string) {
 					oldPre := oldP + "/"
@@ -659,10 +652,8 @@ type pendingRemove struct {
 	armedAt time.Time
 }
 
-// bufferRemove delays a REMOVE_FILE by 1000ms. If CancelPendingRemove is
-// called for the same path before the timer fires, the remove is discarded.
-// The delete's declared base rides along for the edit-race check at
-// execution.
+// bufferRemove delays a REMOVE_FILE by 1000ms; CancelPendingRemove discards
+// it. The declared base rides along for the edit-race check.
 func (kd *KeibidropServiceImpl) bufferRemove(path string, baseMtimeNs int64, logger *slog.Logger) {
 	kd.pendingRemovesMu.Lock()
 	defer kd.pendingRemovesMu.Unlock()
@@ -719,11 +710,8 @@ func (kd *KeibidropServiceImpl) cancelAllPendingRemoves() {
 	kd.pendingRemoves = nil
 }
 
-// executeRemove performs the actual REMOVE_FILE logic (previously inline in
-// Notify). armedAt is when the remove was buffered: a cache file whose mtime
-// is newer was written locally inside the window and must not be deleted.
-// baseMtimeNs is the delete's declared base: a dirty local file above it
-// raced an edit the deleter never saw and is preserved as a sibling first.
+// executeRemove runs the buffered REMOVE_FILE. armedAt: a cache file written
+// after it survives. baseMtimeNs: a dirty file above it is preserved first.
 func (kd *KeibidropServiceImpl) executeRemove(path string, baseMtimeNs int64, logger *slog.Logger, armedAt time.Time) {
 	// Snapshot FS/root once: teardown may SetFS(nil) while this timer
 	// goroutine runs, and repeated loads would race it (nil-receiver panic).
@@ -737,12 +725,8 @@ func (kd *KeibidropServiceImpl) executeRemove(path string, baseMtimeNs int64, lo
 			logger.Info("Skipping buffered remove, local write is newer", "path", path)
 			return
 		}
-		// A delete whose base is below local authority raced an edit the
-		// deleter never saw (same predicate as the swap path). Preserve the
-		// local version as a sibling first; its announce recreates it on the
-		// deleter, so the file sets converge with the edit surviving. Base 0
-		// is an old sender: plain delete, exactly the previous behavior.
-		// The FUSE maps key by leading slash; API-origin paths carry none.
+		// A delete below local authority raced an unseen edit: preserve as
+		// a sibling first. Base 0 keeps the plain delete. Maps key by "/".
 		fusePath := path
 		if !strings.HasPrefix(fusePath, "/") {
 			fusePath = "/" + fusePath

--- a/pkg/logic/service/service.go
+++ b/pkg/logic/service/service.go
@@ -149,7 +149,9 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 			strings.Contains(req.Path, ".fuse_hidden") &&
 			req.OldPath != "" && !strings.Contains(req.OldPath, ".fuse_hidden") {
 			logger.Info("Rename to FUSE hidden name, buffering remove of source", "path", req.OldPath)
-			kd.bufferRemove(req.OldPath, logger)
+			// Base 0 on purpose: the rename's base describes the hidden
+			// TARGET, not the source leaving the folder. Plain delete.
+			kd.bufferRemove(req.OldPath, 0, logger)
 		}
 		return &bindings.NotifyResponse{}, nil
 	}
@@ -342,7 +344,7 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 		// window, the REMOVE is cancelled — it was part of an atomic write,
 		// not a real user deletion.
 		logger.Info("Buffering remove (1000ms)", "path", req.Path)
-		kd.bufferRemove(req.Path, logger)
+		kd.bufferRemove(req.Path, req.BaseMtimeNs, logger)
 	case bindings.NotifyType_RENAME_FILE:
 		// Cancel pending removes for both old and new path.
 		// Git renames .lock→final: the final path may have a pending REMOVE.
@@ -352,9 +354,32 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 		// Peer renamed/moved a file. OldPath -> Path.
 		logger.Info("Rename file", "oldPath", req.OldPath, "newPath", req.Path)
 
+		isDirRename := false
 		if kd.FS() != nil && kd.FS().Root() != nil {
 			oldDiskPath := filepath.Clean(filepath.Join(kd.FS().Root().RealPathOfFile, req.OldPath))
 			newDiskPath := filepath.Clean(filepath.Join(kd.FS().Root().RealPathOfFile, req.Path))
+
+			// Crossing directory moves (mv A B/ against mv B A/): both peers
+			// moved concurrently, and applying the peer's move on top would
+			// nest the trees into each other via the MkdirAll below. The
+			// fingerprint rank picks ONE move on both machines: the loser
+			// undoes its own and applies the winner's; the winner skips the
+			// peer's. One converged tree, no resurrection.
+			if crossed, ourNew, ourOld := kd.FS().Root().CrossingDirMove(req.OldPath, req.Path); crossed {
+				if kd.FS().Root().TieBreakPeerWins.Load() {
+					if undoErr := kd.FS().Root().UndoLocalDirMove(ourNew, ourOld); undoErr != nil {
+						logger.Error("Crossing-move undo failed, applying the peer move on top",
+							"ourMove", ourOld+" -> "+ourNew, "error", undoErr)
+					} else {
+						logger.Info("Crossing directory moves: peer outranks, local move undone",
+							"ourMove", ourOld+" -> "+ourNew)
+					}
+				} else {
+					logger.Info("Crossing directory moves: local move outranks, peer move skipped",
+						"peerMove", req.OldPath+" -> "+req.Path)
+					return &bindings.NotifyResponse{}, nil
+				}
+			}
 
 			// A swap whose declared base is older than LOCAL authority must not
 			// clobber the disk before the acceptance verdict (which preserves
@@ -436,10 +461,28 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 			}
 			kd.FS().Root().AfmLock.Unlock()
 
+			// A directory travels as RENAME_FILE too: re-key the dir's own
+			// entry and every child, or the old paths keep serving as
+			// ghosts, and keep it away from the file-shaped acceptance
+			// branches below.
+			if st, statErr := os.Stat(newDiskPath); statErr == nil && st.IsDir() {
+				isDirRename = true
+				root := kd.FS().Root()
+				root.Adm.Lock()
+				if sub, dok := root.AllDirMap[req.OldPath]; dok {
+					delete(root.AllDirMap, req.OldPath)
+					sub.RelativePath = req.Path
+					sub.LocalDownloadFolder = newDiskPath
+					root.AllDirMap[req.Path] = sub
+				}
+				root.Adm.Unlock()
+				root.RekeyChildren(req.OldPath, req.Path)
+			}
+
 			// Collision or conflict: the target object is canonical; run the
 			// announced state through the acceptance path (watermark, conflict
 			// preserve, bitmap reset/reconcile, prefetch).
-			if (collision || conflictSkip) && req.Attr != nil {
+			if !isDirRename && (collision || conflictSkip) && req.Attr != nil {
 				if err := kd.FS().Root().AddRemoteFileWithBase(logger, req.Path, filepath.Base(req.Path), statFromAttr(req.Attr), req.BaseMtimeNs); err != nil {
 					logger.Error("Rename acceptance failed; the peer must retry",
 						"path", req.Path, "error", err)
@@ -452,7 +495,7 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 			// in progress on the old path and got cancelled above),
 			// (b) file exists but has wrong size (git index-pack appends
 			// 20-byte SHA-1 checksum between the initial write and rename).
-			if exists && !collision && !conflictSkip && req.Attr != nil && req.Attr.Size > 0 {
+			if exists && !isDirRename && !collision && !conflictSkip && req.Attr != nil && req.Attr.Size > 0 {
 				needsRedownload := false
 				localInfo, statErr := os.Stat(newDiskPath)
 				if statErr != nil {
@@ -479,7 +522,7 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 			// RENAME arrives immediately. If the target already exists in
 			// RemoteFiles (e.g., .git/HEAD), trigger re-download now so the
 			// peer doesn't read stale content during the debounce window.
-			if !exists && !collision && !conflictSkip && req.Attr != nil && req.Attr.Size > 0 {
+			if !exists && !isDirRename && !collision && !conflictSkip && req.Attr != nil && req.Attr.Size > 0 {
 				// The rename's SOURCE was a transient temp the peer never received
 				// (git writes tmp_pack_XXX / *.lock then renames to the FINAL name),
 				// so neither map had it and the disk rename above failed with
@@ -504,7 +547,8 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 		// Handle non-FUSE mode.
 		if kd.SyncTracker != nil {
 			kd.SyncTracker.RemoteFilesMu.Lock()
-			if f, ok := kd.SyncTracker.RemoteFiles[req.OldPath]; ok {
+			f, exactHit := kd.SyncTracker.RemoteFiles[req.OldPath]
+			if exactHit {
 				delete(kd.SyncTracker.RemoteFiles, req.OldPath)
 				f.RelativePath = req.Path
 				f.Name = filepath.Base(req.Path)
@@ -513,7 +557,7 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 				}
 				kd.SyncTracker.RemoteFiles[req.Path] = f
 				logger.Info("Renamed file in sync tracker", "oldPath", req.OldPath, "newPath", req.Path, "size", f.Size)
-			} else if req.Attr != nil && req.Attr.Size > 0 {
+			} else if !isDirRename && req.Attr != nil && req.Attr.Size > 0 {
 				// Old path wasn't tracked (temp file notification was debounced away).
 				// Create entry with the correct size from the RENAME attr.
 				kd.SyncTracker.RemoteFiles[req.Path] = &synctracker.File{
@@ -523,6 +567,34 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 					LastEditTime: req.Attr.ModificationTime,
 				}
 				logger.Info("Created file from RENAME (old path not tracked)", "path", req.Path, "size", req.Attr.Size)
+			}
+			// Children of a renamed directory, both key shapes (FUSE-origin
+			// keys carry a leading slash, API-origin none). File renames take
+			// the exact-hit path above and never pay the walk.
+			if isDirRename || !exactHit {
+				rekeyPrefix := func(oldP, newP string) {
+					oldPre := oldP + "/"
+					var stale []string
+					for k := range kd.SyncTracker.RemoteFiles {
+						if strings.HasPrefix(k, oldPre) {
+							stale = append(stale, k)
+						}
+					}
+					for _, k := range stale {
+						cf := kd.SyncTracker.RemoteFiles[k]
+						delete(kd.SyncTracker.RemoteFiles, k)
+						nk := newP + k[len(oldP):]
+						cf.RelativePath = nk
+						cf.Name = filepath.Base(nk)
+						kd.SyncTracker.RemoteFiles[nk] = cf
+					}
+				}
+				rekeyPrefix(req.OldPath, req.Path)
+				if strings.HasPrefix(req.OldPath, "/") {
+					rekeyPrefix(strings.TrimPrefix(req.OldPath, "/"), strings.TrimPrefix(req.Path, "/"))
+				} else {
+					rekeyPrefix("/"+req.OldPath, "/"+req.Path)
+				}
 			}
 			kd.SyncTracker.RemoteFilesMu.Unlock()
 		}
@@ -581,8 +653,9 @@ func (kd *KeibidropServiceImpl) BatchNotify(ctx context.Context, req *bindings.B
 func (kd *KeibidropServiceImpl) ReadOnlyRefusals() uint64 { return kd.readOnlyRefusals.Load() }
 
 // bufferRemove delays a REMOVE_FILE by 1000ms. If cancelPendingRemove is called
-// for the same path before the timer fires, the remove is discarded.
-func (kd *KeibidropServiceImpl) bufferRemove(path string, logger *slog.Logger) {
+// for the same path before the timer fires, the remove is discarded. The
+// delete's declared base rides along for the edit-race check at execution.
+func (kd *KeibidropServiceImpl) bufferRemove(path string, baseMtimeNs int64, logger *slog.Logger) {
 	kd.pendingRemovesMu.Lock()
 	defer kd.pendingRemovesMu.Unlock()
 
@@ -601,7 +674,7 @@ func (kd *KeibidropServiceImpl) bufferRemove(path string, logger *slog.Logger) {
 		kd.pendingRemovesMu.Unlock()
 
 		logger.Info("Executing buffered remove (no ADD/RENAME arrived)", "path", path)
-		kd.executeRemove(path, logger)
+		kd.executeRemove(path, baseMtimeNs, logger)
 	})
 }
 
@@ -635,8 +708,25 @@ func (kd *KeibidropServiceImpl) cancelAllPendingRemoves() {
 }
 
 // executeRemove performs the actual REMOVE_FILE logic (previously inline in Notify).
-func (kd *KeibidropServiceImpl) executeRemove(path string, logger *slog.Logger) {
+func (kd *KeibidropServiceImpl) executeRemove(path string, baseMtimeNs int64, logger *slog.Logger) {
 	if kd.FS() != nil && kd.FS().Root() != nil {
+		// A delete whose base is below local authority raced an edit the
+		// deleter never saw (same predicate as the swap path). Preserve the
+		// local version as a sibling first; its announce recreates it on the
+		// deleter, so the file sets converge with the edit surviving. Base 0
+		// is an old sender: plain delete, exactly the previous behavior.
+		// The FUSE maps key by leading slash; API-origin paths carry none.
+		fusePath := path
+		if !strings.HasPrefix(fusePath, "/") {
+			fusePath = "/" + fusePath
+		}
+		if baseMtimeNs != 0 && kd.FS().Root().SwapWouldConflict(fusePath, baseMtimeNs) {
+			if _, pErr := kd.FS().Root().PreserveConflictSiblingForDelete(logger, fusePath); pErr != nil {
+				logger.Error("Delete raced a local edit and preservation failed, refusing the delete",
+					"path", path, "error", pErr)
+				return
+			}
+		}
 		hasOpenHandles := false
 		kd.FS().Root().AfmLock.Lock()
 		file, exists := kd.FS().Root().AllFileMap[path]

--- a/pkg/logic/service/service.go
+++ b/pkg/logic/service/service.go
@@ -149,7 +149,9 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 			strings.Contains(req.Path, ".fuse_hidden") &&
 			req.OldPath != "" && !strings.Contains(req.OldPath, ".fuse_hidden") {
 			logger.Info("Rename to FUSE hidden name, buffering remove of source", "path", req.OldPath)
-			kd.bufferRemove(req.OldPath, logger)
+			// Base 0 on purpose: the rename's base describes the hidden
+			// TARGET, not the source leaving the folder. Plain delete.
+			kd.bufferRemove(req.OldPath, 0, logger)
 		}
 		return &bindings.NotifyResponse{}, nil
 	}
@@ -342,7 +344,7 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 		// window, the REMOVE is cancelled — it was part of an atomic write,
 		// not a real user deletion.
 		logger.Info("Buffering remove (1000ms)", "path", req.Path)
-		kd.bufferRemove(req.Path, logger)
+		kd.bufferRemove(req.Path, req.BaseMtimeNs, logger)
 	case bindings.NotifyType_RENAME_FILE:
 		// Cancel pending removes for both old and new path.
 		// Git renames .lock→final: the final path may have a pending REMOVE.
@@ -352,9 +354,32 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 		// Peer renamed/moved a file. OldPath -> Path.
 		logger.Info("Rename file", "oldPath", req.OldPath, "newPath", req.Path)
 
+		isDirRename := false
 		if kd.FS() != nil && kd.FS().Root() != nil {
 			oldDiskPath := filepath.Clean(filepath.Join(kd.FS().Root().RealPathOfFile, req.OldPath))
 			newDiskPath := filepath.Clean(filepath.Join(kd.FS().Root().RealPathOfFile, req.Path))
+
+			// Crossing directory moves (mv A B/ against mv B A/): both peers
+			// moved concurrently, and applying the peer's move on top would
+			// nest the trees into each other via the MkdirAll below. The
+			// fingerprint rank picks ONE move on both machines: the loser
+			// undoes its own and applies the winner's; the winner skips the
+			// peer's. One converged tree, no resurrection.
+			if crossed, ourNew, ourOld := kd.FS().Root().CrossingDirMove(req.OldPath, req.Path); crossed {
+				if kd.FS().Root().TieBreakPeerWins.Load() {
+					if undoErr := kd.FS().Root().UndoLocalDirMove(ourNew, ourOld); undoErr != nil {
+						logger.Error("Crossing-move undo failed, applying the peer move on top",
+							"ourMove", ourOld+" -> "+ourNew, "error", undoErr)
+					} else {
+						logger.Info("Crossing directory moves: peer outranks, local move undone",
+							"ourMove", ourOld+" -> "+ourNew)
+					}
+				} else {
+					logger.Info("Crossing directory moves: local move outranks, peer move skipped",
+						"peerMove", req.OldPath+" -> "+req.Path)
+					return &bindings.NotifyResponse{}, nil
+				}
+			}
 
 			// A swap whose declared base is older than LOCAL authority must not
 			// clobber the disk before the acceptance verdict (which preserves
@@ -436,10 +461,28 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 			}
 			kd.FS().Root().AfmLock.Unlock()
 
+			// A directory travels as RENAME_FILE too: re-key the dir's own
+			// entry and every child, or the old paths keep serving as
+			// ghosts, and keep it away from the file-shaped acceptance
+			// branches below.
+			if st, statErr := os.Stat(newDiskPath); statErr == nil && st.IsDir() {
+				isDirRename = true
+				root := kd.FS().Root()
+				root.Adm.Lock()
+				if sub, dok := root.AllDirMap[req.OldPath]; dok {
+					delete(root.AllDirMap, req.OldPath)
+					sub.RelativePath = req.Path
+					sub.LocalDownloadFolder = newDiskPath
+					root.AllDirMap[req.Path] = sub
+				}
+				root.Adm.Unlock()
+				root.RekeyChildren(req.OldPath, req.Path)
+			}
+
 			// Collision or conflict: the target object is canonical; run the
 			// announced state through the acceptance path (watermark, conflict
 			// preserve, bitmap reset/reconcile, prefetch).
-			if (collision || conflictSkip) && req.Attr != nil {
+			if !isDirRename && (collision || conflictSkip) && req.Attr != nil {
 				if err := kd.FS().Root().AddRemoteFileWithBase(logger, req.Path, filepath.Base(req.Path), statFromAttr(req.Attr), req.BaseMtimeNs); err != nil {
 					logger.Error("Rename acceptance failed; the peer must retry",
 						"path", req.Path, "error", err)
@@ -452,7 +495,7 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 			// in progress on the old path and got cancelled above),
 			// (b) file exists but has wrong size (git index-pack appends
 			// 20-byte SHA-1 checksum between the initial write and rename).
-			if exists && !collision && !conflictSkip && req.Attr != nil && req.Attr.Size > 0 {
+			if exists && !isDirRename && !collision && !conflictSkip && req.Attr != nil && req.Attr.Size > 0 {
 				needsRedownload := false
 				localInfo, statErr := os.Stat(newDiskPath)
 				if statErr != nil {
@@ -479,7 +522,7 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 			// RENAME arrives immediately. If the target already exists in
 			// RemoteFiles (e.g., .git/HEAD), trigger re-download now so the
 			// peer doesn't read stale content during the debounce window.
-			if !exists && !collision && !conflictSkip && req.Attr != nil && req.Attr.Size > 0 {
+			if !exists && !isDirRename && !collision && !conflictSkip && req.Attr != nil && req.Attr.Size > 0 {
 				// The rename's SOURCE was a transient temp the peer never received
 				// (git writes tmp_pack_XXX / *.lock then renames to the FINAL name),
 				// so neither map had it and the disk rename above failed with
@@ -504,7 +547,8 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 		// Handle non-FUSE mode.
 		if kd.SyncTracker != nil {
 			kd.SyncTracker.RemoteFilesMu.Lock()
-			if f, ok := kd.SyncTracker.RemoteFiles[req.OldPath]; ok {
+			f, exactHit := kd.SyncTracker.RemoteFiles[req.OldPath]
+			if exactHit {
 				delete(kd.SyncTracker.RemoteFiles, req.OldPath)
 				f.RelativePath = req.Path
 				f.Name = filepath.Base(req.Path)
@@ -513,7 +557,7 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 				}
 				kd.SyncTracker.RemoteFiles[req.Path] = f
 				logger.Info("Renamed file in sync tracker", "oldPath", req.OldPath, "newPath", req.Path, "size", f.Size)
-			} else if req.Attr != nil && req.Attr.Size > 0 {
+			} else if !isDirRename && req.Attr != nil && req.Attr.Size > 0 {
 				// Old path wasn't tracked (temp file notification was debounced away).
 				// Create entry with the correct size from the RENAME attr.
 				kd.SyncTracker.RemoteFiles[req.Path] = &synctracker.File{
@@ -523,6 +567,34 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 					LastEditTime: req.Attr.ModificationTime,
 				}
 				logger.Info("Created file from RENAME (old path not tracked)", "path", req.Path, "size", req.Attr.Size)
+			}
+			// Children of a renamed directory, both key shapes (FUSE-origin
+			// keys carry a leading slash, API-origin none). File renames take
+			// the exact-hit path above and never pay the walk.
+			if isDirRename || !exactHit {
+				rekeyPrefix := func(oldP, newP string) {
+					oldPre := oldP + "/"
+					var stale []string
+					for k := range kd.SyncTracker.RemoteFiles {
+						if strings.HasPrefix(k, oldPre) {
+							stale = append(stale, k)
+						}
+					}
+					for _, k := range stale {
+						cf := kd.SyncTracker.RemoteFiles[k]
+						delete(kd.SyncTracker.RemoteFiles, k)
+						nk := newP + k[len(oldP):]
+						cf.RelativePath = nk
+						cf.Name = filepath.Base(nk)
+						kd.SyncTracker.RemoteFiles[nk] = cf
+					}
+				}
+				rekeyPrefix(req.OldPath, req.Path)
+				if strings.HasPrefix(req.OldPath, "/") {
+					rekeyPrefix(strings.TrimPrefix(req.OldPath, "/"), strings.TrimPrefix(req.Path, "/"))
+				} else {
+					rekeyPrefix("/"+req.OldPath, "/"+req.Path)
+				}
 			}
 			kd.SyncTracker.RemoteFilesMu.Unlock()
 		}
@@ -587,9 +659,11 @@ type pendingRemove struct {
 	armedAt time.Time
 }
 
-// bufferRemove delays a REMOVE_FILE by 1000ms. If CancelPendingRemove is called
-// for the same path before the timer fires, the remove is discarded.
-func (kd *KeibidropServiceImpl) bufferRemove(path string, logger *slog.Logger) {
+// bufferRemove delays a REMOVE_FILE by 1000ms. If CancelPendingRemove is
+// called for the same path before the timer fires, the remove is discarded.
+// The delete's declared base rides along for the edit-race check at
+// execution.
+func (kd *KeibidropServiceImpl) bufferRemove(path string, baseMtimeNs int64, logger *slog.Logger) {
 	kd.pendingRemovesMu.Lock()
 	defer kd.pendingRemovesMu.Unlock()
 
@@ -610,7 +684,7 @@ func (kd *KeibidropServiceImpl) bufferRemove(path string, logger *slog.Logger) {
 		kd.pendingRemovesMu.Unlock()
 
 		logger.Info("Executing buffered remove (no ADD/RENAME arrived)", "path", path)
-		kd.executeRemove(path, logger, armedAt)
+		kd.executeRemove(path, baseMtimeNs, logger, armedAt)
 	})
 	kd.pendingRemoves[path] = pr
 }
@@ -648,7 +722,9 @@ func (kd *KeibidropServiceImpl) cancelAllPendingRemoves() {
 // executeRemove performs the actual REMOVE_FILE logic (previously inline in
 // Notify). armedAt is when the remove was buffered: a cache file whose mtime
 // is newer was written locally inside the window and must not be deleted.
-func (kd *KeibidropServiceImpl) executeRemove(path string, logger *slog.Logger, armedAt time.Time) {
+// baseMtimeNs is the delete's declared base: a dirty local file above it
+// raced an edit the deleter never saw and is preserved as a sibling first.
+func (kd *KeibidropServiceImpl) executeRemove(path string, baseMtimeNs int64, logger *slog.Logger, armedAt time.Time) {
 	// Snapshot FS/root once: teardown may SetFS(nil) while this timer
 	// goroutine runs, and repeated loads would race it (nil-receiver panic).
 	var root *filesystem.Dir
@@ -660,6 +736,23 @@ func (kd *KeibidropServiceImpl) executeRemove(path string, logger *slog.Logger, 
 		if st, err := os.Stat(cachePath); err == nil && !armedAt.IsZero() && st.ModTime().After(armedAt) {
 			logger.Info("Skipping buffered remove, local write is newer", "path", path)
 			return
+		}
+		// A delete whose base is below local authority raced an edit the
+		// deleter never saw (same predicate as the swap path). Preserve the
+		// local version as a sibling first; its announce recreates it on the
+		// deleter, so the file sets converge with the edit surviving. Base 0
+		// is an old sender: plain delete, exactly the previous behavior.
+		// The FUSE maps key by leading slash; API-origin paths carry none.
+		fusePath := path
+		if !strings.HasPrefix(fusePath, "/") {
+			fusePath = "/" + fusePath
+		}
+		if baseMtimeNs != 0 && root.SwapWouldConflict(fusePath, baseMtimeNs) {
+			if _, pErr := root.PreserveConflictSiblingForDelete(logger, fusePath); pErr != nil {
+				logger.Error("Delete raced a local edit and preservation failed, refusing the delete",
+					"path", path, "error", pErr)
+				return
+			}
 		}
 		hasOpenHandles := false
 		root.AfmLock.Lock()

--- a/pkg/logic/service/service_android.go
+++ b/pkg/logic/service/service_android.go
@@ -123,7 +123,7 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 		logger.Info("Directory notification ignored in SyncTracker mode", "type", req.Type)
 
 	case bindings.NotifyType_ADD_FILE:
-		kd.cancelPendingRemove(req.Path)
+		kd.CancelPendingRemove(req.Path)
 		if req.Attr == nil {
 			logger.Error("Failed to add file, invalid attr", "error", ErrGRPCInvalidArgument)
 			return nil, ErrGRPCInvalidArgument
@@ -168,7 +168,7 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 		logger.Info("Success")
 
 	case bindings.NotifyType_EDIT_FILE:
-		kd.cancelPendingRemove(req.Path)
+		kd.CancelPendingRemove(req.Path)
 		if req.Attr == nil {
 			logger.Error("Failed to edit file, invalid attr", "error", ErrGRPCInvalidArgument)
 			return nil, ErrGRPCFailedPrecondition
@@ -217,8 +217,8 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 		kd.bufferRemove(req.Path, logger)
 
 	case bindings.NotifyType_RENAME_FILE:
-		kd.cancelPendingRemove(req.Path)
-		kd.cancelPendingRemove(req.OldPath)
+		kd.CancelPendingRemove(req.Path)
+		kd.CancelPendingRemove(req.OldPath)
 		logger.Info("Rename file", "oldPath", req.OldPath, "newPath", req.Path)
 		kd.SyncTracker.RemoteFilesMu.Lock()
 		if f, ok := kd.SyncTracker.RemoteFiles[req.OldPath]; ok {
@@ -246,7 +246,7 @@ func (kd *KeibidropServiceImpl) Notify(_ context.Context, req *bindings.NotifyRe
 	return &bindings.NotifyResponse{}, nil
 }
 
-// bufferRemove delays a REMOVE_FILE by 1000ms; cancelPendingRemove for the same
+// bufferRemove delays a REMOVE_FILE by 1000ms; CancelPendingRemove for the same
 // path before it fires discards it.
 func (kd *KeibidropServiceImpl) bufferRemove(path string, logger *slog.Logger) {
 	kd.pendingRemovesMu.Lock()
@@ -268,9 +268,9 @@ func (kd *KeibidropServiceImpl) bufferRemove(path string, logger *slog.Logger) {
 	})
 }
 
-// cancelPendingRemove discards a buffered REMOVE when an ADD/EDIT/RENAME for the
+// CancelPendingRemove discards a buffered REMOVE when an ADD/EDIT/RENAME for the
 // same path arrives (the remove was part of git's atomic .lock->rename dance).
-func (kd *KeibidropServiceImpl) cancelPendingRemove(path string) {
+func (kd *KeibidropServiceImpl) CancelPendingRemove(path string) {
 	kd.pendingRemovesMu.Lock()
 	defer kd.pendingRemovesMu.Unlock()
 	if t, ok := kd.pendingRemoves[path]; ok {

--- a/tests/bench_hotpath_test.go
+++ b/tests/bench_hotpath_test.go
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// ABOUTME: KD_PERF-gated hot-path latency storms: the swap-save rename (the
+// ABOUTME: app-save pattern), cold random-offset reads, and cold-path writes.
+
+package tests
+
+import (
+	"crypto/rand"
+	"fmt"
+	mrand "math/rand"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/KeibiSoft/KeibiDrop/pkg/logic/common"
+	"github.com/stretchr/testify/require"
+)
+
+func skipUnlessPerf(t *testing.T) {
+	t.Helper()
+	if os.Getenv("KD_PERF") == "" {
+		t.Skip("latency storm; set KD_PERF=1 to run")
+	}
+	skipIfNoFUSE(t)
+}
+
+func pct(ds []time.Duration, p float64) time.Duration {
+	if len(ds) == 0 {
+		return 0
+	}
+	s := append([]time.Duration(nil), ds...)
+	sort.Slice(s, func(i, j int) bool { return s[i] < s[j] })
+	idx := int(p * float64(len(s)-1))
+	return s[idx]
+}
+
+func logDist(t *testing.T, name string, ds []time.Duration) {
+	t.Helper()
+	t.Logf("%s: n=%d p50=%v p95=%v p99=%v max=%v", name, len(ds),
+		pct(ds, 0.50).Round(time.Microsecond), pct(ds, 0.95).Round(time.Microsecond),
+		pct(ds, 0.99).Round(time.Microsecond), pct(ds, 1.0).Round(time.Microsecond))
+}
+
+// TestPerfHotpath_SwapSaveStorm measures the atomic app-save through the
+// mount: write a working copy, rename it over the target, 100 times. The
+// rename-only distribution is the gate: no conflict fix touches the Rename
+// path, so it must stay at baseline.
+func TestPerfHotpath_SwapSaveStorm(t *testing.T) {
+	skipUnlessPerf(t)
+	require := require.New(t)
+
+	tp := SetupFUSEPeerPair(t, 180*time.Second)
+	waitForFUSEMount(t, tp.AliceMountDir, 15*time.Second)
+
+	payload := make([]byte, 256*1024)
+	_, err := rand.Read(payload)
+	require.NoError(err)
+
+	doc := filepath.Join(tp.AliceMountDir, "storm.bin")
+	require.NoError(os.WriteFile(doc, payload, 0o644))
+
+	const iters = 100
+	renameDur := make([]time.Duration, 0, iters)
+	saveDur := make([]time.Duration, 0, iters)
+	for i := 0; i < iters; i++ {
+		payload[0] = byte(i) // distinct content per save
+		tmp := doc + ".tmp"
+		t0 := time.Now()
+		require.NoError(os.WriteFile(tmp, payload, 0o644))
+		t1 := time.Now()
+		require.NoError(os.Rename(tmp, doc))
+		t2 := time.Now()
+		renameDur = append(renameDur, t2.Sub(t1))
+		saveDur = append(saveDur, t2.Sub(t0))
+	}
+	logDist(t, "swap-save rename-only", renameDur)
+	logDist(t, "swap-save full (write+rename)", saveDur)
+}
+
+// TestPerfHotpath_ColdRandomAccess measures random jumps into cold regions
+// of a large remote file (prefetch off, pure on-demand) and writes landing
+// on cold paths. First-byte latency per jump.
+func TestPerfHotpath_ColdRandomAccess(t *testing.T) {
+	skipUnlessPerf(t)
+	require := require.New(t)
+
+	t.Setenv("KEIBIDROP_PREFETCH_ON_OPEN", "0")
+
+	sizeMB := 64
+	if v := os.Getenv("KD_PERF_SIZE_MB"); v != "" {
+		fmt.Sscanf(v, "%d", &sizeMB) //nolint:errcheck // best-effort override
+	}
+
+	tp := SetupFUSEPeerPairPreConnect(t, 300*time.Second,
+		func(alice, bob *common.KeibiDrop, aliceSave, bobSave string) {
+			big := make([]byte, sizeMB*1024*1024)
+			_, err := rand.Read(big)
+			require.NoError(err)
+			require.NoError(os.WriteFile(filepath.Join(bobSave, "cold.bin"), big, 0o644))
+			bob.ScanSharedOnStart = true
+		})
+	waitForFUSEMount(t, tp.AliceMountDir, 15*time.Second)
+
+	coldPath := filepath.Join(tp.AliceMountDir, "cold.bin")
+	WaitForFileOnMount(t, coldPath, 60*time.Second)
+
+	fh, err := os.Open(coldPath) // #nosec G304
+	require.NoError(err)
+	defer fh.Close()
+	info, err := fh.Stat()
+	require.NoError(err)
+	size := info.Size()
+
+	rng := mrand.New(mrand.NewSource(42)) // #nosec G404 -- deterministic bench
+	const jumps = 32
+	buf := make([]byte, 4096)
+	readDur := make([]time.Duration, 0, jumps)
+	for i := 0; i < jumps; i++ {
+		off := rng.Int63n(size - int64(len(buf)))
+		t0 := time.Now()
+		_, err := fh.ReadAt(buf, off)
+		require.NoError(err)
+		readDur = append(readDur, time.Since(t0))
+	}
+	logDist(t, fmt.Sprintf("cold random 4K reads over %d MiB", sizeMB), readDur)
+
+	// Cold-path writes: 4K writes at random offsets into the still-cold
+	// file through the mount (writes landing in unfetched regions).
+	wfh, err := os.OpenFile(coldPath, os.O_WRONLY, 0o644) // #nosec G304
+	require.NoError(err)
+	defer wfh.Close()
+	writeDur := make([]time.Duration, 0, jumps)
+	for i := 0; i < jumps; i++ {
+		off := rng.Int63n(size - int64(len(buf)))
+		t0 := time.Now()
+		_, err := wfh.WriteAt(buf, off)
+		require.NoError(err)
+		writeDur = append(writeDur, time.Since(t0))
+	}
+	logDist(t, "cold-path random 4K writes", writeDur)
+}

--- a/tests/bench_hotpath_test.go
+++ b/tests/bench_hotpath_test.go
@@ -48,10 +48,8 @@ func logDist(t *testing.T, name string, ds []time.Duration) {
 		pct(ds, 0.99).Round(time.Microsecond), pct(ds, 1.0).Round(time.Microsecond))
 }
 
-// TestPerfHotpath_SwapSaveStorm measures the atomic app-save through the
-// mount: write a working copy, rename it over the target, 100 times. The
-// rename-only distribution is the gate: no conflict fix touches the Rename
-// path, so it must stay at baseline.
+// TestPerfHotpath_SwapSaveStorm: the app save (write copy, rename over)
+// through the mount. The rename-only distribution is the gate.
 func TestPerfHotpath_SwapSaveStorm(t *testing.T) {
 	skipUnlessPerf(t)
 	require := require.New(t)
@@ -84,9 +82,8 @@ func TestPerfHotpath_SwapSaveStorm(t *testing.T) {
 	logDist(t, "swap-save full (write+rename)", saveDur)
 }
 
-// TestPerfHotpath_ColdRandomAccess measures random jumps into cold regions
-// of a large remote file (prefetch off, pure on-demand) and writes landing
-// on cold paths. First-byte latency per jump.
+// TestPerfHotpath_ColdRandomAccess: random jumps into a cold remote file
+// and writes on cold paths. First-byte latency per jump.
 func TestPerfHotpath_ColdRandomAccess(t *testing.T) {
 	skipUnlessPerf(t)
 	require := require.New(t)
@@ -131,8 +128,7 @@ func TestPerfHotpath_ColdRandomAccess(t *testing.T) {
 	}
 	logDist(t, fmt.Sprintf("cold random 4K reads over %d MiB", sizeMB), readDur)
 
-	// Cold-path writes: 4K writes at random offsets into the still-cold
-	// file through the mount (writes landing in unfetched regions).
+	// Cold-path writes: 4K at random offsets into unfetched regions.
 	wfh, err := os.OpenFile(coldPath, os.O_WRONLY, 0o644) // #nosec G304
 	require.NoError(err)
 	defer wfh.Close()

--- a/tests/integration_bidirectional_edits_test.go
+++ b/tests/integration_bidirectional_edits_test.go
@@ -465,6 +465,62 @@ func TestFUSEtoFUSE_BidirectionalEditPatterns(t *testing.T) {
 		t.Logf("swap-save refetch: %d bytes for a 1 MiB change in a 24 MiB file (c1=%d c2=%d)", delta, c1, c2)
 		require.Less(delta, uint64(24*1048576), "reader refetched the full file: reconcile never fired")
 	})
+
+	// Both sides swap-save the SAME file concurrently: each takes a working
+	// copy of v1, edits it, and renames it over the target, the two renames
+	// crossing on the wire. This is the double-app-save case (both machines
+	// autosaving the same document). A rename base can only overstate the
+	// session base (fuse_directory targetIdentity), so this crossing is where
+	// a conflict copy could be suppressed. Measured 2026-08-26 on loopback:
+	// the crossing preserves both versions (canonical plus one sibling on
+	// both peers), so this stands as a hard regression guard.
+	t.Run("ConcurrentSwapSaveCrossing", func(t *testing.T) {
+		listConflicts := func(p *testPeer) []string {
+			var out []string
+			for _, name := range listNames(t, p) {
+				if strings.Contains(name, "swapx.conflict-") {
+					out = append(out, strings.TrimSpace(name))
+				}
+			}
+			return out
+		}
+		require.Equal("OK", bob.send(t, "write_file swapx.txt both-see-this-v1", 10*time.Second))
+		WaitForFileOnMount(t, filepath.Join(aliceMount, "swapx.txt"), 60*time.Second)
+		waitConverged(t, alice, bob, "swapx.txt", 60*time.Second)
+
+		// Both take working copies of v1 and edit them.
+		copyFile(t, bob, "swapx.txt", "swapx.txt.bwork")
+		copyFile(t, alice, "swapx.txt", "swapx.txt.awork")
+		require.Equal("OK", bob.send(t, "write_file swapx.txt.bwork owner-swap-version", 10*time.Second))
+		require.Equal("OK", alice.send(t, "write_file swapx.txt.awork reader-swap-version", 10*time.Second))
+
+		// The crossing swaps, as simultaneous as the protocol allows.
+		renameOver(t, bob, "swapx.txt.bwork", "swapx.txt")
+		renameOver(t, alice, "swapx.txt.awork", "swapx.txt")
+
+		waitConverged(t, alice, bob, "swapx.txt", 90*time.Second)
+
+		// Give the sibling announce time to land, then take stock.
+		time.Sleep(5 * time.Second)
+		canonical := readFile(t, bob, "swapx.txt")
+		aliceConflicts := listConflicts(alice)
+		bobConflicts := listConflicts(bob)
+		t.Logf("canonical=%q aliceConflicts=%v bobConflicts=%v", canonical, aliceConflicts, bobConflicts)
+
+		survived := []string{canonical}
+		for _, c := range bobConflicts {
+			survived = append(survived, readFile(t, bob, c))
+		}
+		both := map[string]bool{}
+		for _, s := range survived {
+			both[s] = true
+		}
+		lost := !both["owner-swap-version"] || !both["reader-swap-version"]
+		require.False(lost, "both crossing swap versions must survive (canonical + conflict), got %v", survived)
+		WaitForCondition(t, 60*time.Second, 500*time.Millisecond, func() bool {
+			return len(listConflicts(alice)) >= 1 && len(listConflicts(bob)) >= 1
+		}, "waiting for the crossing-swap conflict copy on both peers")
+	})
 }
 
 // Editor/tool tier, structured like the git and pijul tests: cold first-contact reads,

--- a/tests/integration_delete_conflict_test.go
+++ b/tests/integration_delete_conflict_test.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// ABOUTME: Delete-vs-edit outside the 1 s buffer: a peer delete whose base is
+// ABOUTME: below dirty local authority preserves the edit as a sibling.
+
+package tests
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	bindings "github.com/KeibiSoft/KeibiDrop/grpc_bindings"
+	"github.com/KeibiSoft/KeibiDrop/pkg/logic/common"
+	"github.com/stretchr/testify/require"
+)
+
+func listConflictFiles(t *testing.T, dir, stem string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	var out []string
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), stem+".conflict-") {
+			out = append(out, e.Name())
+		}
+	}
+	return out
+}
+
+// TestDeleteConflict_EditRacesDelete drives Alice's REMOVE_FILE handler the
+// way Bob's client does, with the three base classes. The dirty case is the
+// gap this closes: before the delete base, an edit made outside the 1 s
+// cancellation window vanished with no copy when the delete executed.
+func TestDeleteConflict_EditRacesDelete(t *testing.T) {
+	skipIfNoFUSE(t)
+	if testing.Short() {
+		t.Skip("FUSE pair test skipped in short mode")
+	}
+	require := require.New(t)
+
+	tp := SetupFUSEPeerPairPreConnect(t, 120*time.Second,
+		func(alice, bob *common.KeibiDrop, aliceSave, bobSave string) {
+			require.NoError(os.WriteFile(filepath.Join(bobSave, "doc.txt"), []byte("v1-from-bob"), 0o644))
+			require.NoError(os.WriteFile(filepath.Join(bobSave, "clean.txt"), []byte("clean-v1"), 0o644))
+			require.NoError(os.WriteFile(filepath.Join(bobSave, "legacy.txt"), []byte("legacy-v1"), 0o644))
+			bob.ScanSharedOnStart = true
+		})
+	waitForFUSEMount(t, tp.AliceMountDir, 15*time.Second)
+
+	for _, name := range []string{"doc.txt", "clean.txt", "legacy.txt"} {
+		WaitForFileOnMount(t, filepath.Join(tp.AliceMountDir, name), 30*time.Second)
+		_, err := os.ReadFile(filepath.Join(tp.AliceMountDir, name))
+		require.NoError(err)
+	}
+
+	// Capture the seed identity BEFORE the edit: this is what a deleter that
+	// never saw the edit declares as its base.
+	seedInfo, err := os.Stat(filepath.Join(tp.BobSaveDir, "doc.txt"))
+	require.NoError(err)
+	seedIdentity := seedInfo.ModTime().UnixNano()
+
+	// Alice edits through her mount: dirty local authority above the seed.
+	const edited = "alice-edit-must-survive"
+	require.NoError(os.WriteFile(filepath.Join(tp.AliceMountDir, "doc.txt"), []byte(edited), 0o644))
+	// Let the edit settle past the debounce so no ADD cancels the remove.
+	time.Sleep(1500 * time.Millisecond)
+
+	svc := tp.Alice.KDSvc
+	require.NotNil(svc)
+
+	// Case 1, the race: delete with the SEED base against dirty local state.
+	// The buffered remove fires after 1 s; the preserved sibling then appears
+	// and the canonical goes away.
+	_, err = svc.Notify(context.Background(), &bindings.NotifyRequest{
+		Type: bindings.NotifyType_REMOVE_FILE, Path: "/doc.txt", BaseMtimeNs: seedIdentity,
+	})
+	require.NoError(err)
+	var siblings []string
+	WaitForCondition(t, 20*time.Second, 250*time.Millisecond, func() bool {
+		siblings = listConflictFiles(t, tp.AliceSaveDir, "doc")
+		return len(siblings) == 1
+	}, "waiting for the delete-race conflict sibling")
+	got, err := os.ReadFile(filepath.Join(tp.AliceSaveDir, siblings[0]))
+	require.NoError(err)
+	require.Equal(edited, string(got), "the racing edit must survive as the sibling")
+	WaitForFileAbsent(t, filepath.Join(tp.AliceMountDir, "doc.txt"), 15*time.Second)
+
+	// Case 2, turn-taking: a delete of a CLEAN file with its current base is
+	// a plain delete, no sibling.
+	cleanInfo, err := os.Stat(filepath.Join(tp.BobSaveDir, "clean.txt"))
+	require.NoError(err)
+	_, err = svc.Notify(context.Background(), &bindings.NotifyRequest{
+		Type: bindings.NotifyType_REMOVE_FILE, Path: "/clean.txt", BaseMtimeNs: cleanInfo.ModTime().UnixNano(),
+	})
+	require.NoError(err)
+	WaitForFileAbsent(t, filepath.Join(tp.AliceMountDir, "clean.txt"), 15*time.Second)
+	require.Empty(listConflictFiles(t, tp.AliceSaveDir, "clean"), "turn-taking delete must not mint a sibling")
+
+	// Case 3, legacy sender: base 0 keeps the old contract, plain delete
+	// even against dirty local state.
+	require.NoError(os.WriteFile(filepath.Join(tp.AliceMountDir, "legacy.txt"), []byte("legacy-dirty"), 0o644))
+	time.Sleep(1500 * time.Millisecond)
+	_, err = svc.Notify(context.Background(), &bindings.NotifyRequest{
+		Type: bindings.NotifyType_REMOVE_FILE, Path: "/legacy.txt", BaseMtimeNs: 0,
+	})
+	require.NoError(err)
+	WaitForFileAbsent(t, filepath.Join(tp.AliceMountDir, "legacy.txt"), 15*time.Second)
+	require.Empty(listConflictFiles(t, tp.AliceSaveDir, "legacy"), "base 0 must keep the legacy plain-delete contract")
+}

--- a/tests/integration_delete_conflict_test.go
+++ b/tests/integration_delete_conflict_test.go
@@ -35,10 +35,8 @@ func listConflictFiles(t *testing.T, dir, stem string) []string {
 	return out
 }
 
-// TestDeleteConflict_EditRacesDelete drives Alice's REMOVE_FILE handler the
-// way Bob's client does, with the three base classes. The dirty case is the
-// gap this closes: before the delete base, an edit made outside the 1 s
-// cancellation window vanished with no copy when the delete executed.
+// TestDeleteConflict_EditRacesDelete drives the REMOVE_FILE handler with the
+// three base classes: racing edit preserved, turn-taking and legacy plain.
 func TestDeleteConflict_EditRacesDelete(t *testing.T) {
 	skipIfNoFUSE(t)
 	if testing.Short() {
@@ -61,8 +59,7 @@ func TestDeleteConflict_EditRacesDelete(t *testing.T) {
 		require.NoError(err)
 	}
 
-	// Capture the seed identity BEFORE the edit: this is what a deleter that
-	// never saw the edit declares as its base.
+	// The seed identity is what a deleter that never saw the edit declares.
 	seedInfo, err := os.Stat(filepath.Join(tp.BobSaveDir, "doc.txt"))
 	require.NoError(err)
 	seedIdentity := seedInfo.ModTime().UnixNano()
@@ -76,9 +73,7 @@ func TestDeleteConflict_EditRacesDelete(t *testing.T) {
 	svc := tp.Alice.KDSvc
 	require.NotNil(svc)
 
-	// Case 1, the race: delete with the SEED base against dirty local state.
-	// The buffered remove fires after 1 s; the preserved sibling then appears
-	// and the canonical goes away.
+	// Case 1, the race: seed base against dirty local state.
 	_, err = svc.Notify(context.Background(), &bindings.NotifyRequest{
 		Type: bindings.NotifyType_REMOVE_FILE, Path: "/doc.txt", BaseMtimeNs: seedIdentity,
 	})
@@ -93,8 +88,7 @@ func TestDeleteConflict_EditRacesDelete(t *testing.T) {
 	require.Equal(edited, string(got), "the racing edit must survive as the sibling")
 	WaitForFileAbsent(t, filepath.Join(tp.AliceMountDir, "doc.txt"), 15*time.Second)
 
-	// Case 2, turn-taking: a delete of a CLEAN file with its current base is
-	// a plain delete, no sibling.
+	// Case 2, turn-taking: clean file, current base, plain delete.
 	cleanInfo, err := os.Stat(filepath.Join(tp.BobSaveDir, "clean.txt"))
 	require.NoError(err)
 	_, err = svc.Notify(context.Background(), &bindings.NotifyRequest{
@@ -104,8 +98,7 @@ func TestDeleteConflict_EditRacesDelete(t *testing.T) {
 	WaitForFileAbsent(t, filepath.Join(tp.AliceMountDir, "clean.txt"), 15*time.Second)
 	require.Empty(listConflictFiles(t, tp.AliceSaveDir, "clean"), "turn-taking delete must not mint a sibling")
 
-	// Case 3, legacy sender: base 0 keeps the old contract, plain delete
-	// even against dirty local state.
+	// Case 3, legacy sender: base 0, plain delete even against dirty state.
 	require.NoError(os.WriteFile(filepath.Join(tp.AliceMountDir, "legacy.txt"), []byte("legacy-dirty"), 0o644))
 	time.Sleep(1500 * time.Millisecond)
 	_, err = svc.Notify(context.Background(), &bindings.NotifyRequest{

--- a/tests/integration_fuse_dirmove_test.go
+++ b/tests/integration_fuse_dirmove_test.go
@@ -1,0 +1,276 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// ABOUTME: Directory moves across two FUSE peers: the sequential control case,
+// ABOUTME: then the concurrent cross-move (mv A B/ vs mv B A/) cycle repro.
+
+package tests
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestFUSEtoFUSE_DirectoryMoves pins directory-rename behavior across peers.
+// Directory renames travel as RENAME_FILE on the wire; both sides re-key the
+// moved directory's children (or the old paths serve forever as ghosts and
+// phantoms). The sequential subtest is the control: a one-sided move keeps
+// children reachable and retires the old path. The concurrent subtest is the
+// classic tree-invariant violation (VMCAI 2018: move is the one operation
+// that unsynchronised breaks the tree): mv A B/ crossing mv B A/. The
+// fingerprint rank picks ONE move on both machines: the loser undoes its own
+// and applies the winner's, the winner skips the peer's, and both trees
+// converge with no MkdirAll resurrection. Content loss is asserted
+// unconditionally. Set KD_DM_LOGDIR to keep the peers' logs.
+func TestFUSEtoFUSE_DirectoryMoves(t *testing.T) {
+	skipIfNoFUSE(t)
+	if runtime.GOOS == "windows" {
+		t.Skip("unix shell forms; the Windows variant needs verb forms for mkdir/find")
+	}
+	if testing.Short() {
+		t.Skip("two-FUSE spawned test skipped in short mode")
+	}
+
+	binary := getTestPeerBinary(t)
+
+	relay := NewMockRelay()
+	defer relay.Close()
+
+	aliceMount := newMountPoint(t)
+	bobMount := newMountPoint(t)
+
+	logDir := os.Getenv("KD_DM_LOGDIR")
+	if logDir == "" {
+		logDir = t.TempDir()
+	}
+	peerEnv := func(in, out int, mount string) map[string]string {
+		return map[string]string{
+			"RELAY_URL":     relay.URL(),
+			"INBOUND_PORT":  fmt.Sprintf("%d", in),
+			"OUTBOUND_PORT": fmt.Sprintf("%d", out),
+			"MOUNT_DIR":     mount,
+			"SAVE_DIR":      t.TempDir(),
+			"USE_FUSE":      "1",
+			"LOG_FILE":      filepath.Join(logDir, filepath.Base(filepath.Dir(mount))+".log"),
+		}
+	}
+	alice := spawnPeer(t, binary, peerEnv(
+		getFreePortInRange(t, 26700, 26749), getFreePortInRange(t, 26750, 26799), aliceMount))
+	bob := spawnPeer(t, binary, peerEnv(
+		getFreePortInRange(t, 26800, 26849), getFreePortInRange(t, 26850, 26899), bobMount))
+
+	t.Cleanup(func() {
+		for _, p := range []*testPeer{alice, bob} {
+			fmt.Fprintln(p.stdin, "quit")
+			done := make(chan error, 1)
+			go func() { done <- p.cmd.Wait() }()
+			select {
+			case <-done:
+			case <-time.After(5 * time.Second):
+				_ = p.cmd.Process.Kill()
+				<-done
+			}
+		}
+		for _, dir := range []string{aliceMount, bobMount} {
+			forceUnmount(dir)
+			waitForUnmount(dir, 5*time.Second)
+		}
+	})
+
+	require := require.New(t)
+
+	aliceFP := strings.TrimPrefix(alice.send(t, "fingerprint", 5*time.Second), "FP:")
+	bobFP := strings.TrimPrefix(bob.send(t, "fingerprint", 5*time.Second), "FP:")
+	require.Equal("OK", alice.send(t, "register "+bobFP, 5*time.Second))
+	require.Equal("OK", bob.send(t, "register "+aliceFP, 5*time.Second))
+
+	aliceConn := alice.sendAsync(t, "create")
+	WaitForCondition(t, 10*time.Second, 100*time.Millisecond, func() bool {
+		return relay.EntryCount() > 0
+	}, "waiting for relay registration")
+	require.Equal("CONNECTED", bob.send(t, "join", 30*time.Second))
+	require.Equal("CONNECTED", <-aliceConn)
+
+	waitForFUSEMount(t, aliceMount, 15*time.Second)
+	waitForFUSEMount(t, bobMount, 15*time.Second)
+
+	ex := func(t *testing.T, p *testPeer, cmdline string, timeout time.Duration) string {
+		t.Helper()
+		resp := p.send(t, "exec . "+cmdline, timeout)
+		if !strings.HasPrefix(resp, "EXEC:0:") {
+			t.Fatalf("%q failed: %s", cmdline, resp)
+		}
+		return strings.TrimPrefix(resp, "EXEC:0:")
+	}
+	mustSend := func(t *testing.T, p *testPeer, verb string) {
+		t.Helper()
+		if resp := p.send(t, verb, 15*time.Second); resp != "OK" {
+			t.Fatalf("%q failed: %s", verb, resp)
+		}
+	}
+
+	// treeOf returns the sorted relative paths of every regular file under the
+	// mount, read through the peer's own exec so the peer's FUSE view is what
+	// is listed, not the host's cached view. A stale map entry can leave a
+	// PHANTOM directory (readdir lists it, stat fails), which makes find exit
+	// 1 while still printing everything it reached; that is itself part of
+	// the demonstration, so any exit code is accepted and phantoms are kept
+	// as entries.
+	treeOf := func(t *testing.T, p *testPeer) []string {
+		t.Helper()
+		resp := p.send(t, "exec . find . -type f", 20*time.Second)
+		if !strings.HasPrefix(resp, "EXEC:") {
+			t.Fatalf("find failed to run: %s", resp)
+		}
+		body := strings.TrimPrefix(resp, "EXEC:")
+		if i := strings.Index(body, ":"); i >= 0 {
+			if code := body[:i]; code != "0" {
+				t.Logf("find exit=%s (phantom entries present)", code)
+			}
+			body = body[i+1:]
+		}
+		var files []string
+		for _, line := range strings.Split(body, "\\n") {
+			line = strings.TrimSpace(line)
+			if strings.HasPrefix(line, "find:") {
+				// "find: ./B: No such file or directory": keep the phantom
+				// as a marker entry so tree comparison sees it.
+				if j := strings.Index(line, ": "); j >= 0 {
+					rest := line[j+2:]
+					if k := strings.Index(rest, ":"); k > 0 {
+						files = append(files, "PHANTOM:"+strings.TrimPrefix(rest[:k], "./"))
+					}
+				}
+				continue
+			}
+			line = strings.TrimPrefix(line, "./")
+			if line != "" && line != "." {
+				files = append(files, line)
+			}
+		}
+		sort.Strings(files)
+		return files
+	}
+
+	readAt := func(t *testing.T, p *testPeer, rel string) string {
+		t.Helper()
+		return strings.TrimSpace(ex(t, p, "cat "+rel, 15*time.Second))
+	}
+
+	// The control: a one-sided directory rename must keep children reachable
+	// on the peer. This is the baseline the concurrent case is judged against.
+	t.Run("SequentialDirRenameKeepsChildren", func(t *testing.T) {
+		ex(t, bob, "mkdir -p projA", 15*time.Second)
+		mustSend(t, bob, "write_file projA/f1.txt hello-from-projA")
+		WaitForFileOnMount(t, filepath.Join(aliceMount, "projA", "f1.txt"), 60*time.Second)
+		if got := readAt(t, alice, "projA/f1.txt"); got != "hello-from-projA" {
+			t.Fatalf("pre-move read through Alice's mount: got %q", got)
+		}
+
+		ex(t, bob, "mv projA projB", 15*time.Second)
+
+		WaitForFileOnMount(t, filepath.Join(aliceMount, "projB", "f1.txt"), 60*time.Second)
+		if got := readAt(t, alice, "projB/f1.txt"); got != "hello-from-projA" {
+			t.Fatalf("child must stay readable through the peer's mount after a directory rename: got %q", got)
+		}
+
+		// Ghost check: the OLD child path must disappear on the peer. Before
+		// the child re-keying it stayed visible forever (measured 2026-08-26).
+		ghostGone := func() bool {
+			_, err := os.Stat(filepath.Join(aliceMount, "projA", "f1.txt"))
+			return os.IsNotExist(err)
+		}
+		deadline := time.Now().Add(30 * time.Second)
+		for !ghostGone() && time.Now().Before(deadline) {
+			time.Sleep(500 * time.Millisecond)
+		}
+		// Cleanup for the next subtest before any verdict.
+		ex(t, bob, "rm -rf projB", 15*time.Second)
+		WaitForFileAbsent(t, filepath.Join(aliceMount, "projB", "f1.txt"), 30*time.Second)
+		if !ghostGone() {
+			t.Fatalf("old child path projA/f1.txt must disappear on the peer after the directory rename")
+		}
+	})
+
+	// The cycle: mv A B/ on Alice crossing mv B A/ on Bob. A correct tree
+	// keeps one arrangement on both peers; the shipped path re-creates the
+	// departed parent via MkdirAll and the trees diverge.
+	t.Run("ConcurrentCrossMoves", func(t *testing.T) {
+		ex(t, bob, "mkdir -p A B", 15*time.Second)
+		mustSend(t, bob, "write_file A/fa.txt content-of-fa")
+		mustSend(t, bob, "write_file B/fb.txt content-of-fb")
+		WaitForFileOnMount(t, filepath.Join(aliceMount, "A", "fa.txt"), 60*time.Second)
+		WaitForFileOnMount(t, filepath.Join(aliceMount, "B", "fb.txt"), 60*time.Second)
+		if got := readAt(t, alice, "A/fa.txt"); got != "content-of-fa" {
+			t.Fatalf("seed read A/fa.txt through Alice's mount: got %q", got)
+		}
+		if got := readAt(t, alice, "B/fb.txt"); got != "content-of-fb" {
+			t.Fatalf("seed read B/fb.txt through Alice's mount: got %q", got)
+		}
+
+		// The crossing moves, issued as close to simultaneously as the
+		// stdin protocol allows.
+		aliceMove := alice.sendAsync(t, "exec . mv A B")
+		bobMove := bob.sendAsync(t, "exec . mv B A")
+		aliceResp := <-aliceMove
+		bobResp := <-bobMove
+		t.Logf("alice mv A B -> %s", aliceResp)
+		t.Logf("bob   mv B A -> %s", bobResp)
+
+		// Let announces, renames and any repair settle.
+		time.Sleep(15 * time.Second)
+
+		aliceTree := treeOf(t, alice)
+		bobTree := treeOf(t, bob)
+		t.Logf("alice tree: %v", aliceTree)
+		t.Logf("bob   tree: %v", bobTree)
+
+		// Content preservation is unconditional: the bytes of both files
+		// must exist somewhere on each peer, diverged tree or not.
+		for _, want := range []struct{ name, content string }{
+			{"fa.txt", "content-of-fa"},
+			{"fb.txt", "content-of-fb"},
+		} {
+			for _, side := range []struct {
+				peer *testPeer
+				tree []string
+				tag  string
+			}{{alice, aliceTree, "alice"}, {bob, bobTree, "bob"}} {
+				found := false
+				for _, rel := range side.tree {
+					if filepath.Base(rel) == want.name && readAt(t, side.peer, rel) == want.content {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Fatalf("%s: %s with its bytes must exist somewhere after the crossing moves (tree: %v)", side.tag, want.name, side.tree)
+				}
+			}
+		}
+
+		converged := len(aliceTree) == len(bobTree)
+		if converged {
+			for i := range aliceTree {
+				if aliceTree[i] != bobTree[i] {
+					converged = false
+					break
+				}
+			}
+		}
+		if !converged {
+			t.Fatalf("both peers must converge to one tree after crossing directory moves: alice=%v bob=%v", aliceTree, bobTree)
+		}
+	})
+}

--- a/tests/integration_fuse_dirmove_test.go
+++ b/tests/integration_fuse_dirmove_test.go
@@ -22,17 +22,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestFUSEtoFUSE_DirectoryMoves pins directory-rename behavior across peers.
-// Directory renames travel as RENAME_FILE on the wire; both sides re-key the
-// moved directory's children (or the old paths serve forever as ghosts and
-// phantoms). The sequential subtest is the control: a one-sided move keeps
-// children reachable and retires the old path. The concurrent subtest is the
-// classic tree-invariant violation (VMCAI 2018: move is the one operation
-// that unsynchronised breaks the tree): mv A B/ crossing mv B A/. The
-// fingerprint rank picks ONE move on both machines: the loser undoes its own
-// and applies the winner's, the winner skips the peer's, and both trees
-// converge with no MkdirAll resurrection. Content loss is asserted
-// unconditionally. Set KD_DM_LOGDIR to keep the peers' logs.
+// TestFUSEtoFUSE_DirectoryMoves: a one-sided directory move keeps children
+// reachable and retires the old path; crossing moves (mv A B/ against
+// mv B A/) converge to the ranked winner's single move on both peers.
+// Set KD_DM_LOGDIR to keep the peers' logs.
 func TestFUSEtoFUSE_DirectoryMoves(t *testing.T) {
 	skipIfNoFUSE(t)
 	if runtime.GOOS == "windows" {
@@ -120,13 +113,8 @@ func TestFUSEtoFUSE_DirectoryMoves(t *testing.T) {
 		}
 	}
 
-	// treeOf returns the sorted relative paths of every regular file under the
-	// mount, read through the peer's own exec so the peer's FUSE view is what
-	// is listed, not the host's cached view. A stale map entry can leave a
-	// PHANTOM directory (readdir lists it, stat fails), which makes find exit
-	// 1 while still printing everything it reached; that is itself part of
-	// the demonstration, so any exit code is accepted and phantoms are kept
-	// as entries.
+	// treeOf lists every regular file through the peer's own mount view.
+	// A phantom entry makes find exit 1; keep it as a PHANTOM: marker.
 	treeOf := func(t *testing.T, p *testPeer) []string {
 		t.Helper()
 		resp := p.send(t, "exec . find . -type f", 20*time.Second)
@@ -168,8 +156,7 @@ func TestFUSEtoFUSE_DirectoryMoves(t *testing.T) {
 		return strings.TrimSpace(ex(t, p, "cat "+rel, 15*time.Second))
 	}
 
-	// The control: a one-sided directory rename must keep children reachable
-	// on the peer. This is the baseline the concurrent case is judged against.
+	// Control: a one-sided rename keeps children reachable on the peer.
 	t.Run("SequentialDirRenameKeepsChildren", func(t *testing.T) {
 		ex(t, bob, "mkdir -p projA", 15*time.Second)
 		mustSend(t, bob, "write_file projA/f1.txt hello-from-projA")
@@ -185,8 +172,7 @@ func TestFUSEtoFUSE_DirectoryMoves(t *testing.T) {
 			t.Fatalf("child must stay readable through the peer's mount after a directory rename: got %q", got)
 		}
 
-		// Ghost check: the OLD child path must disappear on the peer. Before
-		// the child re-keying it stayed visible forever (measured 2026-08-26).
+		// The old child path must disappear on the peer.
 		ghostGone := func() bool {
 			_, err := os.Stat(filepath.Join(aliceMount, "projA", "f1.txt"))
 			return os.IsNotExist(err)
@@ -203,9 +189,7 @@ func TestFUSEtoFUSE_DirectoryMoves(t *testing.T) {
 		}
 	})
 
-	// The cycle: mv A B/ on Alice crossing mv B A/ on Bob. A correct tree
-	// keeps one arrangement on both peers; the shipped path re-creates the
-	// departed parent via MkdirAll and the trees diverge.
+	// The cycle: mv A B/ crossing mv B A/ must converge to one arrangement.
 	t.Run("ConcurrentCrossMoves", func(t *testing.T) {
 		ex(t, bob, "mkdir -p A B", 15*time.Second)
 		mustSend(t, bob, "write_file A/fa.txt content-of-fa")
@@ -219,8 +203,7 @@ func TestFUSEtoFUSE_DirectoryMoves(t *testing.T) {
 			t.Fatalf("seed read B/fb.txt through Alice's mount: got %q", got)
 		}
 
-		// The crossing moves, issued as close to simultaneously as the
-		// stdin protocol allows.
+		// Issue both moves as simultaneously as the protocol allows.
 		aliceMove := alice.sendAsync(t, "exec . mv A B")
 		bobMove := bob.sendAsync(t, "exec . mv B A")
 		aliceResp := <-aliceMove
@@ -236,8 +219,7 @@ func TestFUSEtoFUSE_DirectoryMoves(t *testing.T) {
 		t.Logf("alice tree: %v", aliceTree)
 		t.Logf("bob   tree: %v", bobTree)
 
-		// Content preservation is unconditional: the bytes of both files
-		// must exist somewhere on each peer, diverged tree or not.
+		// Bytes must exist somewhere on each peer, diverged or not.
 		for _, want := range []struct{ name, content string }{
 			{"fa.txt", "content-of-fa"},
 			{"fb.txt", "content-of-fb"},

--- a/tests/integration_reconnect_conflict_test.go
+++ b/tests/integration_reconnect_conflict_test.go
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// ABOUTME: Repro for the reconnect conflict gap: both peers edit the same file
+// ABOUTME: while the session is down; the re-announce must not silently win.
+
+package tests
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/KeibiSoft/KeibiDrop/internal/fp"
+	"github.com/KeibiSoft/KeibiDrop/internal/testkit"
+	"github.com/KeibiSoft/KeibiDrop/pkg/logic/common"
+	"github.com/stretchr/testify/require"
+)
+
+// logContentPresence reports where the given content currently exists under
+// the listed roots. Forensics for the loss case, printed before the failing
+// assertion so the red run documents what happened to the bytes.
+func logContentPresence(t *testing.T, label string, content []byte, roots ...string) {
+	t.Helper()
+	found := []string{}
+	for _, root := range roots {
+		_ = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+			if err != nil || info == nil || info.IsDir() || info.Size() > 1<<20 {
+				return nil
+			}
+			b, err := os.ReadFile(path)
+			if err == nil && bytes.Contains(b, content) {
+				found = append(found, path)
+			}
+			return nil
+		})
+	}
+	if len(found) == 0 {
+		t.Logf("%s: NOT FOUND under any root %v (the bytes are gone)", label, roots)
+	} else {
+		t.Logf("%s: present at %v", label, found)
+	}
+}
+
+// TestReconnectConflict_OfflineEditsBothSides drives the canonical CRDT
+// motivating scenario through the shipped stack: seed a file, sever the
+// session without a goodbye (the mount survives, matching the resilience
+// park path), edit on BOTH sides while disconnected, reconnect, and require
+// that the older side's bytes survive as a conflict sibling.
+//
+// Today this fails at the sibling wait: the reconnect re-announce carries no
+// base (notifyRestoredFiles and ScanAndShareSaveDir both omit BaseMtimeNs),
+// base 0 means plain LWW by design, and Alice's offline edit is truncated
+// away with no copy. The tie/conflict machinery itself is proven live by
+// TestFUSEtoFUSE_BidirectionalEditPatterns/ConcurrentEditConflictCopy; the
+// missing ingredient here is only the base on the reconnect path.
+func TestReconnectConflict_OfflineEditsBothSides(t *testing.T) {
+	skipIfNoFUSE(t)
+	if testing.Short() {
+		t.Skip("FUSE reconnect test skipped in short mode")
+	}
+	require := require.New(t)
+
+	const seedContent = "v1-seed-content"
+	tp := SetupFUSEPeerPairPreConnect(t, 180*time.Second,
+		func(alice, bob *common.KeibiDrop, aliceSave, bobSave string) {
+			require.NoError(os.WriteFile(filepath.Join(bobSave, "doc.txt"), []byte(seedContent), 0o644))
+			bob.ScanSharedOnStart = true
+		})
+	waitForFUSEMount(t, tp.AliceMountDir, 15*time.Second)
+
+	aliceDoc := filepath.Join(tp.AliceMountDir, "doc.txt")
+	WaitForFileOnMount(t, aliceDoc, 30*time.Second)
+
+	// Read through the mount so Alice holds the v1 bytes, not just metadata.
+	got, err := os.ReadFile(aliceDoc)
+	require.NoError(err)
+	require.Equal(seedContent, string(got))
+
+	// Sever the session without a goodbye. Cancel() is what the health
+	// monitor does on a dead connection: the Run loop takes the temporary
+	// disconnect branch and the FUSE mount stays up with its in-memory
+	// state. No NotifyDisconnect: the peer just vanishes.
+	tp.Alice.StopConnectionResilience()
+	tp.Bob.StopConnectionResilience()
+	tp.Alice.Cancel()
+	WaitForCondition(t, 10*time.Second, 50*time.Millisecond, func() bool {
+		return !tp.Alice.IsRunning()
+	}, "waiting for Alice's session to die")
+	tp.Bob.Stop()
+	WaitForCondition(t, 10*time.Second, 50*time.Millisecond, func() bool {
+		return !tp.Bob.IsRunning()
+	}, "waiting for Bob to stop")
+
+	// The mount survived the drop; the file is still served locally.
+	_, err = os.Stat(aliceDoc)
+	require.NoError(err, "Alice's mount must survive a session drop")
+
+	// Offline edit on Alice, THROUGH the live mount: the FUSE write path
+	// sets LocalNewer and snapshots the edit base from the held version.
+	const aliceOffline = "alice-offline-edit"
+	require.NoError(os.WriteFile(aliceDoc, []byte(aliceOffline), 0o644))
+	// Let the debounced announce fire into the dead session and drop.
+	time.Sleep(700 * time.Millisecond)
+
+	// Offline edit on Bob, in his save dir (the no-FUSE surface), stamped
+	// strictly newest so the LWW direction is deterministic.
+	const bobOffline = "bob-offline-edit-newest"
+	bobDoc := filepath.Join(tp.BobSaveDir, "doc.txt")
+	require.NoError(os.WriteFile(bobDoc, []byte(bobOffline), 0o644))
+	future := time.Now().Add(time.Hour)
+	require.NoError(os.Chtimes(bobDoc, future, future))
+
+	// Manual reconnect, the disconnect-suite dance.
+	aliceFp, err := tp.Alice.ExportFingerprint()
+	require.NoError(err)
+	bobFp, err := tp.Bob.ExportFingerprint()
+	require.NoError(err)
+	require.NoError(tp.Alice.AddPeerFingerprint(bobFp))
+	require.NoError(tp.Bob.AddPeerFingerprint(aliceFp))
+	tp.Relay.Clear()
+
+	aliceReady := testkit.Go(func() error { return reconnectJoin(tp.Alice.CreateRoom) })
+	WaitForCondition(t, 10*time.Second, 50*time.Millisecond, func() bool {
+		return tp.Relay.EntryCount() > 0
+	}, "waiting for Alice to re-register on relay")
+	bobReady := testkit.Go(func() error { return reconnectJoin(tp.Bob.JoinRoom) })
+
+	testkit.Run(t, func() error {
+		return fp.Steps(
+			func() error { return testkit.Within(30*time.Second, "Alice CreateRoom round 2", aliceReady) },
+			func() error { return testkit.Within(30*time.Second, "Bob JoinRoom round 2", bobReady) },
+		)
+	})
+
+	// The canonical path converges to the newest offline write (Bob's).
+	WaitForCondition(t, 90*time.Second, 500*time.Millisecond, func() bool {
+		b, err := os.ReadFile(aliceDoc)
+		return err == nil && string(b) == bobOffline
+	}, "waiting for the canonical path to converge to the newest offline write")
+
+	// Forensics before the assertion: where are Alice's offline bytes now?
+	logContentPresence(t, "alice offline bytes", []byte(aliceOffline),
+		tp.AliceSaveDir, tp.BobSaveDir)
+
+	// THE gap assertion. Alice was provably concurrent (she never saw Bob's
+	// offline write), so her bytes must survive as a conflict sibling.
+	var sibling string
+	WaitForCondition(t, 45*time.Second, 500*time.Millisecond, func() bool {
+		entries, err := os.ReadDir(tp.AliceMountDir)
+		if err != nil {
+			return false
+		}
+		for _, e := range entries {
+			if strings.HasPrefix(e.Name(), "doc.conflict-") {
+				sibling = e.Name()
+				return true
+			}
+		}
+		return false
+	}, "waiting for the offline-edit conflict sibling on Alice's mount")
+
+	preserved, err := os.ReadFile(filepath.Join(tp.AliceMountDir, sibling))
+	require.NoError(err)
+	require.Equal(aliceOffline, string(preserved), "the sibling must hold Alice's offline bytes")
+
+	// The sibling is an ordinary new file and must reach Bob too. FUSE-origin
+	// announces carry a leading slash in the path, so a no-FUSE receiver may
+	// key the tracker entry either way.
+	WaitForCondition(t, 30*time.Second, 200*time.Millisecond, func() bool {
+		tp.Bob.SyncTracker.RemoteFilesMu.RLock()
+		defer tp.Bob.SyncTracker.RemoteFilesMu.RUnlock()
+		_, plain := tp.Bob.SyncTracker.RemoteFiles[sibling]
+		_, slashed := tp.Bob.SyncTracker.RemoteFiles["/"+sibling]
+		return plain || slashed
+	}, "waiting for the conflict sibling to reach Bob's tracker")
+}

--- a/tests/integration_reconnect_conflict_test.go
+++ b/tests/integration_reconnect_conflict_test.go
@@ -23,9 +23,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// logContentPresence reports where the given content currently exists under
-// the listed roots. Forensics for the loss case, printed before the failing
-// assertion so the red run documents what happened to the bytes.
+// logContentPresence reports where content exists under roots. Forensics for
+// the loss case.
 func logContentPresence(t *testing.T, label string, content []byte, roots ...string) {
 	t.Helper()
 	found := []string{}
@@ -48,18 +47,9 @@ func logContentPresence(t *testing.T, label string, content []byte, roots ...str
 	}
 }
 
-// TestReconnectConflict_OfflineEditsBothSides drives the canonical CRDT
-// motivating scenario through the shipped stack: seed a file, sever the
-// session without a goodbye (the mount survives, matching the resilience
-// park path), edit on BOTH sides while disconnected, reconnect, and require
-// that the older side's bytes survive as a conflict sibling.
-//
-// Today this fails at the sibling wait: the reconnect re-announce carries no
-// base (notifyRestoredFiles and ScanAndShareSaveDir both omit BaseMtimeNs),
-// base 0 means plain LWW by design, and Alice's offline edit is truncated
-// away with no copy. The tie/conflict machinery itself is proven live by
-// TestFUSEtoFUSE_BidirectionalEditPatterns/ConcurrentEditConflictCopy; the
-// missing ingredient here is only the base on the reconnect path.
+// TestReconnectConflict_OfflineEditsBothSides: sever the session without a
+// goodbye (the mount survives), edit on both sides, reconnect. The older
+// side's bytes must survive as a conflict sibling on both peers.
 func TestReconnectConflict_OfflineEditsBothSides(t *testing.T) {
 	skipIfNoFUSE(t)
 	if testing.Short() {
@@ -83,10 +73,8 @@ func TestReconnectConflict_OfflineEditsBothSides(t *testing.T) {
 	require.NoError(err)
 	require.Equal(seedContent, string(got))
 
-	// Sever the session without a goodbye. Cancel() is what the health
-	// monitor does on a dead connection: the Run loop takes the temporary
-	// disconnect branch and the FUSE mount stays up with its in-memory
-	// state. No NotifyDisconnect: the peer just vanishes.
+	// Sever without a goodbye: Cancel() is what the health monitor does on
+	// a dead connection. The mount stays up; the peer just vanishes.
 	tp.Alice.StopConnectionResilience()
 	tp.Bob.StopConnectionResilience()
 	tp.Alice.Cancel()
@@ -102,15 +90,13 @@ func TestReconnectConflict_OfflineEditsBothSides(t *testing.T) {
 	_, err = os.Stat(aliceDoc)
 	require.NoError(err, "Alice's mount must survive a session drop")
 
-	// Offline edit on Alice, THROUGH the live mount: the FUSE write path
-	// sets LocalNewer and snapshots the edit base from the held version.
+	// Offline edit through the live mount: sets LocalNewer and the base.
 	const aliceOffline = "alice-offline-edit"
 	require.NoError(os.WriteFile(aliceDoc, []byte(aliceOffline), 0o644))
 	// Let the debounced announce fire into the dead session and drop.
 	time.Sleep(700 * time.Millisecond)
 
-	// Offline edit on Bob, in his save dir (the no-FUSE surface), stamped
-	// strictly newest so the LWW direction is deterministic.
+	// Offline edit on Bob's save dir, stamped newest: LWW direction fixed.
 	const bobOffline = "bob-offline-edit-newest"
 	bobDoc := filepath.Join(tp.BobSaveDir, "doc.txt")
 	require.NoError(os.WriteFile(bobDoc, []byte(bobOffline), 0o644))
@@ -149,8 +135,7 @@ func TestReconnectConflict_OfflineEditsBothSides(t *testing.T) {
 	logContentPresence(t, "alice offline bytes", []byte(aliceOffline),
 		tp.AliceSaveDir, tp.BobSaveDir)
 
-	// THE gap assertion. Alice was provably concurrent (she never saw Bob's
-	// offline write), so her bytes must survive as a conflict sibling.
+	// Alice was provably concurrent: her bytes must survive as a sibling.
 	var sibling string
 	WaitForCondition(t, 45*time.Second, 500*time.Millisecond, func() bool {
 		entries, err := os.ReadDir(tp.AliceMountDir)
@@ -170,9 +155,7 @@ func TestReconnectConflict_OfflineEditsBothSides(t *testing.T) {
 	require.NoError(err)
 	require.Equal(aliceOffline, string(preserved), "the sibling must hold Alice's offline bytes")
 
-	// The sibling is an ordinary new file and must reach Bob too. FUSE-origin
-	// announces carry a leading slash in the path, so a no-FUSE receiver may
-	// key the tracker entry either way.
+	// The sibling must reach Bob. Tracker keys may carry a leading slash.
 	WaitForCondition(t, 30*time.Second, 200*time.Millisecond, func() bool {
 		tp.Bob.SyncTracker.RemoteFilesMu.RLock()
 		defer tp.Bob.SyncTracker.RemoteFilesMu.RUnlock()

--- a/tests/model/twopeer_conflictcopy_model_test.go
+++ b/tests/model/twopeer_conflictcopy_model_test.go
@@ -1,15 +1,10 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (c) 2025 KeibiSoft S.R.L.
 
-// Models the life of a conflict sibling across a session drop. A sibling is
-// minted on the losing peer only (registerConflictCopy) and reaches the other
-// peer as an ordinary ADD announcement. Delivery is at-most-once across a
-// session boundary: a drop clears the in-flight queues and nothing re-announces
-// FUSE-registered local files on reconnect. The checked claim, shipped rules:
-// there exist interleavings where the drop lands between the preserve and its
-// delivery, the sibling then exists on exactly one peer at quiescence, and no
-// later action heals it. The fix rule (re-announce local siblings on
-// reconnect) closes every such interleaving.
+// Models a conflict sibling across a session drop. Shipped rules: a drop
+// between the preserve and its delivery strands the sibling on one peer
+// forever. The fix rule (re-announce local siblings on reconnect) closes
+// every such interleaving.
 package model
 
 import (
@@ -95,11 +90,8 @@ func ccKey(s ccState) string {
 	return string(b)
 }
 
-// Actions: a write carrying the base the writer held, delivery of the head
-// message (a stale-base winner preserves the overwritten version as a sibling
-// and announces the sibling), and a session drop that clears both in-flight
-// queues. reannounce models the fix: the drop is followed by a reconnect
-// re-announce of every locally present sibling.
+// Actions: a write with its base, delivery (a stale-base winner preserves
+// and announces a sibling), and a drop that clears both queues.
 func ccSuccessors(s ccState, reannounce bool) []ccState {
 	var out []ccState
 	for i := 0; i < 2; i++ {
@@ -125,8 +117,7 @@ func ccSuccessors(s ccState, reannounce bool) []ccState {
 			case ccEdit:
 				if m.ver > n.p[i].watermark && m.ver > n.p[i].own {
 					if old := n.p[i].content; old != 0 && old != m.base {
-						// Stale base: provably concurrent. Preserve the loser
-						// locally and announce the sibling to the other peer.
+						// Stale base: preserve the loser and announce the sibling.
 						n.p[i].sibs[old] = true
 						n.q[1-i] = append(n.q[1-i], ccMsg{kind: ccSib, sib: old})
 					}
@@ -207,9 +198,7 @@ func checkCC(t *testing.T, writesA, writesB, drops int, reannounce, failOnAsymme
 	return rep.Terminals, asymmetric, withSibs
 }
 
-// Without a session drop every minted sibling is delivered: the sibling sets
-// agree at every quiescent terminal. The announce pipeline alone is enough
-// while the session lives.
+// Without a drop every minted sibling is delivered: the sets agree.
 func TestConflictCopy_NoDropAlwaysSymmetric(t *testing.T) {
 	for _, tc := range []struct{ a, b int }{{1, 1}, {2, 1}, {2, 2}} {
 		_, asymmetric, withSibs := checkCC(t, tc.a, tc.b, 0, false, true)
@@ -220,10 +209,7 @@ func TestConflictCopy_NoDropAlwaysSymmetric(t *testing.T) {
 	}
 }
 
-// Shipped rules with one session drop: interleavings exist where the drop
-// lands between the preserve and its delivery, and the sibling then exists on
-// exactly one peer at quiescence. Nothing re-announces it. This is the
-// deterministic form of the at-most-once weakness for conflict copies.
+// One drop: interleavings exist where the sibling ends on exactly one peer.
 func TestConflictCopy_DropLosesSiblingOnOnePeer(t *testing.T) {
 	_, asymmetric, withSibs := checkCC(t, 1, 1, 1, false, false)
 	if withSibs == 0 {
@@ -234,9 +220,8 @@ func TestConflictCopy_DropLosesSiblingOnOnePeer(t *testing.T) {
 	}
 }
 
-// The fix rule: reconnect re-announces every locally present sibling. Every
-// interleaving then ends with equal sibling sets, at the cost of re-sending
-// already-delivered siblings (idempotent, sibling ids are stable).
+// The fix rule: reconnect re-announces local siblings; every interleaving
+// ends with equal sets. Re-sends are idempotent.
 func TestConflictCopy_ReannounceRestoresSymmetry(t *testing.T) {
 	for _, tc := range []struct{ a, b, drops int }{{1, 1, 1}, {2, 1, 1}, {2, 2, 1}} {
 		_, asymmetric, _ := checkCC(t, tc.a, tc.b, tc.drops, true, true)

--- a/tests/model/twopeer_conflictcopy_model_test.go
+++ b/tests/model/twopeer_conflictcopy_model_test.go
@@ -26,11 +26,11 @@ const (
 )
 
 type ccMsg struct {
-	kind      int
-	content   int // edit: content id (equals its version)
-	ver       int
-	base      int // version the writer held when it wrote
-	sib       int // sibling id (the preserved version)
+	kind    int
+	content int // edit: content id (equals its version)
+	ver     int
+	base    int // version the writer held when it wrote
+	sib     int // sibling id (the preserved version)
 }
 
 type ccPeer struct {

--- a/tests/model/twopeer_conflictcopy_model_test.go
+++ b/tests/model/twopeer_conflictcopy_model_test.go
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+
+// Models the life of a conflict sibling across a session drop. A sibling is
+// minted on the losing peer only (registerConflictCopy) and reaches the other
+// peer as an ordinary ADD announcement. Delivery is at-most-once across a
+// session boundary: a drop clears the in-flight queues and nothing re-announces
+// FUSE-registered local files on reconnect. The checked claim, shipped rules:
+// there exist interleavings where the drop lands between the preserve and its
+// delivery, the sibling then exists on exactly one peer at quiescence, and no
+// later action heals it. The fix rule (re-announce local siblings on
+// reconnect) closes every such interleaving.
+package model
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/KeibiSoft/KeibiDrop/internal/fp"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	ccEdit = iota // announcement of a write: content, ver, base
+	ccSib         // announcement of a minted conflict sibling: id
+)
+
+type ccMsg struct {
+	kind      int
+	content   int // edit: content id (equals its version)
+	ver       int
+	base      int // version the writer held when it wrote
+	sib       int // sibling id (the preserved version)
+}
+
+type ccPeer struct {
+	content   int
+	watermark int
+	own       int
+	sibs      map[int]bool // conflict siblings present on this peer
+}
+
+type ccState struct {
+	p          [2]ccPeer
+	q          [2][]ccMsg
+	nextVer    int
+	writesLeft [2]int
+	dropsLeft  int
+}
+
+func cloneCC(s ccState) ccState {
+	n := s
+	for i := 0; i < 2; i++ {
+		n.q[i] = append([]ccMsg(nil), s.q[i]...)
+		n.p[i].sibs = map[int]bool{}
+		for k := range s.p[i].sibs {
+			n.p[i].sibs[k] = true
+		}
+	}
+	return n
+}
+
+func sortedSibs(sibs map[int]bool) []int {
+	out := make([]int, 0, len(sibs))
+	for k := range sibs {
+		out = append(out, k)
+	}
+	sort.Ints(out)
+	return out
+}
+
+func ccKey(s ccState) string {
+	b := make([]byte, 0, 64)
+	enc := func(v int) { b = append(b, byte(v), byte(v>>8)) }
+	for i := 0; i < 2; i++ {
+		enc(s.p[i].content)
+		enc(s.p[i].watermark)
+		enc(s.p[i].own)
+		for _, id := range sortedSibs(s.p[i].sibs) {
+			enc(id)
+		}
+		b = append(b, 0xFF)
+		enc(s.writesLeft[i])
+		enc(len(s.q[i]))
+		for _, m := range s.q[i] {
+			enc(m.kind)
+			enc(m.content)
+			enc(m.ver)
+			enc(m.base)
+			enc(m.sib)
+		}
+	}
+	enc(s.nextVer)
+	enc(s.dropsLeft)
+	return string(b)
+}
+
+// Actions: a write carrying the base the writer held, delivery of the head
+// message (a stale-base winner preserves the overwritten version as a sibling
+// and announces the sibling), and a session drop that clears both in-flight
+// queues. reannounce models the fix: the drop is followed by a reconnect
+// re-announce of every locally present sibling.
+func ccSuccessors(s ccState, reannounce bool) []ccState {
+	var out []ccState
+	for i := 0; i < 2; i++ {
+		if s.writesLeft[i] > 0 {
+			n := cloneCC(s)
+			n.nextVer++
+			base := 0
+			if n.p[i].content != 0 {
+				base = n.p[i].content // content ids are their versions
+			}
+			n.p[i].content = n.nextVer
+			n.p[i].own = n.nextVer
+			n.writesLeft[i]--
+			other := 1 - i
+			n.q[other] = append(n.q[other], ccMsg{kind: ccEdit, content: n.nextVer, ver: n.nextVer, base: base})
+			out = append(out, n)
+		}
+		if len(s.q[i]) > 0 {
+			n := cloneCC(s)
+			m := n.q[i][0]
+			n.q[i] = append([]ccMsg(nil), n.q[i][1:]...)
+			switch m.kind {
+			case ccEdit:
+				if m.ver > n.p[i].watermark && m.ver > n.p[i].own {
+					if old := n.p[i].content; old != 0 && old != m.base {
+						// Stale base: provably concurrent. Preserve the loser
+						// locally and announce the sibling to the other peer.
+						n.p[i].sibs[old] = true
+						n.q[1-i] = append(n.q[1-i], ccMsg{kind: ccSib, sib: old})
+					}
+					n.p[i].watermark = m.ver
+					n.p[i].content = m.content
+				}
+			case ccSib:
+				n.p[i].sibs[m.sib] = true
+			}
+			out = append(out, n)
+		}
+	}
+	if s.dropsLeft > 0 && (len(s.q[0]) > 0 || len(s.q[1]) > 0) {
+		n := cloneCC(s)
+		n.q[0] = nil
+		n.q[1] = nil
+		n.dropsLeft--
+		if reannounce {
+			// The fix: on reconnect each peer re-announces its local siblings.
+			for i := 0; i < 2; i++ {
+				for _, id := range sortedSibs(n.p[i].sibs) {
+					n.q[1-i] = append(n.q[1-i], ccMsg{kind: ccSib, sib: id})
+				}
+			}
+		}
+		out = append(out, n)
+	}
+	return out
+}
+
+func ccQuiescent(s ccState) bool {
+	return s.writesLeft[0] == 0 && s.writesLeft[1] == 0 &&
+		len(s.q[0]) == 0 && len(s.q[1]) == 0
+}
+
+func sibsEqual(a, b map[int]bool) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k := range a {
+		if !b[k] {
+			return false
+		}
+	}
+	return true
+}
+
+func checkCC(t *testing.T, writesA, writesB, drops int, reannounce, failOnAsymmetry bool) (terminals, asymmetric, withSibs int) {
+	t.Helper()
+
+	m := Model[ccState]{
+		Key:        ccKey,
+		Successors: func(s ccState) []ccState { return ccSuccessors(s, reannounce) },
+		Quiescent:  ccQuiescent,
+		CheckTerminal: func(s ccState) error {
+			if len(s.p[0].sibs) > 0 || len(s.p[1].sibs) > 0 {
+				withSibs++
+			}
+			if !sibsEqual(s.p[0].sibs, s.p[1].sibs) {
+				asymmetric++
+				if failOnAsymmetry {
+					return fp.Equal("SIBLING LOSS: conflict copy exists on one peer only",
+						len(s.p[0].sibs), len(s.p[1].sibs))
+				}
+			}
+			return nil
+		},
+	}
+
+	init := ccState{writesLeft: [2]int{writesA, writesB}, dropsLeft: drops}
+	init.p[0].sibs = map[int]bool{}
+	init.p[1].sibs = map[int]bool{}
+	rep, err := Explore(m, init)
+	require.NoError(t, err)
+
+	t.Logf("writes=%d+%d drops=%d reannounce=%v: states=%d terminals=%d asymmetric=%d withSibs=%d",
+		writesA, writesB, drops, reannounce, rep.Explored, rep.Terminals, asymmetric, withSibs)
+	return rep.Terminals, asymmetric, withSibs
+}
+
+// Without a session drop every minted sibling is delivered: the sibling sets
+// agree at every quiescent terminal. The announce pipeline alone is enough
+// while the session lives.
+func TestConflictCopy_NoDropAlwaysSymmetric(t *testing.T) {
+	for _, tc := range []struct{ a, b int }{{1, 1}, {2, 1}, {2, 2}} {
+		_, asymmetric, withSibs := checkCC(t, tc.a, tc.b, 0, false, true)
+		_ = withSibs
+		if asymmetric != 0 {
+			t.Fatalf("writes=%d+%d no drop: %d asymmetric terminals", tc.a, tc.b, asymmetric)
+		}
+	}
+}
+
+// Shipped rules with one session drop: interleavings exist where the drop
+// lands between the preserve and its delivery, and the sibling then exists on
+// exactly one peer at quiescence. Nothing re-announces it. This is the
+// deterministic form of the at-most-once weakness for conflict copies.
+func TestConflictCopy_DropLosesSiblingOnOnePeer(t *testing.T) {
+	_, asymmetric, withSibs := checkCC(t, 1, 1, 1, false, false)
+	if withSibs == 0 {
+		t.Fatal("scope produced no conflict-copy histories; scope too small")
+	}
+	if asymmetric == 0 {
+		t.Fatal("expected asymmetric sibling terminals under a session drop; found none")
+	}
+}
+
+// The fix rule: reconnect re-announces every locally present sibling. Every
+// interleaving then ends with equal sibling sets, at the cost of re-sending
+// already-delivered siblings (idempotent, sibling ids are stable).
+func TestConflictCopy_ReannounceRestoresSymmetry(t *testing.T) {
+	for _, tc := range []struct{ a, b, drops int }{{1, 1, 1}, {2, 1, 1}, {2, 2, 1}} {
+		_, asymmetric, _ := checkCC(t, tc.a, tc.b, tc.drops, true, true)
+		if asymmetric != 0 {
+			t.Fatalf("writes=%d+%d drops=%d with reannounce: %d asymmetric terminals",
+				tc.a, tc.b, tc.drops, asymmetric)
+		}
+	}
+}

--- a/tests/model/twopeer_tie_model_test.go
+++ b/tests/model/twopeer_tie_model_test.go
@@ -1,16 +1,10 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (c) 2025 KeibiSoft S.R.L.
 
-// Models the exact version tie: both peers write concurrently and the two
-// writes carry the same nanosecond stamp. Observed once in CI (see
-// research_artefacts/bidirectional-edit-matrix.md, iter-7, same-kernel coarse
-// stamps), and named a known residual in twopeer_swap_model_test.go. The two
-// shipped acceptance shapes both diverge on a tie: the ADD predicate is
-// strictly-greater, so both peers reject and each keeps its own bytes; the
-// EDIT predicate rejects only strictly-older, so both peers accept and the
-// contents swap. The checked fix rule breaks the tie by a fixed peer rank
-// (fingerprint order): exactly one side accepts, both converge on one winner,
-// and the loser's version is preserved, never silently dropped.
+// Models the exact version tie (observed once in CI). Both shipped acceptance
+// shapes diverge on a tie: ADD rejects on both sides, EDIT swaps contents.
+// The checked fix rule breaks the tie by peer rank: one winner on both sides,
+// the loser preserved.
 package model
 
 import (
@@ -23,16 +17,11 @@ import (
 type tieMode int
 
 const (
-	// tieModeAddStrict is the shipped ADD predicate: accept only strictly
-	// newer (fuse_directory.go AddRemoteFileWithBase). A tie rejects on both
-	// sides.
+	// tieModeAddStrict: shipped ADD predicate, a tie rejects on both sides.
 	tieModeAddStrict tieMode = iota
-	// tieModeEditGE is the shipped EDIT predicate: reject only strictly
-	// older (fuse_directory.go EditRemoteFileWithBase). A tie passes on both
-	// sides.
+	// tieModeEditGE: shipped EDIT predicate, a tie passes on both sides.
 	tieModeEditGE
-	// tieModeRanked is the fix rule: on an exact tie the higher-ranked
-	// peer's write wins on both sides. Peer 1 holds the higher rank here.
+	// tieModeRanked: the fix rule, peer 1 wins an exact tie on both sides.
 	tieModeRanked
 )
 
@@ -87,8 +76,7 @@ func cloneTie(s tieState) tieState {
 	return n
 }
 
-// tieAccept is the acceptance predicate under the chosen mode. i is the
-// receiving peer; the sender is the other peer.
+// tieAccept is the acceptance predicate under the chosen mode.
 func tieAccept(mode tieMode, i int, p tiePeer, m tieMsg) bool {
 	switch mode {
 	case tieModeAddStrict:
@@ -106,10 +94,8 @@ func tieAccept(mode tieMode, i int, p tiePeer, m tieMsg) bool {
 	return false
 }
 
-// Actions: a unique-stamp write on either peer, the paired tie write (both
-// peers write with one shared stamp; the interesting case is exactly both
-// writing before seeing each other, so the pairing is atomic), or delivery
-// of the head announcement.
+// Actions: a unique-stamp write, the paired tie write (one shared stamp,
+// atomic pairing), or delivery of the head announcement.
 func tieSuccessors(s tieState, mode tieMode) []tieState {
 	var out []tieState
 	for i := 0; i < 2; i++ {
@@ -131,9 +117,7 @@ func tieSuccessors(s tieState, mode tieMode) []tieState {
 			n.q[i] = append([]tieMsg(nil), n.q[i][1:]...)
 			if tieAccept(mode, i, n.p[i], m) {
 				if mode == tieModeRanked && m.ver == n.p[i].own && n.p[i].content != m.content {
-					// The tie loser adopts the winner and preserves its own
-					// concurrent write (the conflict-copy policy still applies:
-					// a tie is provably concurrent).
+					// The loser adopts the winner and preserves its own write.
 					n.preserved = n.p[i].content
 				}
 				n.p[i].watermark = m.ver
@@ -166,8 +150,7 @@ func tieQuiescent(s tieState) bool {
 		len(s.q[0]) == 0 && len(s.q[1]) == 0
 }
 
-// checkTie explores one scope. In counting mode divergent terminals are
-// counted, not failed, so the shipped predicates can be demonstrated.
+// checkTie explores one scope. Counting mode demonstrates, fail mode gates.
 func checkTie(t *testing.T, mode tieMode, writesA, writesB, ties int, failOnDiverge bool) (terminals, divergent, preservedTerminals int) {
 	t.Helper()
 
@@ -198,9 +181,7 @@ func checkTie(t *testing.T, mode tieMode, writesA, writesB, ties int, failOnDive
 	return rep.Terminals, divergent, preservedTerminals
 }
 
-// The shipped ADD predicate (strictly greater) diverges permanently on a tie:
-// both peers reject the other's announce and each keeps its own bytes. No
-// interleaving heals it. No loss, no convergence.
+// The shipped ADD predicate diverges permanently on a tie: both reject.
 func TestTie_AddStrictPredicateDiverges(t *testing.T) {
 	for _, tc := range []struct{ a, b int }{{0, 0}, {1, 0}, {1, 1}} {
 		_, divergent, _ := checkTie(t, tieModeAddStrict, tc.a, tc.b, 1, false)
@@ -210,9 +191,7 @@ func TestTie_AddStrictPredicateDiverges(t *testing.T) {
 	}
 }
 
-// The shipped EDIT predicate (rejects only strictly older) also diverges on a
-// tie, in the worse shape: both peers accept and the contents SWAP. Each side
-// ends holding the other's bytes.
+// The shipped EDIT predicate diverges worse: both accept, contents swap.
 func TestTie_EditPredicateSwapsContents(t *testing.T) {
 	_, divergent, _ := checkTie(t, tieModeEditGE, 0, 0, 1, false)
 	if divergent == 0 {
@@ -220,8 +199,7 @@ func TestTie_EditPredicateSwapsContents(t *testing.T) {
 	}
 }
 
-// Without a tie both shipped predicates converge in every interleaving; the
-// divergence is caused by the tie alone, not by the added tie action.
+// Without a tie every interleaving converges: the tie alone diverges.
 func TestTie_NoTieNoDivergence(t *testing.T) {
 	for _, mode := range []tieMode{tieModeAddStrict, tieModeRanked} {
 		_, divergent, _ := checkTie(t, mode, 2, 1, 0, false)
@@ -231,9 +209,8 @@ func TestTie_NoTieNoDivergence(t *testing.T) {
 	}
 }
 
-// The fix rule: on an exact tie the higher-ranked peer wins on both sides.
-// Exactly one side accepts, every interleaving converges, and in the pure tie
-// scope the losing write is preserved, never silently dropped.
+// The fix rule: one winner on both sides, every interleaving converges,
+// the losing write is preserved.
 func TestTie_RankedTieBreakConverges(t *testing.T) {
 	for _, tc := range []struct{ a, b int }{{0, 0}, {1, 0}, {0, 1}, {1, 1}} {
 		checkTie(t, tieModeRanked, tc.a, tc.b, 1, true)
@@ -245,8 +222,7 @@ func TestTie_RankedTieBreakConverges(t *testing.T) {
 	}
 }
 
-// In the pure tie scope the winner is the higher-ranked peer's write, on both
-// peers. The rank decides the survivor deterministically.
+// The winner is the higher-ranked peer's write, on both peers.
 func TestTie_RankedWinnerIsHigherRank(t *testing.T) {
 	m := Model[tieState]{
 		Key:        tieKey,

--- a/tests/model/twopeer_tie_model_test.go
+++ b/tests/model/twopeer_tie_model_test.go
@@ -1,0 +1,265 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2025 KeibiSoft S.R.L.
+
+// Models the exact version tie: both peers write concurrently and the two
+// writes carry the same nanosecond stamp. Observed once in CI (see
+// research_artefacts/bidirectional-edit-matrix.md, iter-7, same-kernel coarse
+// stamps), and named a known residual in twopeer_swap_model_test.go. The two
+// shipped acceptance shapes both diverge on a tie: the ADD predicate is
+// strictly-greater, so both peers reject and each keeps its own bytes; the
+// EDIT predicate rejects only strictly-older, so both peers accept and the
+// contents swap. The checked fix rule breaks the tie by a fixed peer rank
+// (fingerprint order): exactly one side accepts, both converge on one winner,
+// and the loser's version is preserved, never silently dropped.
+package model
+
+import (
+	"testing"
+
+	"github.com/KeibiSoft/KeibiDrop/internal/fp"
+	"github.com/stretchr/testify/require"
+)
+
+type tieMode int
+
+const (
+	// tieModeAddStrict is the shipped ADD predicate: accept only strictly
+	// newer (fuse_directory.go AddRemoteFileWithBase). A tie rejects on both
+	// sides.
+	tieModeAddStrict tieMode = iota
+	// tieModeEditGE is the shipped EDIT predicate: reject only strictly
+	// older (fuse_directory.go EditRemoteFileWithBase). A tie passes on both
+	// sides.
+	tieModeEditGE
+	// tieModeRanked is the fix rule: on an exact tie the higher-ranked
+	// peer's write wins on both sides. Peer 1 holds the higher rank here.
+	tieModeRanked
+)
+
+type tiePeer struct {
+	content   int // id of the write this peer holds (0 = initial)
+	heldVer   int // version stamp of that content
+	watermark int // highest accepted announced version
+	own       int // version stamp of this peer's own newest local write
+}
+
+type tieMsg struct{ content, ver int }
+
+type tieState struct {
+	p          [2]tiePeer
+	q          [2][]tieMsg
+	nextVer    int
+	nextCid    int
+	writesLeft [2]int // unique-stamp writes
+	tiesLeft   int    // paired equal-stamp writes
+	tieCid     [2]int // content ids of the tie pair, 0 until the tie fires
+	preserved  int    // content id preserved on tie acceptance, ranked mode
+}
+
+func tieKey(s tieState) string {
+	b := make([]byte, 0, 48)
+	enc := func(v int) { b = append(b, byte(v), byte(v>>8)) }
+	for i := 0; i < 2; i++ {
+		enc(s.p[i].content)
+		enc(s.p[i].heldVer)
+		enc(s.p[i].watermark)
+		enc(s.p[i].own)
+		enc(s.writesLeft[i])
+		enc(s.tieCid[i])
+		enc(len(s.q[i]))
+		for _, m := range s.q[i] {
+			enc(m.content)
+			enc(m.ver)
+		}
+	}
+	enc(s.nextVer)
+	enc(s.nextCid)
+	enc(s.tiesLeft)
+	enc(s.preserved)
+	return string(b)
+}
+
+func cloneTie(s tieState) tieState {
+	n := s
+	for i := 0; i < 2; i++ {
+		n.q[i] = append([]tieMsg(nil), s.q[i]...)
+	}
+	return n
+}
+
+// tieAccept is the acceptance predicate under the chosen mode. i is the
+// receiving peer; the sender is the other peer.
+func tieAccept(mode tieMode, i int, p tiePeer, m tieMsg) bool {
+	switch mode {
+	case tieModeAddStrict:
+		return m.ver > p.watermark && m.ver > p.own
+	case tieModeEditGE:
+		return m.ver >= p.watermark && m.ver >= p.own
+	case tieModeRanked:
+		if m.ver > p.watermark && m.ver > p.own {
+			return true
+		}
+		// Exact tie with our own write: the higher-ranked peer wins.
+		// Peer 1 outranks peer 0, so only peer 0 accepts the tie.
+		return m.ver == p.own && m.ver >= p.watermark && i == 0
+	}
+	return false
+}
+
+// Actions: a unique-stamp write on either peer, the paired tie write (both
+// peers write with one shared stamp; the interesting case is exactly both
+// writing before seeing each other, so the pairing is atomic), or delivery
+// of the head announcement.
+func tieSuccessors(s tieState, mode tieMode) []tieState {
+	var out []tieState
+	for i := 0; i < 2; i++ {
+		if s.writesLeft[i] > 0 {
+			n := cloneTie(s)
+			n.nextVer++
+			n.nextCid++
+			n.p[i].content = n.nextCid
+			n.p[i].heldVer = n.nextVer
+			n.p[i].own = n.nextVer
+			n.writesLeft[i]--
+			other := 1 - i
+			n.q[other] = append(n.q[other], tieMsg{content: n.nextCid, ver: n.nextVer})
+			out = append(out, n)
+		}
+		if len(s.q[i]) > 0 {
+			n := cloneTie(s)
+			m := n.q[i][0]
+			n.q[i] = append([]tieMsg(nil), n.q[i][1:]...)
+			if tieAccept(mode, i, n.p[i], m) {
+				if mode == tieModeRanked && m.ver == n.p[i].own && n.p[i].content != m.content {
+					// The tie loser adopts the winner and preserves its own
+					// concurrent write (the conflict-copy policy still applies:
+					// a tie is provably concurrent).
+					n.preserved = n.p[i].content
+				}
+				n.p[i].watermark = m.ver
+				n.p[i].content = m.content
+				n.p[i].heldVer = m.ver
+			}
+			out = append(out, n)
+		}
+	}
+	if s.tiesLeft > 0 {
+		n := cloneTie(s)
+		n.nextVer++
+		ver := n.nextVer
+		for i := 0; i < 2; i++ {
+			n.nextCid++
+			n.p[i].content = n.nextCid
+			n.p[i].heldVer = ver
+			n.p[i].own = ver
+			n.tieCid[i] = n.nextCid
+			n.q[1-i] = append(n.q[1-i], tieMsg{content: n.nextCid, ver: ver})
+		}
+		n.tiesLeft--
+		out = append(out, n)
+	}
+	return out
+}
+
+func tieQuiescent(s tieState) bool {
+	return s.writesLeft[0] == 0 && s.writesLeft[1] == 0 && s.tiesLeft == 0 &&
+		len(s.q[0]) == 0 && len(s.q[1]) == 0
+}
+
+// checkTie explores one scope. In counting mode divergent terminals are
+// counted, not failed, so the shipped predicates can be demonstrated.
+func checkTie(t *testing.T, mode tieMode, writesA, writesB, ties int, failOnDiverge bool) (terminals, divergent, preservedTerminals int) {
+	t.Helper()
+
+	m := Model[tieState]{
+		Key:        tieKey,
+		Successors: func(s tieState) []tieState { return tieSuccessors(s, mode) },
+		Quiescent:  tieQuiescent,
+		CheckTerminal: func(s tieState) error {
+			if s.p[0].content != s.p[1].content {
+				divergent++
+				if failOnDiverge {
+					return fp.Equal("CONVERGENCE VIOLATION: peers diverged at quiescence",
+						s.p[0].content, s.p[1].content)
+				}
+			}
+			if s.preserved != 0 {
+				preservedTerminals++
+			}
+			return nil
+		},
+	}
+
+	rep, err := Explore(m, tieState{writesLeft: [2]int{writesA, writesB}, tiesLeft: ties})
+	require.NoError(t, err)
+
+	t.Logf("mode=%d writes=%d+%d ties=%d: states=%d terminals=%d divergent=%d preservedTerminals=%d",
+		mode, writesA, writesB, ties, rep.Explored, rep.Terminals, divergent, preservedTerminals)
+	return rep.Terminals, divergent, preservedTerminals
+}
+
+// The shipped ADD predicate (strictly greater) diverges permanently on a tie:
+// both peers reject the other's announce and each keeps its own bytes. No
+// interleaving heals it. No loss, no convergence.
+func TestTie_AddStrictPredicateDiverges(t *testing.T) {
+	for _, tc := range []struct{ a, b int }{{0, 0}, {1, 0}, {1, 1}} {
+		_, divergent, _ := checkTie(t, tieModeAddStrict, tc.a, tc.b, 1, false)
+		if divergent == 0 {
+			t.Fatalf("writes=%d+%d ties=1: expected divergent terminals under the strict ADD predicate; found none", tc.a, tc.b)
+		}
+	}
+}
+
+// The shipped EDIT predicate (rejects only strictly older) also diverges on a
+// tie, in the worse shape: both peers accept and the contents SWAP. Each side
+// ends holding the other's bytes.
+func TestTie_EditPredicateSwapsContents(t *testing.T) {
+	_, divergent, _ := checkTie(t, tieModeEditGE, 0, 0, 1, false)
+	if divergent == 0 {
+		t.Fatal("ties=1: expected divergent (swapped) terminals under the EDIT predicate; found none")
+	}
+}
+
+// Without a tie both shipped predicates converge in every interleaving; the
+// divergence is caused by the tie alone, not by the added tie action.
+func TestTie_NoTieNoDivergence(t *testing.T) {
+	for _, mode := range []tieMode{tieModeAddStrict, tieModeRanked} {
+		_, divergent, _ := checkTie(t, mode, 2, 1, 0, false)
+		if divergent != 0 {
+			t.Fatalf("mode=%d without ties: %d divergent terminals", mode, divergent)
+		}
+	}
+}
+
+// The fix rule: on an exact tie the higher-ranked peer wins on both sides.
+// Exactly one side accepts, every interleaving converges, and in the pure tie
+// scope the losing write is preserved, never silently dropped.
+func TestTie_RankedTieBreakConverges(t *testing.T) {
+	for _, tc := range []struct{ a, b int }{{0, 0}, {1, 0}, {0, 1}, {1, 1}} {
+		checkTie(t, tieModeRanked, tc.a, tc.b, 1, true)
+	}
+
+	terminals, _, preservedTerminals := checkTie(t, tieModeRanked, 0, 0, 1, true)
+	if preservedTerminals != terminals {
+		t.Fatalf("pure tie scope: loser preserved in %d of %d terminals; want all", preservedTerminals, terminals)
+	}
+}
+
+// In the pure tie scope the winner is the higher-ranked peer's write, on both
+// peers. The rank decides the survivor deterministically.
+func TestTie_RankedWinnerIsHigherRank(t *testing.T) {
+	m := Model[tieState]{
+		Key:        tieKey,
+		Successors: func(s tieState) []tieState { return tieSuccessors(s, tieModeRanked) },
+		Quiescent:  tieQuiescent,
+		CheckTerminal: func(s tieState) error {
+			return fp.All(
+				fp.Equal("winner on peer 0", s.p[0].content, s.tieCid[1]),
+				fp.Equal("winner on peer 1", s.p[1].content, s.tieCid[1]),
+			)
+		},
+	}
+	rep, err := Explore(m, tieState{tiesLeft: 1})
+	require.NoError(t, err)
+	t.Logf("pure tie scope: states=%d terminals=%d, winner is peer 1's write in all", rep.Explored, rep.Terminals)
+}


### PR DESCRIPTION
A peer REMOVE_FILE is buffered for 1000ms to absorb git's atomic-write dance, but only peer messages cancelled the buffer: a local write that landed and closed inside the window was silently deleted when the timer fired. Desktop only; Android's executeRemove touches no disk.

Local add/edit/rename events now cancel the pending remove, with an mtime backstop in executeRemove for the timer-already-firing sliver. Zero hot-path cost: one map lookup per file-level event, never per Write. The repro test was red before the fix, green after.